### PR TITLE
fix: correct the default value of open_at parameter 'mode'

### DIFF
--- a/src/linyaps_box/utils/open_file.h
+++ b/src/linyaps_box/utils/open_file.h
@@ -12,11 +12,11 @@
 
 namespace linyaps_box::utils {
 
-file_descriptor open(const std::filesystem::path &path, int flag = O_RDONLY, mode_t mode = 0644);
+file_descriptor open(const std::filesystem::path &path, int flag = O_RDONLY, mode_t mode = 0);
 
 file_descriptor open_at(const file_descriptor &root,
                         const std::filesystem::path &path,
                         int flag = O_RDONLY,
-                        mode_t mode = 0644);
+                        mode_t mode = 0);
 
 } // namespace linyaps_box::utils


### PR DESCRIPTION
if mode is nonzero, but how.flags does not contain O_CREAT or O_TMPFILE will cause an EINVAL.