### PR TITLE
feat: add rootfsPropagation support and improve error handling

### DIFF
--- a/src/linyaps_box/app.cpp
+++ b/src/linyaps_box/app.cpp
@@ -77,10 +77,10 @@ try {
                                   } },
                       options.subcommand_opt);
 } catch (const std::exception &e) {
-    std::cerr << "Error: " << e.what() << std::endl;
+    LINYAPS_BOX_ERR() << "Error: " << e.what();
     return -1;
 } catch (...) {
-    std::cerr << "Error: unknown" << std::endl;
+    LINYAPS_BOX_ERR() << "unknown error";
     return -1;
 }
 

--- a/src/linyaps_box/config.cpp
+++ b/src/linyaps_box/config.cpp
@@ -79,7 +79,7 @@ parse_mount_options(const std::vector<std::string> &options)
             continue;
         }
         if (auto it = propagation_flags_map.find(opt); it != propagation_flags_map.end()) {
-            propagation_flags &= it->second;
+            propagation_flags |= it->second;
             continue;
         }
 
@@ -260,6 +260,21 @@ linyaps_box::config::linux_t parse_linux(const nlohmann::json &obj,
                            return json.get<std::string>();
                        });
         linux.readonly_paths = std::move(readonly_paths);
+    }
+
+    if (auto rootfs_propagation = ptr / "rootfsPropagation"; obj.contains(rootfs_propagation)) {
+        auto val = obj[rootfs_propagation].get<std::string>();
+        if (val == "shared") {
+            linux.rootfs_propagation = MS_SHARED;
+        } else if (val == "slave") {
+            linux.rootfs_propagation = MS_SLAVE;
+        } else if (val == "private") {
+            linux.rootfs_propagation = MS_PRIVATE;
+        } else if (val == "unbindable") {
+            linux.rootfs_propagation = MS_UNBINDABLE;
+        } else {
+            throw std::runtime_error("unsupported rootfs propagation: " + val);
+        }
     }
 
     return linux;

--- a/src/linyaps_box/config.h
+++ b/src/linyaps_box/config.h
@@ -123,6 +123,7 @@ struct config
         std::optional<std::vector<id_mapping_t>> gid_mappings;
         std::optional<std::vector<std::filesystem::path>> masked_paths;
         std::optional<std::vector<std::filesystem::path>> readonly_paths;
+        unsigned int rootfs_propagation{ 0 };
     };
 
     std::optional<linux_t> linux;


### PR DESCRIPTION
- Add rootfsPropagation field to linux config (shared/slave/private/unbindable)
- Fix mount propagation flag handling (use |= instead of &=)
- Replace std::cerr with LINYAPS_BOX_ERR() for consistent logging
- Use _exit() instead of exit() in child processes
- Improve error messages with better context

Allows control over mount propagation for the root filesystem according to OCI spec.