### PR TITLE
feat: add flag 'mount_dev_from_host'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,7 +415,8 @@ function(setup_linyaps_box_smoke_tests)
       ./tests/ll-box-st/08-check-umask.json
       ./tests/ll-box-st/09-check-rlimit.json
       ./tests/ll-box-st/10-check-oom.json
-      ./tests/ll-box-st/11-output-to-null.json)
+      ./tests/ll-box-st/11-output-to-null.json
+      ./tests/ll-box-st/12-bind-host-dev.json)
 
   foreach(test ${linyaps-box_SMOKE_TESTS})
     add_test(

--- a/tests/ll-box-st/12-bind-host-dev.json
+++ b/tests/ll-box-st/12-bind-host-dev.json
@@ -1,0 +1,25 @@
+{
+	"name": "Bind host dev",
+	"process": {
+		"user": {
+			"uid": 0,
+			"gid": 0
+		},
+		"args": ["/bin/env", "bash", "-c", "pwd"],
+		"env": [
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"TERM=xterm",
+			"HOME=/root"
+		],
+		"cwd": "/"
+	},
+	"mounts": [
+		{
+			"source": "/dev",
+			"destination": "/dev",
+			"type": "bind",
+			"options": ["rbind", "nosuid", "noexec"]
+		}
+	],
+	"expected": ""
+}

--- a/tests/ll-box-st/ll-box-st
+++ b/tests/ll-box-st/ll-box-st
@@ -175,9 +175,17 @@ function run_test() {
 	mkdir -p -- "${TEST_DIR}"
 
 	local TEST_CONFIG="${TEST_DIR}/test_config.json"
+	# patch process from test file
 	"${JQ}" >"${TEST_CONFIG}" \
 		".process |= $("${JQ}" -r '.process' "${TEST_FILE}" || true)" \
 		"${BUNDLE_DIR}/config.json"
+
+	# patch mount from test file if test file has mount field
+	if "${JQ}" -e '.mounts' "${TEST_FILE}" &>/dev/null; then
+		"${JQ}" >"${TEST_CONFIG}" \
+			".mounts |= $("${JQ}" -r '.mounts' "${TEST_FILE}" || true)" \
+			"${BUNDLE_DIR}/config.json"
+	fi
 
 	local CONTAINER_NAME
 	CONTAINER_NAME="$(basename -- "${TEST_FILE_NAME}" .json)"


### PR DESCRIPTION
skip processing default devices if user binds '/dev' from host