### PR TITLE
fix: 'cgroup-manager' is not assigned while creating container

### DIFF
--- a/src/linyaps_box/cgroup.h
+++ b/src/linyaps_box/cgroup.h
@@ -34,4 +34,23 @@ private:
     cgroup_manager_t manager;
 };
 
+inline std::ostream &operator<<(std::ostream &os, cgroup_manager_t manager)
+{
+    switch (manager) {
+    case cgroup_manager_t::disabled: {
+        os << "disabled";
+    } break;
+    case cgroup_manager_t::systemd: {
+        os << "systemd";
+    } break;
+    case cgroup_manager_t::cgroupfs: {
+        os << "cgroupfs";
+    } break;
+    default:
+        os << "unknown";
+    }
+
+    return os;
+}
+
 } // namespace linyaps_box

--- a/src/linyaps_box/command/options.cpp
+++ b/src/linyaps_box/command/options.cpp
@@ -42,7 +42,7 @@ linyaps_box::command::options linyaps_box::command::parse(int argc, char *argv[]
                             { "systemd", cgroup_manager_t::systemd },
                             { "disabled", cgroup_manager_t::disabled },
                     }))
-            ->default_val(cgroup_manager_t::cgroupfs);
+            ->default_val(cgroup_manager_t::disabled);
 
     list_options list_opt{ options.global };
     auto *cmd_list = app.add_subcommand("list", "List know containers");

--- a/src/linyaps_box/command/options.h
+++ b/src/linyaps_box/command/options.h
@@ -15,7 +15,7 @@ namespace linyaps_box::command {
 
 struct global_options
 {
-    cgroup_manager_t manager{ cgroup_manager_t::cgroupfs };
+    cgroup_manager_t manager{ cgroup_manager_t::disabled };
     std::filesystem::path root;
     int return_code{ 0 };
 };

--- a/src/linyaps_box/command/run.cpp
+++ b/src/linyaps_box/command/run.cpp
@@ -17,6 +17,7 @@ int linyaps_box::command::run(const struct run_options &options)
     create_container_options.bundle = options.bundle;
     create_container_options.config = options.config;
     create_container_options.ID = options.ID;
+    create_container_options.manager = options.global.get().manager;
 
     auto container = runtime.create_container(create_container_options);
 


### PR DESCRIPTION
make 'disabled' as the default value of field 'cgroup-manager'