### PR TITLE
feat(container): handle /dev/ptmx per OCI runtime spec

### DIFF
--- a/src/linyaps_box/container.cpp
+++ b/src/linyaps_box/container.cpp
@@ -610,16 +610,16 @@ try {
 }
 
 void do_propagation_mount(const linyaps_box::utils::file_descriptor &destination,
-                          const unsigned long &flags)
+                          unsigned long flags)
 {
     LINYAPS_BOX_DEBUG() << "mount propagation flags";
 
-    if (destination.get() == -1) {
-        throw std::invalid_argument("invalid destination file descriptor for propagation mount");
-    }
-
     if (flags == 0) {
         return;
+    }
+
+    if (UNLIKELY(!destination.valid())) {
+        throw std::invalid_argument("invalid destination file descriptor for propagation mount");
     }
 
     syscall_mount(nullptr, destination.current_path().c_str(), nullptr, flags, nullptr);
@@ -1241,14 +1241,47 @@ private:
         this->configure_device("/dev/urandom", default_mode, default_type, makedev(1, 9), uid, gid);
         this->configure_device("/dev/tty", default_mode, default_type, makedev(5, 0), uid, gid);
 
-        // bind mount /dev/pts/ptmx to /dev/ptmx
         // https://docs.kernel.org/filesystems/devpts.html
-        linyaps_box::config::mount_t mount;
-        mount.source = root.current_path() / "dev/pts/ptmx";
-        mount.destination = "/dev/ptmx";
-        mount.type = "bind";
-        mount.flags = MS_BIND | MS_PRIVATE | MS_NOEXEC | MS_NOSUID;
-        this->mount(mount);
+        // TODO: Record "mounted_ptmx": "true" in state.json annotations when falling back to
+        // bind-mount.
+        // WARNING: Without this state, host-side teardown (rm -rf rootfs) will fail
+        // with EBUSY due to VFS reference leaks if the container's mount namespace is not
+        // immediately or fully released.
+        try {
+            auto ptmx =
+              linyaps_box::utils::open_at(root, "dev/ptmx", O_PATH | O_NOFOLLOW | O_CLOEXEC);
+            auto ptmx_stat = linyaps_box::utils::fstat(ptmx);
+
+            if (S_ISREG(ptmx_stat.st_mode)) {
+                // /dev/ptmx is a regular file: bind mount /dev/pts/ptmx over it
+                linyaps_box::config::mount_t mount;
+                mount.source = root.current_path() / "dev/pts/ptmx";
+                mount.destination = "/dev/ptmx";
+                mount.type = "bind";
+                mount.flags = MS_BIND | MS_PRIVATE | MS_NOEXEC | MS_NOSUID;
+                this->mount(mount);
+            } else if (S_ISLNK(ptmx_stat.st_mode)) {
+                // /dev/ptmx is a symlink: check if it points to pts/ptmx
+                auto link_target = linyaps_box::utils::readlinkat(ptmx, "");
+                if (link_target != "pts/ptmx" && link_target != "/dev/pts/ptmx") {
+                    // Atomically replace the symlink using a temp + rename
+                    std::error_code ec;
+                    linyaps_box::utils::symlink_at("pts/ptmx", root, "dev/.ptmx.tmp", ec);
+                    if (ec) {
+                        throw std::system_error(ec, "symlink_at .ptmx.tmp");
+                    }
+
+                    linyaps_box::utils::rename_at(root, "dev/.ptmx.tmp", root, "dev/ptmx");
+                }
+            }
+        } catch (const std::system_error &e) {
+            if (e.code().value() != ENOENT) {
+                throw;
+            }
+
+            // /dev/ptmx does not exist, create symlink pts/ptmx
+            linyaps_box::utils::symlink_at("pts/ptmx", root, "dev/ptmx");
+        }
     }
 
     // https://github.com/opencontainers/runtime-spec/blob/main/runtime-linux.md

--- a/src/linyaps_box/utils/file.cpp
+++ b/src/linyaps_box/utils/file.cpp
@@ -518,4 +518,41 @@ auto read_exact(const file_descriptor &fd, std::size_t size) -> std::string
     return content;
 }
 
+void unlink_at(const file_descriptor &root, const std::filesystem::path &path)
+{
+    LINYAPS_BOX_DEBUG() << "Unlink " << path << " at " << root.current_path();
+
+    auto ret = ::unlinkat(root.get(), path.c_str(), 0);
+    if (UNLIKELY(ret != 0)) {
+        throw std::system_error(errno, std::system_category(), "unlinkat");
+    }
+}
+
+void unlink_at(const file_descriptor &root,
+               const std::filesystem::path &path,
+               std::error_code &ec) noexcept
+{
+    LINYAPS_BOX_DEBUG() << "Unlink " << path << " at " << root.current_path();
+
+    ec.clear();
+    auto ret = ::unlinkat(root.get(), path.c_str(), 0);
+    if (UNLIKELY(ret != 0)) {
+        ec.assign(errno, std::system_category());
+    }
+}
+
+auto rename_at(const file_descriptor &old_dir,
+               const std::filesystem::path &old_path,
+               const file_descriptor &new_dir,
+               const std::filesystem::path &new_path) -> void
+{
+    LINYAPS_BOX_DEBUG() << "Rename " << old_path << " at " << old_dir.current_path() << " to "
+                        << new_path << " at " << new_dir.current_path();
+
+    auto ret = ::renameat(old_dir.get(), old_path.c_str(), new_dir.get(), new_path.c_str());
+    if (UNLIKELY(ret != 0)) {
+        throw std::system_error(errno, std::system_category(), "renameat");
+    }
+}
+
 } // namespace linyaps_box::utils

--- a/src/linyaps_box/utils/file.h
+++ b/src/linyaps_box/utils/file.h
@@ -66,4 +66,15 @@ auto read_all(const std::filesystem::path &path) -> std::string;
 
 auto read_exact(const file_descriptor &fd, std::size_t size) -> std::string;
 
+auto unlink_at(const file_descriptor &root, const std::filesystem::path &path) -> void;
+
+auto unlink_at(const file_descriptor &root,
+               const std::filesystem::path &path,
+               std::error_code &ec) noexcept -> void;
+
+auto rename_at(const file_descriptor &old_dir,
+               const std::filesystem::path &old_path,
+               const file_descriptor &new_dir,
+               const std::filesystem::path &new_path) -> void;
+
 } // namespace linyaps_box::utils


### PR DESCRIPTION
Open dev/ptmx with O_NOFOLLOW, then fstat to determine type:
- regular file: bind-mount pts/ptmx over it (devpts legacy)
- missing: create pts/ptmx symlink
- wrong symlink target: atomically replace via renameat

This change for compatibility.

Add unlink_at and rename_at wrappers to utils/file.
Move do_propagation_mount validity check after early return.

Signed-off-by: Yuming He <ComixHe1895@outlook.com>
