### PR TITLE
refactor(fd): query O_NONBLOCK from kernel instead of caching

### DIFF
--- a/src/linyaps_box/container.cpp
+++ b/src/linyaps_box/container.cpp
@@ -22,6 +22,7 @@
 #include "linyaps_box/utils/session.h"
 #include "linyaps_box/utils/signal.h"
 #include "linyaps_box/utils/symlink.h"
+#include "utils/defer.h"
 
 #include <linux/magic.h>
 #include <sys/mount.h>
@@ -2609,7 +2610,28 @@ int linyaps_box::container::run(run_container_options_t options)
 
         auto in = utils::file_descriptor{ STDIN_FILENO, false };
         auto out = utils::file_descriptor{ STDOUT_FILENO, false };
-        [&recv_socketpair, &monitor, &in, &out]() -> void {
+
+        bool changed{ false };
+        auto in_flags = in.flags();
+        auto out_flags = out.flags();
+
+        auto restore_if_changed =
+          utils::make_defer([&]() noexcept {
+              if (!changed) {
+                  return;
+              }
+
+              try {
+                  in.set_flags(in_flags);
+                  out.set_flags(out_flags);
+              } catch (const std::exception &e) {
+                  LINYAPS_BOX_ERR()
+                    << "failed to restore stdin/stdout flags, some behavior may be unexpected: "
+                    << e.what();
+              }
+          });
+
+        [&recv_socketpair, &monitor, &in, &out, &changed]() -> void {
             if (!recv_socketpair) {
                 return;
             }
@@ -2621,6 +2643,7 @@ int linyaps_box::container::run(run_container_options_t options)
 
             in.set_nonblock(true);
             out.set_nonblock(true);
+            changed = true;
 
             monitor.enable_io_forwarding(std::move(master), in, out);
         }();

--- a/src/linyaps_box/container_ref.cpp
+++ b/src/linyaps_box/container_ref.cpp
@@ -7,6 +7,7 @@
 #include "linyaps_box/container_monitor.h"
 #include "linyaps_box/socket.h"
 #include "linyaps_box/terminal.h"
+#include "linyaps_box/utils/defer.h"
 #include "linyaps_box/utils/log.h"
 #include "linyaps_box/utils/process.h"
 #include "linyaps_box/utils/session.h"
@@ -126,7 +127,27 @@ auto linyaps_box::container_ref::exec(exec_container_option option) -> int
 
     auto in = utils::file_descriptor{ STDIN_FILENO, false };
     auto out = utils::file_descriptor{ STDOUT_FILENO, false };
-    [&recv_socketpair, &monitor, &in, &out]() {
+
+    bool changed{ false };
+    auto in_flags = in.flags();
+    auto out_flags = out.flags();
+
+    auto restore_if_changed = utils::make_defer([&]() noexcept {
+        if (!changed) {
+            return;
+        }
+
+        try {
+            in.set_flags(in_flags);
+            out.set_flags(out_flags);
+        } catch (const std::exception &e) {
+            LINYAPS_BOX_ERR()
+              << "failed to restore stdin/stdout flags, some behavior may be unexpected: "
+              << e.what();
+        }
+    });
+
+    [&recv_socketpair, &monitor, &in, &out, &changed]() {
         if (!recv_socketpair) {
             return;
         }
@@ -140,6 +161,7 @@ auto linyaps_box::container_ref::exec(exec_container_option option) -> int
 
         in.set_nonblock(true);
         out.set_nonblock(true);
+        changed = true;
 
         monitor.enable_io_forwarding(std::move(master), in, out);
     }();

--- a/src/linyaps_box/utils/file_describer.cpp
+++ b/src/linyaps_box/utils/file_describer.cpp
@@ -41,11 +41,6 @@ linyaps_box::utils::file_descriptor::file_descriptor(int fd, bool auto_close)
     if (UNLIKELY(fd_ < 0)) {
         throw file_descriptor_invalid_exception("invalid file descriptor");
     }
-
-    auto flag = fcntl(*this, F_GETFL);
-    if ((flag & O_NONBLOCK) != 0) {
-        nonblock_ = true;
-    }
 }
 
 linyaps_box::utils::file_descriptor::~file_descriptor() noexcept
@@ -59,12 +54,13 @@ linyaps_box::utils::file_descriptor::~file_descriptor() noexcept
         close();
     } catch (const std::system_error &e) {
         LINYAPS_BOX_ERR() << "close " << fd_ << " failed:" << e.what();
+    } catch (...) {
+        LINYAPS_BOX_ERR() << "close " << fd_ << " failed with unknown error";
     }
 }
 
 linyaps_box::utils::file_descriptor::file_descriptor(file_descriptor &&other) noexcept
     : fd_(other.fd_)
-    , nonblock_(other.nonblock_)
     , auto_close_(other.auto_close_)
 {
     other.fd_ = -1;
@@ -79,7 +75,6 @@ auto linyaps_box::utils::file_descriptor::operator=(file_descriptor &&other) noe
 
     std::swap(this->fd_, other.fd_);
     std::swap(this->auto_close_, other.auto_close_);
-    std::swap(this->nonblock_, other.nonblock_);
     return *this;
 }
 
@@ -166,7 +161,7 @@ auto linyaps_box::utils::file_descriptor::duplicate_to(int target, int flags) co
 auto linyaps_box::utils::file_descriptor::operator<<(const std::byte &byte)
   -> linyaps_box::utils::file_descriptor &
 {
-    if (UNLIKELY(nonblock_)) {
+    if (UNLIKELY(nonblock())) {
         throw std::logic_error("cannot write to non-blocking fd using operator<<");
     }
 
@@ -187,7 +182,7 @@ auto linyaps_box::utils::file_descriptor::operator<<(const std::byte &byte)
 auto linyaps_box::utils::file_descriptor::operator>>(std::byte &byte)
   -> linyaps_box::utils::file_descriptor &
 {
-    if (UNLIKELY(nonblock_)) {
+    if (UNLIKELY(nonblock())) {
         throw std::logic_error("cannot read from non-blocking fd using operator>>");
     }
 
@@ -236,15 +231,31 @@ auto linyaps_box::utils::file_descriptor::cwd() -> file_descriptor
     return file_descriptor{ AT_FDCWD };
 }
 
-auto linyaps_box::utils::file_descriptor::set_nonblock(bool nonblock) & -> void
+auto linyaps_box::utils::file_descriptor::nonblock() const -> bool
+{
+    auto flags = this->flags();
+    return (flags & O_NONBLOCK) != 0;
+}
+
+auto linyaps_box::utils::file_descriptor::set_nonblock(bool nonblock) const & -> void
 {
     LINYAPS_BOX_DEBUG() << "set fd " << fd_ << " to nonblock: " << std::boolalpha << nonblock;
 
-    auto flags = fcntl(*this, F_GETFL, 0);
-    fcntl(*this,
-          F_SETFL,
-          nonblock ? (flags | O_NONBLOCK) : (flags & ~static_cast<unsigned>(O_NONBLOCK)));
-    nonblock_ = nonblock;
+    auto flags = this->flags();
+    auto new_flags = nonblock ? (flags | O_NONBLOCK) : (flags & ~static_cast<unsigned>(O_NONBLOCK));
+    fcntl(*this, F_SETFL, new_flags);
+}
+
+auto linyaps_box::utils::file_descriptor::flags() const -> unsigned int
+{
+    return fcntl(*this, F_GETFL);
+}
+
+auto linyaps_box::utils::file_descriptor::set_flags(unsigned int flags) const & -> void
+{
+    LINYAPS_BOX_DEBUG() << "set fd " << fd_ << " flags to " << std::hex << flags;
+
+    fcntl(*this, F_SETFL, flags);
 }
 
 auto linyaps_box::utils::file_descriptor::type() const -> std::filesystem::file_type
@@ -275,7 +286,7 @@ auto linyaps_box::utils::file_descriptor::read_span(span<std::byte> ws) const ->
         }
 
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
-            return { nonblock_ ? IOStatus::TryAgain : IOStatus::Timeout, 0 };
+            return { nonblock() ? IOStatus::TryAgain : IOStatus::Timeout, 0 };
         }
 
         if (errno == EIO || errno == ECONNRESET) {
@@ -314,7 +325,7 @@ auto linyaps_box::utils::file_descriptor::write_span(span<const std::byte> rs) c
         }
 
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
-            return { nonblock_ ? IOStatus::TryAgain : IOStatus::Timeout, bytes_written };
+            return { nonblock() ? IOStatus::TryAgain : IOStatus::Timeout, bytes_written };
         }
 
         if (errno == EPIPE || errno == ECONNRESET || errno == ENOTCONN || errno == EIO) {
@@ -357,7 +368,7 @@ auto linyaps_box::utils::file_descriptor::read_vecs(span<struct iovec> ws) const
         }
 
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
-            return { nonblock_ ? IOStatus::TryAgain : IOStatus::Timeout, 0 };
+            return { nonblock() ? IOStatus::TryAgain : IOStatus::Timeout, 0 };
         }
 
         if (errno == EIO || errno == ECONNRESET) {
@@ -441,7 +452,7 @@ auto linyaps_box::utils::file_descriptor::write_vecs(span<const struct iovec> rs
         }
 
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
-            return { nonblock_ ? IOStatus::TryAgain : IOStatus::Timeout, total_bytes_written };
+            return { nonblock() ? IOStatus::TryAgain : IOStatus::Timeout, total_bytes_written };
         }
 
         if (errno == EPIPE || errno == ECONNRESET || errno == ENOTCONN || errno == EIO) {

--- a/src/linyaps_box/utils/file_describer.h
+++ b/src/linyaps_box/utils/file_describer.h
@@ -8,6 +8,7 @@
 
 #include <filesystem>
 
+#include <fcntl.h>
 #include <sys/uio.h>
 #include <unistd.h>
 
@@ -87,7 +88,13 @@ public:
 
     [[nodiscard]] auto type() const -> std::filesystem::file_type;
 
-    auto set_nonblock(bool nonblock) & -> void;
+    [[nodiscard]] auto flags() const -> unsigned int;
+
+    auto set_flags(unsigned int flags) const & -> void;
+
+    auto set_nonblock(bool nonblock) const & -> void;
+
+    [[nodiscard]] auto nonblock() const -> bool;
 
     [[nodiscard]] auto read_span(span<std::byte> ws) const -> IOResult;
 
@@ -147,7 +154,6 @@ public:
 private:
     // keep this layout, for padding optimization
     int fd_{ -1 };
-    bool nonblock_{ false };
     bool auto_close_{ false };
 };
 


### PR DESCRIPTION
Caching nonblock_ in file_descriptor desynchronizes from actual fd state. Replace with flags()/nonblock() that read fcntl live, and restore stdin/stdout flags after IO forwarding to prevent nonblock leaking to the caller.