### PR TITLE
test: ignore deprecated warning from libstdc++

### DIFF
--- a/tests/ll-box-ut/src/test.cpp
+++ b/tests/ll-box-ut/src/test.cpp
@@ -2,7 +2,25 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include <string> // IWYU pragma: keep
+
+#if _GLIBCXX_RELEASE >= 15
+
+#pragma GCC diagnostic push
+
+#if defined(__clang__)
+#pragma GCC diagnostic ignored "-W#warnings"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic ignored "-Wcpp"
+#endif
+
+#endif
+
 #include "gtest/gtest.h"
+
+#if _GLIBCXX_RELEASE >= 15
+#pragma GCC diagnostic pop
+#endif
 
 TEST(LINYAPS_BOX, Placeholder1) {
   EXPECT_EQ(1, 1);


### PR DESCRIPTION
refer: https://github.com/gcc-mirror/gcc/commit/5c34f02ba7ebe0dfec5595ebc8298c47d5f65e6e