### PR TITLE
fix: handle broken symlinks during mount destination creation

### DIFF
--- a/src/linyaps_box/utils/file_describer.cpp
+++ b/src/linyaps_box/utils/file_describer.cpp
@@ -18,6 +18,15 @@ linyaps_box::utils::file_descriptor_closed_exception::file_descriptor_closed_exc
 linyaps_box::utils::file_descriptor_closed_exception::~file_descriptor_closed_exception() noexcept =
         default;
 
+linyaps_box::utils::file_descriptor_invalid_exception::file_descriptor_invalid_exception(
+        const std::string &message)
+    : std::runtime_error(message)
+{
+}
+
+linyaps_box::utils::file_descriptor_invalid_exception::
+        ~file_descriptor_invalid_exception() noexcept = default;
+
 linyaps_box::utils::file_descriptor::file_descriptor(int fd)
     : fd_(fd)
 {
@@ -25,7 +34,7 @@ linyaps_box::utils::file_descriptor::file_descriptor(int fd)
 
 linyaps_box::utils::file_descriptor::~file_descriptor()
 {
-    if (fd_ == -1) {
+    if (fd_ < 0) {
         return;
     }
 
@@ -56,6 +65,10 @@ auto linyaps_box::utils::file_descriptor::duplicate() const -> linyaps_box::util
 {
     if (fd_ == -1) {
         throw file_descriptor_closed_exception();
+    }
+
+    if (fd_ == AT_FDCWD) {
+        throw file_descriptor_invalid_exception("cannot duplicate AT_FDCWD");
     }
 
     auto ret = dup(fd_);
@@ -133,4 +146,9 @@ auto linyaps_box::utils::file_descriptor::current_path() const noexcept -> std::
     }
 
     return path;
+}
+
+auto linyaps_box::utils::file_descriptor::cwd() -> file_descriptor
+{
+    return file_descriptor{ AT_FDCWD };
 }

--- a/src/linyaps_box/utils/file_describer.h
+++ b/src/linyaps_box/utils/file_describer.h
@@ -23,6 +23,19 @@ public:
     ~file_descriptor_closed_exception() noexcept override;
 };
 
+class file_descriptor_invalid_exception : public std::runtime_error
+{
+public:
+    explicit file_descriptor_invalid_exception(const std::string &message);
+    file_descriptor_invalid_exception(const file_descriptor_invalid_exception &) = default;
+    file_descriptor_invalid_exception(file_descriptor_invalid_exception &&) noexcept = default;
+    auto operator=(const file_descriptor_invalid_exception &)
+            -> file_descriptor_invalid_exception & = default;
+    auto operator=(file_descriptor_invalid_exception &&) noexcept
+            -> file_descriptor_invalid_exception & = default;
+    ~file_descriptor_invalid_exception() noexcept override;
+};
+
 class file_descriptor
 {
 public:
@@ -50,6 +63,8 @@ public:
     [[nodiscard]] auto proc_path() const -> std::filesystem::path;
 
     [[nodiscard]] auto current_path() const noexcept -> std::filesystem::path;
+
+    static auto cwd() -> file_descriptor;
 
 private:
     int fd_{ -1 };

--- a/src/linyaps_box/utils/symlink.cpp
+++ b/src/linyaps_box/utils/symlink.cpp
@@ -6,6 +6,10 @@
 
 #include "linyaps_box/utils/log.h"
 
+#include <linux/limits.h>
+
+#include <array>
+
 void linyaps_box::utils::symlink(const std::filesystem::path &target,
                                  const std::filesystem::path &link_path)
 {
@@ -29,4 +33,27 @@ void linyaps_box::utils::symlink_at(const std::filesystem::path &target,
     if (ret == -1) {
         throw std::system_error(errno, std::system_category(), "symlinkat");
     }
+}
+
+std::filesystem::path linyaps_box::utils::readlink(const std::filesystem::path &path)
+{
+    std::error_code ec;
+    auto ret = std::filesystem::read_symlink(path, ec);
+    if (ec) {
+        throw std::system_error{ ec.value(), std::system_category(), ec.message() };
+    }
+
+    return ret;
+}
+
+std::filesystem::path linyaps_box::utils::readlinkat(const file_descriptor &dirfd,
+                                                     const std::filesystem::path &path)
+{
+    std::array<char, PATH_MAX + 1> buf{};
+    auto ret = ::readlinkat(dirfd.get(), path.c_str(), buf.data(), PATH_MAX + 1);
+    if (ret == -1) {
+        throw std::system_error(errno, std::system_category(), "readlinkat");
+    }
+
+    return std::filesystem::path{ buf.data() };
 }

--- a/src/linyaps_box/utils/symlink.h
+++ b/src/linyaps_box/utils/symlink.h
@@ -16,4 +16,8 @@ void symlink_at(const std::filesystem::path &target,
                 const file_descriptor &dirfd,
                 const std::filesystem::path &link_path);
 
+std::filesystem::path readlink(const std::filesystem::path &path);
+
+std::filesystem::path readlinkat(const file_descriptor &dirfd, const std::filesystem::path &path);
+
 } // namespace linyaps_box::utils

--- a/src/linyaps_box/utils/touch.cpp
+++ b/src/linyaps_box/utils/touch.cpp
@@ -9,11 +9,13 @@
 
 #include <fcntl.h>
 
-auto linyaps_box::utils::touch(const file_descriptor &root, const std::filesystem::path &path)
-        -> linyaps_box::utils::file_descriptor
+auto linyaps_box::utils::touch(const file_descriptor &root,
+                               const std::filesystem::path &path,
+                               int flag,
+                               mode_t mode) -> linyaps_box::utils::file_descriptor
 {
     LINYAPS_BOX_DEBUG() << "touch " << path << " at " << inspect_fd(root.get());
-    const auto fd = ::openat(root.get(), path.c_str(), O_CREAT | O_WRONLY, 0666);
+    const auto fd = ::openat(root.get(), path.c_str(), flag, mode);
     if (fd == -1) {
         throw std::system_error(errno,
                                 std::system_category(),

--- a/src/linyaps_box/utils/touch.h
+++ b/src/linyaps_box/utils/touch.h
@@ -8,6 +8,9 @@
 
 namespace linyaps_box::utils {
 
-auto touch(const file_descriptor &root, const std::filesystem::path &path) -> file_descriptor;
+auto touch(const file_descriptor &root,
+           const std::filesystem::path &path,
+           int flag,
+           mode_t mode = 0700) -> file_descriptor;
 
 } // namespace linyaps_box::utils


### PR DESCRIPTION
When a destination file doesn't exist, the previous implementation couldn't distinguish between creation failure due to existing files vs other reasons. If both opening and creating fail, the destination is definitely a broken symlink.

- Add recursive symlink resolution with depth limit (32) in create_destination_file()
- Use O_NOFOLLOW to detect symlink during file creation
- When creation fails with ELOOP, read symlink target and recursively create it
- Replace filesystem functions with internal utils for consistent error handling
- Add proper broken symlink detection and resolution logic

This ensures mount destinations work correctly even when they point to broken symlinks, by creating the missing target files in the symlink chain.