### PR TITLE
fix(container): throw when remount fallback conditions unmet

### DIFF
--- a/src/linyaps_box/container.cpp
+++ b/src/linyaps_box/container.cpp
@@ -461,7 +461,10 @@ void do_remount(const remount_t &mount)
     if ((dest_flag & MS_RDONLY) != 0) {
         remount_flags = dest_flag & (MS_NOSUID | MS_NODEV | MS_NOEXEC | MS_RDONLY);
         syscall_mount(nullptr, destination.c_str(), nullptr, mount.flags | remount_flags, data_ptr);
+        return;
     }
+
+    throw std::runtime_error("remount failed after all fallbacks");
 }
 
 [[nodiscard]] linyaps_box::utils::file_descriptor create_destination_directory(


### PR DESCRIPTION
Previously do_remount silently returned when the initial mount failed and no fallback condition was satisfied, misleading callers into thinking the remount succeeded.