### PR TITLE
fix: resolve GCC enum conversion error in MountFlag

### DIFF
--- a/src/linyaps_box/container.cpp
+++ b/src/linyaps_box/container.cpp
@@ -119,7 +119,7 @@ std::ostream &operator<<(std::ostream &os, const sync_message message)
 
 struct MountFlag
 {
-    decltype(MS_RDONLY) flag;
+    std::underlying_type_t<decltype(MS_RDONLY)> flag;
     std::string_view name;
 };
 


### PR DESCRIPTION
Use std::underlying_type_t to fix "int cannot be converted to unnamed enum" compilation error on older GCC versions.