### PR TITLE
fix: early return if an exception is thrown while command parsing

### DIFF
--- a/src/linyaps_box/command/options.cpp
+++ b/src/linyaps_box/command/options.cpp
@@ -111,6 +111,7 @@ linyaps_box::command::options linyaps_box::command::parse(int argc, char *argv[]
         app.parse(argc, argv);
     } catch (const CLI::ParseError &e) {
         options.global.return_code = app.exit(e);
+        return options;
     }
 
     if (cmd_list->parsed()) {


### PR DESCRIPTION
According the documentation of CLI11, this library will throw a exception while encounter -h,--help or a parse error.