### PR TITLE
fix: correct output flag name in inspect_fcntl_or_open_flags

### DIFF
--- a/src/linyaps_box/utils/inspect.cpp
+++ b/src/linyaps_box/utils/inspect.cpp
@@ -87,7 +87,7 @@ std::string inspect_fcntl_or_open_flags(size_t flags)
         ss << " O_NONBLOCK";
     }
     if ((flags & O_NDELAY) != 0) {
-        ss << " O_SYNC";
+        ss << " O_NDELAY";
     }
     if ((flags & O_SYNC) != 0) {
         ss << " O_SYNC";


### PR DESCRIPTION
## Description
Fixed incorrect flag name output in `inspect_fcntl_or_open_flags` function.

## Problem
The function was incorrectly outputting 'O_SYNC' when checking for the O_NDELAY flag at line 82. This was likely a copy-paste error that could cause confusion when debugging file descriptor flags.

## Solution  
Changed the output string from 'O_SYNC' to 'O_NDELAY' to match the actual flag being checked.

## Changes
- `src/linyaps_box/utils/inspect.cpp`: Fixed flag name output on line 82

## Testing
- [x] Code compiles without errors
- [x] Function now correctly displays O_NDELAY flag when present
- [x] No functional behavior changes, only output string correction