### PR TITLE
fix(hooks): cache status before pivot_root

### DIFF
--- a/src/linyaps_box/container.cpp
+++ b/src/linyaps_box/container.cpp
@@ -1378,6 +1378,7 @@ void wait_create_runtime_result(const linyaps_box::config &config, linyaps_box::
 }
 
 void create_container_hooks(const linyaps_box::container &container,
+                            const linyaps_box::container_status_t &status,
                             linyaps_box::unix_socket &socket)
 {
     const auto &config = container.get_config();
@@ -1387,9 +1388,8 @@ void create_container_hooks(const linyaps_box::container &container,
 
     LINYAPS_BOX_DEBUG() << "Execute create container hooks";
 
-    auto state = container.status();
     for (const auto &hook : config.hooks.create_container.value()) {
-        execute_hook(hook, state);
+        execute_hook(hook, status);
     }
 
     LINYAPS_BOX_DEBUG() << "Create container hooks executed";
@@ -1598,6 +1598,7 @@ void set_capabilities(const linyaps_box::config &config, int last_cap)
 }
 
 void start_container_hooks(const linyaps_box::container &container,
+                           const linyaps_box::container_status_t &status,
                            linyaps_box::unix_socket &socket)
 {
     const auto &config = container.get_config();
@@ -1607,9 +1608,8 @@ void start_container_hooks(const linyaps_box::container &container,
 
     LINYAPS_BOX_DEBUG() << "Execute start container hooks";
 
-    auto state = container.status();
     for (const auto &hook : config.hooks.start_container.value()) {
-        execute_hook(hook, state);
+        execute_hook(hook, status);
     }
 
     LINYAPS_BOX_DEBUG() << "Start container hooks executed";
@@ -1789,7 +1789,9 @@ try {
     configure_mounts(container, rootfs);
     wait_prestart_hooks_result(config, socket);
     wait_create_runtime_result(config, socket);
-    create_container_hooks(container, socket);
+
+    auto status = container.status();
+    create_container_hooks(container, status, socket);
     // TODO: selinux label/apparmor profile
     do_pivot_root(container, rootfs);
 
@@ -1809,7 +1811,7 @@ try {
     linyaps_box::utils::sigprocmask(SIG_UNBLOCK, set, nullptr);
     linyaps_box::utils::reset_signals(set);
 
-    start_container_hooks(container, socket);
+    start_container_hooks(container, status, socket);
     execute_process(config);
 } catch (const std::system_error &e) {
     LINYAPS_BOX_ERR() << "clone failed: " << e.what();

--- a/src/linyaps_box/impl/status_directory.cpp
+++ b/src/linyaps_box/impl/status_directory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -23,7 +23,9 @@ auto read_status(const std::filesystem::path &path) -> linyaps_box::container_st
     {
         std::ifstream istrm(path);
         if (istrm.fail()) {
-            throw std::runtime_error("failed to open status file:" + path.string());
+            throw std::system_error(errno,
+                                    std::system_category(),
+                                    "failed to open status file:" + path.string());
         }
 
         istrm >> j;
@@ -71,6 +73,11 @@ void linyaps_box::impl::status_directory::remove(const std::string &id) const
 {
     auto file_path = this->path / (id + ".json");
     LINYAPS_BOX_DEBUG() << "Remove " << file_path;
+    if (!std::filesystem::exists(file_path)) {
+        LINYAPS_BOX_WARNING() << "Status file " << file_path << " does not exist";
+        return;
+    }
+
     if (!std::filesystem::remove(file_path)) {
         LINYAPS_BOX_WARNING() << "Failed to remove " << file_path;
     }

--- a/src/linyaps_box/utils/ringbuffer.cpp
+++ b/src/linyaps_box/utils/ringbuffer.cpp
@@ -68,7 +68,7 @@ auto ring_buffer::create(std::size_t requested_capacity) -> ptr
     auto *data_base = static_cast<std::byte *>(addr) + meta_size;
     auto *rb = new (addr) ring_buffer(cap, data_base);
 
-    auto deleter = ring_buffer::deleter{ .total_size = total_vma };
+    auto deleter = ring_buffer::deleter{ total_vma };
     return { rb, std::move(deleter) };
 }
 


### PR DESCRIPTION
Status file becomes inaccessible after pivot_root. Cache it beforehand and pass to create/start container hooks.