### PR TITLE
refactor(config): restructure OCI config parser and mount subsystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,9 +251,11 @@ find_package(PkgConfig REQUIRED)
 if(linyaps-box_ENABLE_SECCOMP)
   pkg_check_modules(libseccomp REQUIRED IMPORTED_TARGET libseccomp>=2.3.3)
   list(APPEND linyaps-box_LIBRARY_LINK_LIBRARIES PUBLIC PkgConfig::libseccomp)
+  #TODO: detect seccomp_arch_resolve_name and use if available
 endif()
 
 if(linyaps-box_ENABLE_CAP)
+  #TODO: remove libcap and implement it by ourself
   pkg_check_modules(libcap REQUIRED IMPORTED_TARGET libcap>=2.25)
   list(APPEND linyaps-box_LIBRARY_LINK_LIBRARIES PUBLIC PkgConfig::libcap)
 endif()
@@ -341,6 +343,10 @@ endif()
 if(linyaps-box_ENABLE_SECCOMP)
   target_compile_definitions("${linyaps-box_LIBRARY}"
                              PUBLIC LINYAPS_BOX_ENABLE_SECCOMP)
+  if(linyaps-box_HAVE_SECCOMP_ARCH_RESOLVE_NAME)
+    target_compile_definitions("${linyaps-box_LIBRARY}"
+                               PUBLIC SECCOMP_ARCH_RESOLVE_NAME=1)
+  endif()
 endif()
 
 if(linyaps-box_ENABLE_CAP)

--- a/src/linyaps_box/app.cpp
+++ b/src/linyaps_box/app.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -44,22 +44,22 @@ try {
         return opts.global.return_code;
     }
 
-    return std::visit(utils::Overload{ [](const command::list_options &options) {
+    return std::visit(utils::Overload{ [](const command::list_options &options) -> int {
                                           command::list(options);
                                           return 0;
                                       },
                                        [](const command::exec_options &options) -> int {
                                            return command::exec(options);
                                        },
-                                       [](const command::kill_options &options) {
+                                       [](const command::kill_options &options) -> int {
                                            command::kill(options);
                                            return 0;
                                        },
-                                       [](const command::run_options &options) {
+                                       [](const command::run_options &options) -> int {
                                            return command::run(options);
                                        },
-                                       [](const std::monostate &) {
-                                           return 0;
+                                       [](const std::monostate &) -> int {
+                                           __builtin_unreachable();
                                        } },
                       opts.subcommand_opt);
 } catch (const std::exception &e) {

--- a/src/linyaps_box/command/exec.cpp
+++ b/src/linyaps_box/command/exec.cpp
@@ -7,6 +7,10 @@
 #include "linyaps_box/runtime.h"
 #include "linyaps_box/status_directory_manager.h"
 
+#ifdef LINYAPS_BOX_ENABLE_CAP
+#  include <sys/capability.h>
+#endif
+
 auto linyaps_box::command::exec(const struct exec_options &options) -> int
 {
     status_directory_manager mgr(options.global_.get().root);
@@ -37,30 +41,21 @@ auto linyaps_box::command::exec(const struct exec_options &options) -> int
             option.proc.capabilities.emplace();
         }
 
-        auto transform_cap = [&caps](std::optional<std::vector<cap_value_t>> &cap_set) {
-            if (!cap_set) {
-                cap_set.emplace();
+        std::vector<cap_value_t> parsed;
+        parsed.reserve(caps.size());
+        for (const auto &name : caps) {
+            cap_value_t val{ };
+            if (cap_from_name(name.c_str(), &val) < 0) {
+                throw std::system_error(errno, std::system_category(), "cap_from_name");
             }
 
-            cap_set->reserve(caps.size());
-            std::transform(
-              caps.cbegin(),
-              caps.cend(),
-              std::back_inserter(*cap_set),
-              [](const std::string &cap) {
-                  cap_value_t val{ 0 };
-                  if (cap_from_name(cap.c_str(), &val) < 0) {
-                      throw std::system_error(errno, std::system_category(), "cap_from_name");
-                  }
+            parsed.push_back(val);
+        }
 
-                  return val;
-              });
-        };
-
-        transform_cap(option.proc.capabilities->effective);
-        transform_cap(option.proc.capabilities->ambient);
-        transform_cap(option.proc.capabilities->bounding);
-        transform_cap(option.proc.capabilities->permitted);
+        option.proc.capabilities->effective = parsed;
+        option.proc.capabilities->ambient = parsed;
+        option.proc.capabilities->bounding = parsed;
+        option.proc.capabilities->permitted = parsed;
     }
 #endif
 

--- a/src/linyaps_box/command/options.cpp
+++ b/src/linyaps_box/command/options.cpp
@@ -19,7 +19,7 @@ linyaps_box::command::options linyaps_box::command::parse(int argc, char *argv[]
     app.set_version_flag("-v,--version", [] {
         std::stringstream ss;
         ss << "ll-box version " << LINYAPS_BOX_VERSION << "\n";
-        ss << "spec " << linyaps_box::config::oci_version;
+        ss << "spec " << linyaps_box::Config::oci_version;
         return ss.str();
     });
     app.require_subcommand();
@@ -155,7 +155,7 @@ linyaps_box::command::options linyaps_box::command::parse(int argc, char *argv[]
     }
 
     if (cmd_list->parsed()) {
-        options.subcommand_opt = std::move(list_opt);
+        options.subcommand_opt = list_opt;
     } else if (cmd_run->parsed()) {
         options.subcommand_opt = std::move(run_opt);
     } else if (cmd_exec->parsed()) {

--- a/src/linyaps_box/command/run.cpp
+++ b/src/linyaps_box/command/run.cpp
@@ -6,6 +6,7 @@
 
 #include "linyaps_box/runtime.h"
 #include "linyaps_box/status_directory_manager.h"
+#include "linyaps_box/utils/utils.h"
 
 auto linyaps_box::command::run(const struct run_options &options) -> int
 {
@@ -20,7 +21,12 @@ auto linyaps_box::command::run(const struct run_options &options) -> int
     run_container_options_t run_options;
     run_options.preserve_fds = options.preserve_fds;
 
-    if (container.get_config().process.terminal && options.console_socket) {
+    const auto &cfg = container.get_config();
+    if (UNLIKELY(!cfg.process || !cfg.root)) {
+        throw std::runtime_error("'process' and 'root' are required for run a container");
+    }
+
+    if (container.get_config().process->terminal && options.console_socket) {
         run_options.console_socket = unix_socket::connect(options.console_socket.value());
     }
 

--- a/src/linyaps_box/config.cpp
+++ b/src/linyaps_box/config.cpp
@@ -4,26 +4,20 @@
 
 #include "linyaps_box/config.h"
 
+#include "linyaps_box/config/mount_options.h"
+#include "linyaps_box/utils/enum_traits.h"
 #include "linyaps_box/utils/semver.h"
+#include "linyaps_box/utils/utils.h"
 #include "nlohmann/json.hpp"
 
-#include <algorithm>
-#include <sstream>
-
-#include <sys/resource.h>
+#include <bitset>
+#include <fstream>
+#include <limits>
 
 namespace nlohmann {
 template <typename T>
 struct adl_serializer<std::optional<T>>
 {
-    static void to_json(json &j, const std::optional<T> &opt)
-    {
-        if (opt) {
-            j = *opt;
-        } else {
-            j = nullptr;
-        }
-    }
 
     static void from_json(const json &j, std::optional<T> &opt)
     {
@@ -38,2175 +32,1425 @@ struct adl_serializer<std::optional<T>>
 
 namespace {
 
-template <typename T>
-const T *find_in_sorted(const std::vector<std::pair<std::string_view, T>> &vec,
-                        std::string_view key) noexcept
-{
-    auto it =
-      std::lower_bound(vec.begin(), vec.end(), key, [](const auto &p, std::string_view k) noexcept {
-          return p.first < k;
-      });
-    if (it != vec.end() && it->first == key) {
-        return &it->second;
-    }
-    return nullptr;
-}
+namespace mo = linyaps_box::config::mount_options;
 
-// Maps are sorted vectors for cache-friendly small-N lookups.
-// N ≤ 22 for all maps; linear / binary search beats std::unordered_map at this scale.
-
-static const std::vector<std::pair<std::string_view, unsigned long>> propagation_flags_map{
-    { "private", MS_PRIVATE },
-    { "rprivate", MS_PRIVATE | MS_REC },
-    { "rslave", MS_SLAVE | MS_REC },
-    { "runbindable", MS_UNBINDABLE | MS_REC },
-    { "rshared", MS_SHARED | MS_REC },
-    { "shared", MS_SHARED },
-    { "slave", MS_SLAVE },
-    { "unbindable", MS_UNBINDABLE },
-};
-
-static const std::vector<std::pair<std::string_view, unsigned long>> flags_map{
-    { "bind", MS_BIND },           { "defaults", 0 },           { "dirsync", MS_DIRSYNC },
-    { "iversion", MS_I_VERSION },  { "lazytime", MS_LAZYTIME }, { "mand", MS_MANDLOCK },
-    { "noatime", MS_NOATIME },     { "nodev", MS_NODEV },       { "nodiratime", MS_NODIRATIME },
-    { "noexec", MS_NOEXEC },       { "nosuid", MS_NOSUID },     { "nosymfollow", MS_NOSYMFOLLOW },
-    { "rbind", MS_BIND | MS_REC }, { "relatime", MS_RELATIME }, { "remount", MS_REMOUNT },
-    { "ro", MS_RDONLY },           { "silent", MS_SILENT },     { "strictatime", MS_STRICTATIME },
-    { "sync", MS_SYNCHRONOUS },
-};
-
-static const std::vector<std::pair<std::string_view, unsigned long>> unset_flags_map{
-    { "async", MS_SYNCHRONOUS },
-    { "atime", MS_NOATIME },
-    { "dev", MS_NODEV },
-    { "diratime", MS_NODIRATIME },
-    { "exec", MS_NOEXEC },
-    { "loud", MS_SILENT },
-    { "noiversion", MS_I_VERSION },
-    { "nolazytime", MS_LAZYTIME },
-    { "nomand", MS_MANDLOCK },
-    { "norelatime", MS_RELATIME },
-    { "nostrictatime", MS_STRICTATIME },
-    { "rw", MS_RDONLY },
-    { "suid", MS_NOSUID },
-    { "symfollow", MS_NOSYMFOLLOW },
-};
-
-static const std::vector<std::pair<std::string_view, linyaps_box::config::mount_t::extension>>
-  extra_flags_map{
-      { "copy-symlink", linyaps_box::config::mount_t::extension::COPY_SYMLINK },
+constexpr auto rlimit_type_table =
+  linyaps_box::utils::enum_table<linyaps_box::Config::process_t::rlimit_t::type_t, 16>{
+      { { { linyaps_box::Config::process_t::rlimit_t::type_t::AS, "RLIMIT_AS" },
+          { linyaps_box::Config::process_t::rlimit_t::type_t::CORE, "RLIMIT_CORE" },
+          { linyaps_box::Config::process_t::rlimit_t::type_t::CPU, "RLIMIT_CPU" },
+          { linyaps_box::Config::process_t::rlimit_t::type_t::DATA, "RLIMIT_DATA" },
+          { linyaps_box::Config::process_t::rlimit_t::type_t::FSIZE, "RLIMIT_FSIZE" },
+          { linyaps_box::Config::process_t::rlimit_t::type_t::LOCKS, "RLIMIT_LOCKS" },
+          { linyaps_box::Config::process_t::rlimit_t::type_t::MEMLOCK, "RLIMIT_MEMLOCK" },
+          { linyaps_box::Config::process_t::rlimit_t::type_t::MSGQUEUE, "RLIMIT_MSGQUEUE" },
+          { linyaps_box::Config::process_t::rlimit_t::type_t::NICE, "RLIMIT_NICE" },
+          { linyaps_box::Config::process_t::rlimit_t::type_t::NOFILE, "RLIMIT_NOFILE" },
+          { linyaps_box::Config::process_t::rlimit_t::type_t::NPROC, "RLIMIT_NPROC" },
+          { linyaps_box::Config::process_t::rlimit_t::type_t::RSS, "RLIMIT_RSS" },
+          { linyaps_box::Config::process_t::rlimit_t::type_t::RTPRIO, "RLIMIT_RTPRIO" },
+          { linyaps_box::Config::process_t::rlimit_t::type_t::RTTIME, "RLIMIT_RTTIME" },
+          { linyaps_box::Config::process_t::rlimit_t::type_t::SIGPENDING, "RLIMIT_SIGPENDING" },
+          { linyaps_box::Config::process_t::rlimit_t::type_t::STACK, "RLIMIT_STACK" } } }
   };
 
-// For serialization: list in priority order (r* before non-recursive)
-static const std::vector<std::pair<unsigned long, std::string_view>> propagation_flags_to_names{
-    { MS_PRIVATE | MS_REC, "rprivate" },       { MS_PRIVATE, "private" },
-    { MS_SLAVE | MS_REC, "rslave" },           { MS_SLAVE, "slave" },
-    { MS_SHARED | MS_REC, "rshared" },         { MS_SHARED, "shared" },
-    { MS_UNBINDABLE | MS_REC, "runbindable" }, { MS_UNBINDABLE, "unbindable" },
-};
+static_assert(linyaps_box::utils::verify_enum_table(rlimit_type_table));
 
-static const std::vector<std::pair<unsigned long, std::string_view>> flags_to_names{
-    { MS_BIND | MS_REC, "rbind" },
-    { MS_BIND, "bind" },
-    { MS_DIRSYNC, "dirsync" },
-    { MS_I_VERSION, "iversion" },
-    { MS_LAZYTIME, "lazytime" },
-    { MS_MANDLOCK, "mand" },
-    { MS_NOATIME, "noatime" },
-    { MS_NODEV, "nodev" },
-    { MS_NODIRATIME, "nodiratime" },
-    { MS_NOEXEC, "noexec" },
-    { MS_NOSUID, "nosuid" },
-    { MS_NOSYMFOLLOW, "nosymfollow" },
-    { MS_RDONLY, "ro" },
-    { MS_RELATIME, "relatime" },
-    { MS_REMOUNT, "remount" },
-    { MS_SILENT, "silent" },
-    { MS_STRICTATIME, "strictatime" },
-    { MS_SYNCHRONOUS, "sync" },
-};
-
-static const std::vector<std::pair<linyaps_box::config::mount_t::extension, std::string_view>>
-  extra_flags_to_names{
-      { linyaps_box::config::mount_t::extension::COPY_SYMLINK, "copy-symlink" },
+constexpr auto scheduler_policy_table =
+  linyaps_box::utils::enum_table<linyaps_box::Config::process_t::scheduler_t::policy_t, 7>{
+      { { { linyaps_box::Config::process_t::scheduler_t::policy_t::OTHER, "SCHED_OTHER" },
+          { linyaps_box::Config::process_t::scheduler_t::policy_t::FIFO, "SCHED_FIFO" },
+          { linyaps_box::Config::process_t::scheduler_t::policy_t::RR, "SCHED_RR" },
+          { linyaps_box::Config::process_t::scheduler_t::policy_t::BATCH, "SCHED_BATCH" },
+          { linyaps_box::Config::process_t::scheduler_t::policy_t::ISO, "SCHED_ISO" },
+          { linyaps_box::Config::process_t::scheduler_t::policy_t::IDLE, "SCHED_IDLE" },
+          { linyaps_box::Config::process_t::scheduler_t::policy_t::DEADLINE, "SCHED_DEADLINE" } } }
   };
+
+static_assert(linyaps_box::utils::verify_enum_table(scheduler_policy_table));
+
+constexpr auto scheduler_flag_table =
+  linyaps_box::utils::enum_table<linyaps_box::Config::process_t::scheduler_t::flag_t, 7>{ { {
+    { linyaps_box::Config::process_t::scheduler_t::flag_t::RESET_ON_FORK,
+      "SCHED_FLAG_RESET_ON_FORK" },
+    { linyaps_box::Config::process_t::scheduler_t::flag_t::RECLAIM, "SCHED_FLAG_RECLAIM" },
+    { linyaps_box::Config::process_t::scheduler_t::flag_t::DL_OVERRUN, "SCHED_FLAG_DL_OVERRUN" },
+    { linyaps_box::Config::process_t::scheduler_t::flag_t::KEEP_POLICY, "SCHED_FLAG_KEEP_POLICY" },
+    { linyaps_box::Config::process_t::scheduler_t::flag_t::KEEP_PARAMS, "SCHED_FLAG_KEEP_PARAMS" },
+    { linyaps_box::Config::process_t::scheduler_t::flag_t::UTIL_CLAMP_MIN,
+      "SCHED_FLAG_UTIL_CLAMP_MIN" },
+    { linyaps_box::Config::process_t::scheduler_t::flag_t::UTIL_CLAMP_MAX,
+      "SCHED_FLAG_UTIL_CLAMP_MAX" },
+  } } };
+
+static_assert(linyaps_box::utils::verify_enum_table(scheduler_flag_table));
+
+constexpr auto io_priority_class_table =
+  linyaps_box::utils::enum_table<linyaps_box::Config::process_t::io_priority_t::class_t, 3>{
+      { { { linyaps_box::Config::process_t::io_priority_t::class_t::RT, "IOPRIO_CLASS_RT" },
+          { linyaps_box::Config::process_t::io_priority_t::class_t::BEST_EFFORT,
+            "IOPRIO_CLASS_BE" },
+          { linyaps_box::Config::process_t::io_priority_t::class_t::IDLE, "IOPRIO_CLASS_IDLE" } } }
+  };
+
+static_assert(linyaps_box::utils::verify_enum_table(io_priority_class_table));
+
+constexpr auto personality_domain_table =
+  linyaps_box::utils::enum_table<linyaps_box::Config::linux_t::personality_t::domain_t, 2>{
+      { { { linyaps_box::Config::linux_t::personality_t::domain_t::LINUX, "LINUX" },
+          { linyaps_box::Config::linux_t::personality_t::domain_t::LINUX32, "LINUX32" } } }
+  };
+
+static_assert(linyaps_box::utils::verify_enum_table(personality_domain_table));
+
+constexpr auto memory_policy_mode_table =
+  linyaps_box::utils::enum_table<linyaps_box::Config::linux_t::memory_policy_t::mode_t, 7>{
+      { { { linyaps_box::Config::linux_t::memory_policy_t::mode_t::DEFAULT, "MPOL_DEFAULT" },
+          { linyaps_box::Config::linux_t::memory_policy_t::mode_t::BIND, "MPOL_BIND" },
+          { linyaps_box::Config::linux_t::memory_policy_t::mode_t::INTERLEAVE, "MPOL_INTERLEAVE" },
+          { linyaps_box::Config::linux_t::memory_policy_t::mode_t::WEIGHTED_INTERLEAVE,
+            "MPOL_WEIGHTED_INTERLEAVE" },
+          { linyaps_box::Config::linux_t::memory_policy_t::mode_t::PREFERRED, "MPOL_PREFERRED" },
+          { linyaps_box::Config::linux_t::memory_policy_t::mode_t::PREFERRED_MANY,
+            "MPOL_PREFERRED_MANY" },
+          { linyaps_box::Config::linux_t::memory_policy_t::mode_t::LOCAL, "MPOL_LOCAL" } } }
+  };
+
+static_assert(linyaps_box::utils::verify_enum_table(memory_policy_mode_table));
+
+constexpr auto memory_policy_flag_table =
+  linyaps_box::utils::enum_table<linyaps_box::Config::linux_t::memory_policy_t::flag_t, 3>{
+      { { { linyaps_box::Config::linux_t::memory_policy_t::flag_t::NUMA_BALANCING,
+            "MPOL_F_NUMA_BALANCING" },
+          { linyaps_box::Config::linux_t::memory_policy_t::flag_t::RELATIVE_NODES,
+            "MPOL_F_RELATIVE_NODES" },
+          { linyaps_box::Config::linux_t::memory_policy_t::flag_t::STATIC_NODES,
+            "MPOL_F_STATIC_NODES" } } }
+  };
+
+static_assert(linyaps_box::utils::verify_enum_table(memory_policy_flag_table));
+
+#ifdef LINYAPS_BOX_ENABLE_SECCOMP
+constexpr auto seccomp_op_table =
+  linyaps_box::utils::enum_table<linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t,
+                                 7>{
+      { { { linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t::EQ, "SCMP_CMP_EQ" },
+          { linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t::NE, "SCMP_CMP_NE" },
+          { linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t::LT, "SCMP_CMP_LT" },
+          { linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t::LE, "SCMP_CMP_LE" },
+          { linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t::GT, "SCMP_CMP_GT" },
+          { linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t::GE, "SCMP_CMP_GE" },
+          { linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t::MASKED_EQ,
+            "SCMP_CMP_MASKED_EQ" } } }
+  };
+
+static_assert(linyaps_box::utils::verify_enum_table(seccomp_op_table));
+
+constexpr auto seccomp_action_table =
+  linyaps_box::utils::enum_table<linyaps_box::Config::linux_t::seccomp_t::action_t, 9>{
+      { { { linyaps_box::Config::linux_t::seccomp_t::action_t::ALLOW, "SCMP_ACT_ALLOW" },
+          { linyaps_box::Config::linux_t::seccomp_t::action_t::ERRNO, "SCMP_ACT_ERRNO" },
+          { linyaps_box::Config::linux_t::seccomp_t::action_t::KILL, "SCMP_ACT_KILL" },
+          { linyaps_box::Config::linux_t::seccomp_t::action_t::KILL_PROCESS,
+            "SCMP_ACT_KILL_PROCESS" },
+          { linyaps_box::Config::linux_t::seccomp_t::action_t::KILL_THREAD,
+            "SCMP_ACT_KILL_THREAD" },
+          { linyaps_box::Config::linux_t::seccomp_t::action_t::LOG, "SCMP_ACT_LOG" },
+          { linyaps_box::Config::linux_t::seccomp_t::action_t::NOTIFY, "SCMP_ACT_NOTIFY" },
+          { linyaps_box::Config::linux_t::seccomp_t::action_t::TRACE, "SCMP_ACT_TRACE" },
+          { linyaps_box::Config::linux_t::seccomp_t::action_t::TRAP, "SCMP_ACT_TRAP" } } }
+  };
+
+// SCMP_ACT_KILL is aliased to KILL_THREAD or KILL_PROCESS depending on the
+// libseccomp version — only (KILL, KILL_THREAD) or (KILL, KILL_PROCESS) may
+// share the same value.
+static_assert(linyaps_box::utils::verify_enum_table(
+  seccomp_action_table, [](const auto &a, const auto &b) noexcept {
+      if (a.name == b.name) {
+          return false;
+      }
+
+      if (a.value == b.value) {
+          return (a.name == "SCMP_ACT_KILL" && b.name == "SCMP_ACT_KILL_THREAD")
+            || (a.name == "SCMP_ACT_KILL_THREAD" && b.name == "SCMP_ACT_KILL")
+            || (a.name == "SCMP_ACT_KILL" && b.name == "SCMP_ACT_KILL_PROCESS")
+            || (a.name == "SCMP_ACT_KILL_PROCESS" && b.name == "SCMP_ACT_KILL");
+      }
+
+      return true;
+  }));
+
+constexpr auto seccomp_flag_table =
+  linyaps_box::utils::enum_table<linyaps_box::Config::linux_t::seccomp_t::flag_t, 4>{
+      { { { linyaps_box::Config::linux_t::seccomp_t::flag_t::TSYNC, "SECCOMP_FILTER_FLAG_TSYNC" },
+          { linyaps_box::Config::linux_t::seccomp_t::flag_t::LOG, "SECCOMP_FILTER_FLAG_LOG" },
+          { linyaps_box::Config::linux_t::seccomp_t::flag_t::SPEC_ALLOW,
+            "SECCOMP_FILTER_FLAG_SPEC_ALLOW" },
+          { linyaps_box::Config::linux_t::seccomp_t::flag_t::WAIT_KILLABLE_RECV,
+            "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV" } } }
+  };
+
+static_assert(linyaps_box::utils::verify_enum_table(seccomp_flag_table));
+#endif
+
+constexpr auto extra_flags_table =
+  linyaps_box::utils::enum_table<linyaps_box::Config::mount_t::extension, 2>{
+      { { { linyaps_box::Config::mount_t::extension::COPY_SYMLINK, "copy-symlink" },
+          { linyaps_box::Config::mount_t::extension::TMPCOPYUP, "tmpcopyup" } } }
+  };
+
+static_assert(linyaps_box::utils::verify_enum_table(extra_flags_table));
+
+constexpr auto idmap_options_table =
+  linyaps_box::utils::enum_table<linyaps_box::Config::mount_t::idmap_type, 2>{
+      { { { linyaps_box::Config::mount_t::idmap_type::IDMAP, "idmap" },
+          { linyaps_box::Config::mount_t::idmap_type::RIDMAP, "ridmap" } } }
+  };
+
+static_assert(linyaps_box::utils::verify_enum_table(idmap_options_table));
 
 auto parse_mount_options(const std::vector<std::string> &options)
-  -> std::tuple<unsigned long, unsigned long, linyaps_box::config::mount_t::extension, std::string>
+  -> std::tuple<unsigned long,
+                unsigned long,
+                std::optional<linyaps_box::Config::mount_t::recursive_attr>,
+                linyaps_box::Config::mount_t::extension,
+                std::optional<linyaps_box::Config::mount_t::idmap_type>,
+                std::string>
 {
-    unsigned long flags = 0;
-    auto extra_flags = linyaps_box::config::mount_t::extension::NONE;
-    unsigned long propagation_flags = 0;
+    using extension = linyaps_box::Config::mount_t::extension;
+
+    auto vfs_flags{ 0UL };
+    auto propagation_flags{ 0UL };
+    std::optional<linyaps_box::Config::mount_t::recursive_attr> rec_attr;
+    auto extension_flags{ extension::NONE };
+    std::optional<linyaps_box::Config::mount_t::idmap_type> idmap;
+
     std::string data;
 
     for (const auto &opt : options) {
-        if (auto *val = find_in_sorted(flags_map, opt)) {
-            flags |= *val;
+        if (const auto *entry = mo::find(mo::vfs, opt)) {
+            vfs_flags |= entry->value;
             continue;
         }
-        if (auto *val = find_in_sorted(unset_flags_map, opt)) {
-            flags &= ~*val;
+
+        if (const auto *entry = mo::find(mo::unset, opt)) {
+            vfs_flags &= ~entry->value;
             continue;
         }
-        if (auto *val = find_in_sorted(propagation_flags_map, opt)) {
-            propagation_flags |= *val;
+
+        if (const auto *entry = mo::find(mo::propagation, opt)) {
+            propagation_flags |= entry->value;
             continue;
         }
-        if (auto *val = find_in_sorted(extra_flags_map, opt)) {
-            extra_flags |= *val;
+
+        if (const auto *entry = mo::find(mo::recursive_attr_set, opt)) {
+            if (!rec_attr) {
+                rec_attr.emplace();
+            }
+            rec_attr->set |= entry->value;
+            continue;
+        }
+
+        if (const auto *entry = mo::find(mo::recursive_attr_clr, opt)) {
+            if (!rec_attr) {
+                rec_attr.emplace();
+            }
+            rec_attr->clr |= entry->value;
+            continue;
+        }
+
+        if (auto ev = extra_flags_table.from_name(opt)) {
+            extension_flags = extension_flags | *ev;
+            continue;
+        }
+
+        // TODO: handle inline mapping strings like "idmap=uids=0:1000:1,gids=0:1000:1"
+        if (auto iv = idmap_options_table.from_name(opt)) {
+            if (UNLIKELY(idmap.has_value() && *idmap != *iv)) {
+                throw std::runtime_error("idmap and ridmap options are mutually exclusive");
+            }
+
+            idmap.emplace(std::move(iv).value());
             continue;
         }
 
         if (!data.empty()) {
-            data += ',';
+            data.push_back(',');
         }
-        data += opt;
+
+        data.append(opt);
     }
 
-    return { flags, propagation_flags, extra_flags, std::move(data) };
+    return { vfs_flags, propagation_flags, rec_attr, extension_flags, idmap, std::move(data) };
 }
 
-auto to_mount_options(unsigned long flags,
-                      unsigned long propagation_flags,
-                      linyaps_box::config::mount_t::extension ext_flags,
-                      const std::string &data) -> std::vector<std::string>
-{
-    std::vector<std::string> result;
-
-    for (const auto &[val, name] : flags_to_names) {
-        if ((flags & val) == val) {
-            result.emplace_back(name);
-            flags &= ~val;
-        }
-    }
-    for (const auto &[val, name] : propagation_flags_to_names) {
-        if ((propagation_flags & val) == val) {
-            result.emplace_back(name);
-            propagation_flags &= ~val;
-        }
-    }
-    for (const auto &[val, name] : extra_flags_to_names) {
-        if ((static_cast<std::underlying_type_t<linyaps_box::config::mount_t::extension>>(ext_flags)
-             & static_cast<std::underlying_type_t<linyaps_box::config::mount_t::extension>>(val))
-            == static_cast<std::underlying_type_t<linyaps_box::config::mount_t::extension>>(val)) {
-            result.emplace_back(name);
-        }
-    }
-
-    if (!data.empty()) {
-        result.push_back(data);
-    }
-
-    return result;
-}
-
-static const std::vector<
-  std::pair<std::string_view, linyaps_box::config::linux_t::namespace_t::type>>
-  namespace_type_map{
-      { "cgroup", linyaps_box::config::linux_t::namespace_t::type::CGROUP },
-      { "ipc", linyaps_box::config::linux_t::namespace_t::type::IPC },
-      { "mount", linyaps_box::config::linux_t::namespace_t::type::MOUNT },
-      { "network", linyaps_box::config::linux_t::namespace_t::type::NET },
-      { "pid", linyaps_box::config::linux_t::namespace_t::type::PID },
-      { "time", linyaps_box::config::linux_t::namespace_t::type::TIME },
-      { "user", linyaps_box::config::linux_t::namespace_t::type::USER },
-      { "uts", linyaps_box::config::linux_t::namespace_t::type::UTS },
+constexpr auto namespace_type_table =
+  linyaps_box::utils::enum_table<linyaps_box::Config::linux_t::namespace_t::type, 8>{
+      { { { linyaps_box::Config::linux_t::namespace_t::type::CGROUP, "cgroup" },
+          { linyaps_box::Config::linux_t::namespace_t::type::IPC, "ipc" },
+          { linyaps_box::Config::linux_t::namespace_t::type::MOUNT, "mount" },
+          { linyaps_box::Config::linux_t::namespace_t::type::NET, "network" },
+          { linyaps_box::Config::linux_t::namespace_t::type::PID, "pid" },
+          { linyaps_box::Config::linux_t::namespace_t::type::TIME, "time" },
+          { linyaps_box::Config::linux_t::namespace_t::type::USER, "user" },
+          { linyaps_box::Config::linux_t::namespace_t::type::UTS, "uts" } } }
   };
 
-static const std::vector<
-  std::pair<linyaps_box::config::linux_t::namespace_t::type, std::string_view>>
-  namespace_type_to_string{
-      { linyaps_box::config::linux_t::namespace_t::type::TIME, "time" },
-      { linyaps_box::config::linux_t::namespace_t::type::MOUNT, "mount" },
-      { linyaps_box::config::linux_t::namespace_t::type::CGROUP, "cgroup" },
-      { linyaps_box::config::linux_t::namespace_t::type::UTS, "uts" },
-      { linyaps_box::config::linux_t::namespace_t::type::IPC, "ipc" },
-      { linyaps_box::config::linux_t::namespace_t::type::USER, "user" },
-      { linyaps_box::config::linux_t::namespace_t::type::PID, "pid" },
-      { linyaps_box::config::linux_t::namespace_t::type::NET, "network" },
-  };
-
-static const std::vector<std::pair<std::string_view, unsigned int>> rootfs_propagation_map{
-    { "private", MS_PRIVATE },
-    { "shared", MS_SHARED },
-    { "slave", MS_SLAVE },
-    { "unbindable", MS_UNBINDABLE },
-};
-
-static const std::vector<std::pair<unsigned int, std::string_view>> rootfs_propagation_to_string{
-    { MS_PRIVATE, "private" },
-    { MS_SLAVE, "slave" },
-    { MS_SHARED, "shared" },
-    { MS_UNBINDABLE, "unbindable" },
-};
-
-static const std::vector<
-  std::pair<std::string_view, linyaps_box::config::process_t::scheduler_t::policy_t>>
-  scheduler_policy_map{
-      { "SCHED_BATCH", linyaps_box::config::process_t::scheduler_t::policy_t::BATCH },
-      { "SCHED_DEADLINE", linyaps_box::config::process_t::scheduler_t::policy_t::DEADLINE },
-      { "SCHED_FIFO", linyaps_box::config::process_t::scheduler_t::policy_t::FIFO },
-      { "SCHED_IDLE", linyaps_box::config::process_t::scheduler_t::policy_t::IDLE },
-      { "SCHED_ISO", linyaps_box::config::process_t::scheduler_t::policy_t::ISO },
-      { "SCHED_OTHER", linyaps_box::config::process_t::scheduler_t::policy_t::OTHER },
-      { "SCHED_RR", linyaps_box::config::process_t::scheduler_t::policy_t::RR },
-  };
-
-static const std::vector<
-  std::pair<linyaps_box::config::process_t::scheduler_t::policy_t, std::string_view>>
-  scheduler_policy_to_string{
-      { linyaps_box::config::process_t::scheduler_t::policy_t::OTHER, "SCHED_OTHER" },
-      { linyaps_box::config::process_t::scheduler_t::policy_t::FIFO, "SCHED_FIFO" },
-      { linyaps_box::config::process_t::scheduler_t::policy_t::RR, "SCHED_RR" },
-      { linyaps_box::config::process_t::scheduler_t::policy_t::BATCH, "SCHED_BATCH" },
-      { linyaps_box::config::process_t::scheduler_t::policy_t::ISO, "SCHED_ISO" },
-      { linyaps_box::config::process_t::scheduler_t::policy_t::IDLE, "SCHED_IDLE" },
-      { linyaps_box::config::process_t::scheduler_t::policy_t::DEADLINE, "SCHED_DEADLINE" },
-  };
-
-static const std::vector<std::pair<int, std::string_view>> scheduler_flags_to_names{
-    { SCHED_FLAG_RESET_ON_FORK, "SCHED_FLAG_RESET_ON_FORK" },
-    { SCHED_FLAG_RECLAIM, "SCHED_FLAG_RECLAIM" },
-    { SCHED_FLAG_DL_OVERRUN, "SCHED_FLAG_DL_OVERRUN" },
-    { SCHED_FLAG_KEEP_POLICY, "SCHED_FLAG_KEEP_POLICY" },
-    { SCHED_FLAG_KEEP_PARAMS, "SCHED_FLAG_KEEP_PARAMS" },
-    { SCHED_FLAG_UTIL_CLAMP_MIN, "SCHED_FLAG_UTIL_CLAMP_MIN" },
-    { SCHED_FLAG_UTIL_CLAMP_MAX, "SCHED_FLAG_UTIL_CLAMP_MAX" },
-};
-
-static const std::vector<
-  std::pair<std::string_view, linyaps_box::config::process_t::io_priority_t::class_t>>
-  io_priority_class_map{
-      { "IOPRIO_CLASS_BE", linyaps_box::config::process_t::io_priority_t::class_t::BEST_EFFORT },
-      { "IOPRIO_CLASS_IDLE", linyaps_box::config::process_t::io_priority_t::class_t::IDLE },
-      { "IOPRIO_CLASS_RT", linyaps_box::config::process_t::io_priority_t::class_t::RT },
-  };
-
-static const std::vector<
-  std::pair<linyaps_box::config::process_t::io_priority_t::class_t, std::string_view>>
-  io_priority_class_to_string{
-      { linyaps_box::config::process_t::io_priority_t::class_t::RT, "IOPRIO_CLASS_RT" },
-      { linyaps_box::config::process_t::io_priority_t::class_t::BEST_EFFORT, "IOPRIO_CLASS_BE" },
-      { linyaps_box::config::process_t::io_priority_t::class_t::IDLE, "IOPRIO_CLASS_IDLE" },
-  };
-
-static const std::vector<
-  std::pair<std::string_view, linyaps_box::config::linux_t::personality_t::domain_t>>
-  personality_domain_map{
-      { "LINUX", linyaps_box::config::linux_t::personality_t::domain_t::LINUX },
-      { "LINUX32", linyaps_box::config::linux_t::personality_t::domain_t::LINUX32 },
-  };
-
-static const std::vector<
-  std::pair<linyaps_box::config::linux_t::personality_t::domain_t, std::string_view>>
-  personality_domain_to_string{
-      { linyaps_box::config::linux_t::personality_t::domain_t::LINUX, "LINUX" },
-      { linyaps_box::config::linux_t::personality_t::domain_t::LINUX32, "LINUX32" },
-  };
-
-static const std::vector<
-  std::pair<std::string_view, linyaps_box::config::linux_t::memory_policy_t::mode_t>>
-  memory_policy_mode_map{
-      { "MPOL_BIND", linyaps_box::config::linux_t::memory_policy_t::mode_t::BIND },
-      { "MPOL_DEFAULT", linyaps_box::config::linux_t::memory_policy_t::mode_t::DEFAULT },
-      { "MPOL_INTERLEAVE", linyaps_box::config::linux_t::memory_policy_t::mode_t::INTERLEAVE },
-      { "MPOL_LOCAL", linyaps_box::config::linux_t::memory_policy_t::mode_t::LOCAL },
-      { "MPOL_PREFERRED", linyaps_box::config::linux_t::memory_policy_t::mode_t::PREFERRED },
-      { "MPOL_PREFERRED_MANY",
-        linyaps_box::config::linux_t::memory_policy_t::mode_t::PREFERRED_MANY },
-      { "MPOL_WEIGHTED_INTERLEAVE",
-        linyaps_box::config::linux_t::memory_policy_t::mode_t::WEIGHTED_INTERLEAVE },
-  };
-
-static const std::vector<
-  std::pair<linyaps_box::config::linux_t::memory_policy_t::mode_t, std::string_view>>
-  memory_policy_mode_to_string{
-      { linyaps_box::config::linux_t::memory_policy_t::mode_t::DEFAULT, "MPOL_DEFAULT" },
-      { linyaps_box::config::linux_t::memory_policy_t::mode_t::PREFERRED, "MPOL_PREFERRED" },
-      { linyaps_box::config::linux_t::memory_policy_t::mode_t::BIND, "MPOL_BIND" },
-      { linyaps_box::config::linux_t::memory_policy_t::mode_t::INTERLEAVE, "MPOL_INTERLEAVE" },
-      { linyaps_box::config::linux_t::memory_policy_t::mode_t::LOCAL, "MPOL_LOCAL" },
-      { linyaps_box::config::linux_t::memory_policy_t::mode_t::PREFERRED_MANY,
-        "MPOL_PREFERRED_MANY" },
-      { linyaps_box::config::linux_t::memory_policy_t::mode_t::WEIGHTED_INTERLEAVE,
-        "MPOL_WEIGHTED_INTERLEAVE" },
-  };
-
-static const std::vector<std::pair<uint16_t, std::string_view>> memory_policy_flags_to_names{
-    { static_cast<uint16_t>(linyaps_box::config::linux_t::memory_policy_t::flag_t::NUMA_BALANCING),
-      "MPOL_F_NUMA_BALANCING" },
-    { static_cast<uint16_t>(linyaps_box::config::linux_t::memory_policy_t::flag_t::RELATIVE_NODES),
-      "MPOL_F_RELATIVE_NODES" },
-    { static_cast<uint16_t>(linyaps_box::config::linux_t::memory_policy_t::flag_t::STATIC_NODES),
-      "MPOL_F_STATIC_NODES" },
-};
+static_assert(linyaps_box::utils::verify_enum_table(namespace_type_table));
 
 #ifdef LINYAPS_BOX_ENABLE_SECCOMP
-static const std::vector<
-  std::pair<std::string_view, linyaps_box::config::linux_t::seccomp_t::arch_t>>
-  seccomp_arch_map{
-      { "SCMP_ARCH_AARCH64", linyaps_box::config::linux_t::seccomp_t::arch_t::AARCH64 },
-      { "SCMP_ARCH_ARM", linyaps_box::config::linux_t::seccomp_t::arch_t::ARM },
-      { "SCMP_ARCH_LOONGARCH64", linyaps_box::config::linux_t::seccomp_t::arch_t::LOONGARCH64 },
-      { "SCMP_ARCH_M68K", linyaps_box::config::linux_t::seccomp_t::arch_t::M68K },
-      { "SCMP_ARCH_MIPS", linyaps_box::config::linux_t::seccomp_t::arch_t::MIPS },
-      { "SCMP_ARCH_MIPS64", linyaps_box::config::linux_t::seccomp_t::arch_t::MIPS64 },
-      { "SCMP_ARCH_MIPS64N32", linyaps_box::config::linux_t::seccomp_t::arch_t::MIPS64N32 },
-      { "SCMP_ARCH_MIPSEL", linyaps_box::config::linux_t::seccomp_t::arch_t::MIPSEL },
-      { "SCMP_ARCH_MIPSEL64", linyaps_box::config::linux_t::seccomp_t::arch_t::MIPSEL64 },
-      { "SCMP_ARCH_MIPSEL64N32", linyaps_box::config::linux_t::seccomp_t::arch_t::MIPSEL64N32 },
-      { "SCMP_ARCH_PARISC", linyaps_box::config::linux_t::seccomp_t::arch_t::PARISC },
-      { "SCMP_ARCH_PARISC64", linyaps_box::config::linux_t::seccomp_t::arch_t::PARISC64 },
-      { "SCMP_ARCH_PPC", linyaps_box::config::linux_t::seccomp_t::arch_t::PPC },
-      { "SCMP_ARCH_PPC64", linyaps_box::config::linux_t::seccomp_t::arch_t::PPC64 },
-      { "SCMP_ARCH_PPC64LE", linyaps_box::config::linux_t::seccomp_t::arch_t::PPC64LE },
-      { "SCMP_ARCH_RISCV64", linyaps_box::config::linux_t::seccomp_t::arch_t::RISCV64 },
-      { "SCMP_ARCH_S390", linyaps_box::config::linux_t::seccomp_t::arch_t::S390 },
-      { "SCMP_ARCH_S390X", linyaps_box::config::linux_t::seccomp_t::arch_t::S390X },
-      { "SCMP_ARCH_SH", linyaps_box::config::linux_t::seccomp_t::arch_t::SH },
-      { "SCMP_ARCH_SHEB", linyaps_box::config::linux_t::seccomp_t::arch_t::SHEB },
-      { "SCMP_ARCH_X32", linyaps_box::config::linux_t::seccomp_t::arch_t::X32 },
-      { "SCMP_ARCH_X86", linyaps_box::config::linux_t::seccomp_t::arch_t::X86 },
-      { "SCMP_ARCH_X86_64", linyaps_box::config::linux_t::seccomp_t::arch_t::X86_64 },
-  };
-
-static const std::vector<
-  std::pair<linyaps_box::config::linux_t::seccomp_t::arch_t, std::string_view>>
-  seccomp_arch_to_string{
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::AARCH64, "SCMP_ARCH_AARCH64" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::ARM, "SCMP_ARCH_ARM" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::LOONGARCH64, "SCMP_ARCH_LOONGARCH64" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::M68K, "SCMP_ARCH_M68K" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::MIPS, "SCMP_ARCH_MIPS" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::MIPS64, "SCMP_ARCH_MIPS64" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::MIPS64N32, "SCMP_ARCH_MIPS64N32" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::MIPSEL, "SCMP_ARCH_MIPSEL" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::MIPSEL64, "SCMP_ARCH_MIPSEL64" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::MIPSEL64N32, "SCMP_ARCH_MIPSEL64N32" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::PARISC, "SCMP_ARCH_PARISC" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::PARISC64, "SCMP_ARCH_PARISC64" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::PPC, "SCMP_ARCH_PPC" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::PPC64, "SCMP_ARCH_PPC64" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::PPC64LE, "SCMP_ARCH_PPC64LE" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::RISCV64, "SCMP_ARCH_RISCV64" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::S390, "SCMP_ARCH_S390" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::S390X, "SCMP_ARCH_S390X" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::SH, "SCMP_ARCH_SH" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::SHEB, "SCMP_ARCH_SHEB" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::X32, "SCMP_ARCH_X32" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::X86, "SCMP_ARCH_X86" },
-      { linyaps_box::config::linux_t::seccomp_t::arch_t::X86_64, "SCMP_ARCH_X86_64" },
-  };
-
-static const std::vector<
-  std::pair<std::string_view, linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t>>
-  seccomp_op_map{
-      { "SCMP_CMP_EQ", linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t::EQ },
-      { "SCMP_CMP_GE", linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t::GE },
-      { "SCMP_CMP_GT", linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t::GT },
-      { "SCMP_CMP_LE", linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t::LE },
-      { "SCMP_CMP_LT", linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t::LT },
-      { "SCMP_CMP_MASKED_EQ",
-        linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t::MASKED_EQ },
-      { "SCMP_CMP_NE", linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t::NE },
-  };
-
-static const std::vector<
-  std::pair<linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t, std::string_view>>
-  seccomp_op_to_string{
-      { linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t::EQ, "SCMP_CMP_EQ" },
-      { linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t::NE, "SCMP_CMP_NE" },
-      { linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t::LT, "SCMP_CMP_LT" },
-      { linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t::LE, "SCMP_CMP_LE" },
-      { linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t::GT, "SCMP_CMP_GT" },
-      { linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t::GE, "SCMP_CMP_GE" },
-      { linyaps_box::config::linux_t::seccomp_t::syscall_t::arg_t::op_t::MASKED_EQ,
-        "SCMP_CMP_MASKED_EQ" },
-  };
-
-static const std::vector<
-  std::pair<std::string_view, linyaps_box::config::linux_t::seccomp_t::flag_t>>
-  seccomp_flag_map{
-      { "SECCOMP_FILTER_FLAG_LOG", linyaps_box::config::linux_t::seccomp_t::flag_t::LOG },
-      { "SECCOMP_FILTER_FLAG_SPEC_ALLOW",
-        linyaps_box::config::linux_t::seccomp_t::flag_t::SPEC_ALLOW },
-      { "SECCOMP_FILTER_FLAG_TSYNC", linyaps_box::config::linux_t::seccomp_t::flag_t::TSYNC },
-      { "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV",
-        linyaps_box::config::linux_t::seccomp_t::flag_t::WAIT_KILLABLE_RECV },
-  };
-
-static const std::vector<
-  std::pair<linyaps_box::config::linux_t::seccomp_t::flag_t, std::string_view>>
-  seccomp_flag_to_string{
-      { linyaps_box::config::linux_t::seccomp_t::flag_t::LOG, "SECCOMP_FILTER_FLAG_LOG" },
-      { linyaps_box::config::linux_t::seccomp_t::flag_t::SPEC_ALLOW,
-        "SECCOMP_FILTER_FLAG_SPEC_ALLOW" },
-      { linyaps_box::config::linux_t::seccomp_t::flag_t::TSYNC, "SECCOMP_FILTER_FLAG_TSYNC" },
-      { linyaps_box::config::linux_t::seccomp_t::flag_t::WAIT_KILLABLE_RECV,
-        "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV" },
-  };
+using arch_t = linyaps_box::Config::linux_t::seccomp_t::arch_t;
+constexpr auto seccomp_arch_table =
+  linyaps_box::utils::enum_table<arch_t, 23>{ { { { arch_t::X86, "SCMP_ARCH_X86" },
+                                                  { arch_t::X86_64, "SCMP_ARCH_X86_64" },
+                                                  { arch_t::X32, "SCMP_ARCH_X32" },
+                                                  { arch_t::ARM, "SCMP_ARCH_ARM" },
+                                                  { arch_t::AARCH64, "SCMP_ARCH_AARCH64" },
+                                                  { arch_t::MIPS, "SCMP_ARCH_MIPS" },
+                                                  { arch_t::MIPS64, "SCMP_ARCH_MIPS64" },
+                                                  { arch_t::MIPS64N32, "SCMP_ARCH_MIPS64N32" },
+                                                  { arch_t::MIPSEL, "SCMP_ARCH_MIPSEL" },
+                                                  { arch_t::MIPSEL64, "SCMP_ARCH_MIPSEL64" },
+                                                  { arch_t::MIPSEL64N32, "SCMP_ARCH_MIPSEL64N32" },
+                                                  { arch_t::PPC, "SCMP_ARCH_PPC" },
+                                                  { arch_t::PPC64, "SCMP_ARCH_PPC64" },
+                                                  { arch_t::PPC64LE, "SCMP_ARCH_PPC64LE" },
+                                                  { arch_t::S390, "SCMP_ARCH_S390" },
+                                                  { arch_t::S390X, "SCMP_ARCH_S390X" },
+                                                  { arch_t::PARISC, "SCMP_ARCH_PARISC" },
+                                                  { arch_t::PARISC64, "SCMP_ARCH_PARISC64" },
+                                                  { arch_t::RISCV64, "SCMP_ARCH_RISCV64" },
+                                                  { arch_t::LOONGARCH64, "SCMP_ARCH_LOONGARCH64" },
+                                                  { arch_t::M68K, "SCMP_ARCH_M68K" },
+                                                  { arch_t::SH, "SCMP_ARCH_SH" },
+                                                  { arch_t::SHEB, "SCMP_ARCH_SHEB" } } } };
+static_assert(linyaps_box::utils::verify_enum_table(seccomp_arch_table));
 #endif
 
-auto parse_range_list(const std::string &s) -> std::vector<unsigned int>
+auto parse_range_list(std::string_view s) -> std::vector<unsigned int>
 {
-    if (s.empty()) {
-        return { };
-    }
     std::vector<unsigned int> result;
-    std::istringstream ss(s);
-    std::string part;
-    while (std::getline(ss, part, ',')) {
-        auto dash = part.find('-');
-        if (dash == std::string::npos) {
-            result.push_back(static_cast<unsigned int>(std::stoul(part)));
-        } else {
-            auto start = static_cast<unsigned int>(std::stoul(part.substr(0, dash)));
-            auto end = static_cast<unsigned int>(std::stoul(part.substr(dash + 1)));
-            auto n = static_cast<size_t>(end - start + 1);
+    if (s.empty()) {
+        return result;
+    }
+
+    result.reserve(16);
+
+    const auto *ptr = s.data();
+    const auto *end = ptr + s.size();
+
+    auto skip_whitespace = [](const char *p, const char *e) {
+        while (p < e && static_cast<unsigned char>(*p) <= ' ') {
+            ++p;
+        }
+
+        return p;
+    };
+
+    while (ptr < end) {
+        ptr = skip_whitespace(ptr, end);
+        if (ptr == end) {
+            break;
+        }
+
+        auto start{ 0U };
+        auto [p_start, ec_start] = std::from_chars(ptr, end, start);
+        if (UNLIKELY(ec_start != std::errc{ })) {
+            if (ec_start == std::errc::result_out_of_range) {
+                throw std::runtime_error(
+                  "value overflow in range list at: "
+                  + std::string(ptr, std::min(end - ptr, static_cast<std::ptrdiff_t>(16))));
+            }
+
+            throw std::runtime_error(
+              "invalid value in range list at: "
+              + std::string(ptr, std::min(end - ptr, static_cast<std::ptrdiff_t>(16))));
+        }
+
+        ptr = p_start;
+        ptr = skip_whitespace(ptr, end);
+
+        if (ptr < end && *ptr == '-') {
+            ++ptr;
+            ptr = skip_whitespace(ptr, end);
+
+            auto finish{ 0U };
+            auto [p_finish, ec_finish] = std::from_chars(ptr, end, finish);
+            if (UNLIKELY(ec_finish != std::errc{ })) {
+                if (ec_finish == std::errc::result_out_of_range) {
+                    throw std::runtime_error(
+                      "value overflow in range list at: "
+                      + std::string(ptr, std::min(end - ptr, static_cast<std::ptrdiff_t>(16))));
+                }
+                throw std::runtime_error(
+                  "invalid range end in range list at: "
+                  + std::string(ptr, std::min(end - ptr, static_cast<std::ptrdiff_t>(16))));
+            }
+
+            ptr = p_finish;
+            if (UNLIKELY(finish < start)) {
+                throw std::runtime_error(
+                  "invalid range in range list (finish < start) at: "
+                  + std::string(ptr, std::min(end - ptr, static_cast<std::ptrdiff_t>(16))));
+            }
+
+            if (UNLIKELY(start == 0 && finish == std::numeric_limits<unsigned int>::max())) {
+                throw std::runtime_error(
+                  "range too large in range list at: "
+                  + std::string(ptr, std::min(end - ptr, static_cast<std::ptrdiff_t>(16))));
+            }
+
+            auto n = finish - start + 1;
             auto pos = result.size();
             result.resize(pos + n);
-            std::iota(result.begin() + static_cast<std::ptrdiff_t>(pos), result.end(), start);
+            for (unsigned int j = 0; j < n; ++j) {
+                result[pos + j] = start + j;
+            }
+        } else {
+            result.push_back(start);
+        }
+
+        ptr = skip_whitespace(ptr, end);
+        if (ptr < end) {
+            if (UNLIKELY(*ptr != ',')) {
+                throw std::runtime_error(
+                  "expected ',' or end-of-string in range list at: "
+                  + std::string(ptr, std::min(end - ptr, static_cast<std::ptrdiff_t>(16))));
+            }
+
+            ++ptr;
         }
     }
+
     return result;
 }
 
-auto format_range_list(std::vector<unsigned int> v) -> std::string
+// see: https://pubs.opengroup.org/onlinepubs/9799919799/
+auto is_invalid_env(std::string_view env) noexcept -> bool
 {
-    if (v.empty()) {
-        return { };
+    auto pos = env.find('=');
+    if (pos == std::string_view::npos) {
+        return true;
     }
-    std::sort(v.begin(), v.end());
-    v.erase(std::unique(v.begin(), v.end()), v.end());
 
-    std::string result;
-    size_t i = 0;
-    while (i < v.size()) {
-        auto start = v[i];
-        auto end = start;
-        while (i + 1 < v.size() && v[i + 1] == end + 1) {
-            ++i;
-            ++end;
-        }
-        if (!result.empty()) {
-            result += ',';
-        }
-        result += std::to_string(start);
-        if (end > start) {
-            result += '-';
-            result += std::to_string(end);
-        }
-        ++i;
+    if (pos == 0) {
+        return true;
     }
-    return result;
+
+    if (env.find('\0') != std::string_view::npos) {
+        return true;
+    }
+
+    return false;
 }
 
 } // namespace
 
 namespace linyaps_box {
 
-// --- console_size_t ---
-
-void from_json(const nlohmann::json &j, config::process_t::console_size_t &v)
+void from_json(const nlohmann::json &j, linyaps_box::Config::process_t::console_size_t &v)
 {
     j.at("height").get_to(v.height);
     j.at("width").get_to(v.width);
 }
 
-void to_json(nlohmann::json &j, const config::process_t::console_size_t &v)
+void from_json(const nlohmann::json &j, linyaps_box::Config::process_t::rlimit_t &v)
 {
-    j = nlohmann::json::object({ { "height", v.height }, { "width", v.width } });
-}
-
-// --- rlimit_t ---
-
-static const std::vector<
-  std::pair<std::string_view, linyaps_box::config::process_t::rlimit_t::type_t>>
-  rlimit_type_map{
-      { "RLIMIT_AS", linyaps_box::config::process_t::rlimit_t::type_t::AS },
-      { "RLIMIT_CORE", linyaps_box::config::process_t::rlimit_t::type_t::CORE },
-      { "RLIMIT_CPU", linyaps_box::config::process_t::rlimit_t::type_t::CPU },
-      { "RLIMIT_DATA", linyaps_box::config::process_t::rlimit_t::type_t::DATA },
-      { "RLIMIT_FSIZE", linyaps_box::config::process_t::rlimit_t::type_t::FSIZE },
-      { "RLIMIT_MEMLOCK", linyaps_box::config::process_t::rlimit_t::type_t::MEMLOCK },
-      { "RLIMIT_MSGQUEUE", linyaps_box::config::process_t::rlimit_t::type_t::MSGQUEUE },
-      { "RLIMIT_NICE", linyaps_box::config::process_t::rlimit_t::type_t::NICE },
-      { "RLIMIT_NOFILE", linyaps_box::config::process_t::rlimit_t::type_t::NOFILE },
-      { "RLIMIT_NPROC", linyaps_box::config::process_t::rlimit_t::type_t::NPROC },
-      { "RLIMIT_RSS", linyaps_box::config::process_t::rlimit_t::type_t::RSS },
-      { "RLIMIT_RTPRIO", linyaps_box::config::process_t::rlimit_t::type_t::RTPRIO },
-      { "RLIMIT_RTTIME", linyaps_box::config::process_t::rlimit_t::type_t::RTTIME },
-      { "RLIMIT_SIGPENDING", linyaps_box::config::process_t::rlimit_t::type_t::SIGPENDING },
-      { "RLIMIT_STACK", linyaps_box::config::process_t::rlimit_t::type_t::STACK },
-  };
-
-static const std::vector<
-  std::pair<linyaps_box::config::process_t::rlimit_t::type_t, std::string_view>>
-  rlimit_type_to_string{
-      { linyaps_box::config::process_t::rlimit_t::type_t::AS, "RLIMIT_AS" },
-      { linyaps_box::config::process_t::rlimit_t::type_t::CORE, "RLIMIT_CORE" },
-      { linyaps_box::config::process_t::rlimit_t::type_t::CPU, "RLIMIT_CPU" },
-      { linyaps_box::config::process_t::rlimit_t::type_t::DATA, "RLIMIT_DATA" },
-      { linyaps_box::config::process_t::rlimit_t::type_t::FSIZE, "RLIMIT_FSIZE" },
-      { linyaps_box::config::process_t::rlimit_t::type_t::MEMLOCK, "RLIMIT_MEMLOCK" },
-      { linyaps_box::config::process_t::rlimit_t::type_t::MSGQUEUE, "RLIMIT_MSGQUEUE" },
-      { linyaps_box::config::process_t::rlimit_t::type_t::NICE, "RLIMIT_NICE" },
-      { linyaps_box::config::process_t::rlimit_t::type_t::NOFILE, "RLIMIT_NOFILE" },
-      { linyaps_box::config::process_t::rlimit_t::type_t::NPROC, "RLIMIT_NPROC" },
-      { linyaps_box::config::process_t::rlimit_t::type_t::RSS, "RLIMIT_RSS" },
-      { linyaps_box::config::process_t::rlimit_t::type_t::RTPRIO, "RLIMIT_RTPRIO" },
-      { linyaps_box::config::process_t::rlimit_t::type_t::RTTIME, "RLIMIT_RTTIME" },
-      { linyaps_box::config::process_t::rlimit_t::type_t::SIGPENDING, "RLIMIT_SIGPENDING" },
-      { linyaps_box::config::process_t::rlimit_t::type_t::STACK, "RLIMIT_STACK" },
-  };
-
-void from_json(const nlohmann::json &j, config::process_t::rlimit_t &v)
-{
-    if (!j.contains("type")) {
-        throw std::runtime_error("rlimit must contain type");
+    auto name = j.at("type").get<std::string_view>();
+    auto opt = rlimit_type_table.from_name(name);
+    if (UNLIKELY(!opt)) {
+        throw std::runtime_error("unknown value: " + std::string(name));
     }
-    auto type_str = j.at("type").get_ref<const std::string &>();
-    auto *val = find_in_sorted(rlimit_type_map, type_str);
-    if (!val) {
-        throw std::runtime_error("unknown rlimit type: " + type_str);
-    }
-    v.type = *val;
+    v.type = *opt;
     j.at("soft").get_to(v.soft);
     j.at("hard").get_to(v.hard);
 }
 
-void to_json(nlohmann::json &j, const config::process_t::rlimit_t &v)
-{
-    std::string_view type_str;
-    for (const auto &[val, name] : rlimit_type_to_string) {
-        if (val == v.type) {
-            type_str = name;
-            break;
-        }
-    }
-    j = nlohmann::json::object({ { "type", type_str }, { "soft", v.soft }, { "hard", v.hard } });
-}
-
-// --- user_t ---
-
-void from_json(const nlohmann::json &j, config::process_t::user_t &v)
+void from_json(const nlohmann::json &j, Config::process_t::user_t &v)
 {
     j.at("uid").get_to(v.uid);
     j.at("gid").get_to(v.gid);
 
-    if (auto it = j.find("umask"); it != j.end()) {
-        v.umask = it->get<mode_t>();
+    if (auto it = j.find("umask"); it != j.end() && !it->is_null()) {
+        it->get_to(v.umask.emplace());
     }
 
-    if (auto it = j.find("additionalGids"); it != j.end()) {
-        v.additional_gids = it->get<std::vector<gid_t>>();
+    if (auto it = j.find("additionalGids"); it != j.end() && !it->is_null()) {
+        it->get_to(v.additional_gids.emplace());
     }
 }
-
-void to_json(nlohmann::json &j, const config::process_t::user_t &v)
-{
-    auto obj = nlohmann::json::object({ { "uid", v.uid }, { "gid", v.gid } });
-    if (v.umask) {
-        obj["umask"] = *v.umask;
-    }
-    if (v.additional_gids) {
-        obj["additionalGids"] = *v.additional_gids;
-    }
-    j = std::move(obj);
-}
-
-// --- capabilities_t ---
 
 #ifdef LINYAPS_BOX_ENABLE_CAP
-void from_json(const nlohmann::json &j, config::process_t::capabilities_t &v)
+void from_json(const nlohmann::json &j, Config::process_t::capabilities_t &v)
 {
-    auto parse_cap_set = [&j](const char *name) -> std::vector<cap_value_t> {
-        auto it = j.find(name);
-        if (it == j.end()) {
-            return { };
-        }
-
-        std::vector<cap_value_t> result;
-        result.reserve(it->size());
-        std::transform(it->begin(), it->end(), std::back_inserter(result), [](const auto &elem) {
-            cap_value_t val{ 0 };
-            auto cap_name = elem.template get_ref<const std::string &>();
-            if (cap_from_name(cap_name.c_str(), &val) < 0) {
-                throw std::runtime_error("unknown capability: " + cap_name);
+    auto parse_set = [](const nlohmann::json &j, std::vector<cap_value_t> &set) {
+        set.reserve(j.size());
+        for (const auto &elem : j) {
+            const auto &name = elem.get_ref<const std::string &>();
+            cap_value_t val{ };
+            if (UNLIKELY(cap_from_name(name.c_str(), &val) < 0)) {
+                throw std::runtime_error("failed to parse cap " + name + ": " + ::strerror(errno));
             }
-            return val;
-        });
-        return result;
+
+            set.push_back(val);
+        }
     };
 
-    v.effective = parse_cap_set("effective");
-    v.ambient = parse_cap_set("ambient");
-    v.bounding = parse_cap_set("bounding");
-    v.inheritable = parse_cap_set("inheritable");
-    v.permitted = parse_cap_set("permitted");
+    if (auto it = j.find("effective"); it != j.end() && !it->is_null()) {
+        parse_set(*it, v.effective.emplace());
+    }
+
+    if (auto it = j.find("ambient"); it != j.end() && !it->is_null()) {
+        parse_set(*it, v.ambient.emplace());
+    }
+
+    if (auto it = j.find("bounding"); it != j.end() && !it->is_null()) {
+        parse_set(*it, v.bounding.emplace());
+    }
+
+    if (auto it = j.find("inheritable"); it != j.end() && !it->is_null()) {
+        parse_set(*it, v.inheritable.emplace());
+    }
+
+    if (auto it = j.find("permitted"); it != j.end() && !it->is_null()) {
+        parse_set(*it, v.permitted.emplace());
+    }
 }
 
-void to_json(nlohmann::json &j, const config::process_t::capabilities_t &v)
+#endif // LINYAPS_BOX_ENABLE_CAP
+
+void from_json(const nlohmann::json &j, Config::process_t::io_priority_t &v)
 {
-    auto format_cap_set = [](const std::optional<std::vector<cap_value_t>> &caps)
-      -> std::optional<std::vector<std::string>> {
-        if (!caps) {
-            return std::nullopt;
-        }
-        std::vector<std::string> result;
-        result.reserve(caps->size());
-        std::transform(caps->begin(), caps->end(), std::back_inserter(result), [](cap_value_t cap) {
-            auto *name = cap_to_name(cap);
-            if (name == nullptr) {
-                throw std::runtime_error("unknown capability value: "
-                                         + std::to_string(static_cast<int>(cap)));
-            }
-            std::string s(name);
-            cap_free(name);
-            return s;
-        });
-        return result;
-    };
+    auto name = j.at("class").get<std::string_view>();
+    auto opt = io_priority_class_table.from_name(name);
+    if (UNLIKELY(!opt)) {
+        throw std::runtime_error("unknown value: " + std::string(name));
+    }
+    v.class_ = *opt;
 
-    j = nlohmann::json::object();
-    if (auto effective = format_cap_set(v.effective)) {
-        j["effective"] = std::move(*effective);
-    }
-    if (auto ambient = format_cap_set(v.ambient)) {
-        j["ambient"] = std::move(*ambient);
-    }
-    if (auto bounding = format_cap_set(v.bounding)) {
-        j["bounding"] = std::move(*bounding);
-    }
-    if (auto inheritable = format_cap_set(v.inheritable)) {
-        j["inheritable"] = std::move(*inheritable);
-    }
-    if (auto permitted = format_cap_set(v.permitted)) {
-        j["permitted"] = std::move(*permitted);
-    }
-}
-#endif
-
-// --- io_priority_t ---
-
-void from_json(const nlohmann::json &j, config::process_t::io_priority_t &v)
-{
-    auto class_str = j.at("class").get_ref<const std::string &>();
-    auto *val = find_in_sorted(io_priority_class_map, class_str);
-    if (!val) {
-        throw std::runtime_error("unknown io priority class: " + class_str);
-    }
-    v.class_ = *val;
     v.priority = j.value("priority", 0);
+
+    if (UNLIKELY(v.priority < 0 || v.priority > 7)) {
+        throw std::runtime_error("io priority must be in range [0, 7], got: "
+                                 + std::to_string(v.priority));
+    }
 }
 
-void to_json(nlohmann::json &j, const config::process_t::io_priority_t &v)
+void from_json(const nlohmann::json &j, Config::process_t::scheduler_t &v)
 {
-    std::string_view class_str;
-    for (const auto &[val, name] : io_priority_class_to_string) {
-        if (val == v.class_) {
-            class_str = name;
-            break;
-        }
+    auto policy_name = j.at("policy").get<std::string_view>();
+    auto policy_opt = scheduler_policy_table.from_name(policy_name);
+    if (UNLIKELY(!policy_opt)) {
+        throw std::runtime_error("unknown value: " + std::string(policy_name));
     }
-    if (class_str.empty()) {
-        throw std::runtime_error("unknown io priority class value");
-    }
+    v.policy = *policy_opt;
 
-    j = nlohmann::json::object({ { "class", class_str }, { "priority", v.priority } });
-}
-
-// --- scheduler_t ---
-
-void from_json(const nlohmann::json &j, config::process_t::scheduler_t &v)
-{
-    auto policy_str = j.at("policy").get_ref<const std::string &>();
-    auto *val = find_in_sorted(scheduler_policy_map, policy_str);
-    if (!val) {
-        throw std::runtime_error("unknown scheduler policy: " + policy_str);
-    }
-    v.policy = *val;
-
-    if (auto nice_it = j.find("nice"); nice_it != j.end()) {
-        v.nice = nice_it->get<int32_t>();
-    }
-    if (auto prio_it = j.find("priority"); prio_it != j.end()) {
-        v.priority = prio_it->get<int32_t>();
+    if (auto it = j.find("nice"); it != j.end() && !it->is_null()) {
+        it->get_to(v.nice.emplace());
     }
 
-    if (auto flags_it = j.find("flags"); flags_it != j.end()) {
-        int flags = 0;
+    if (auto it = j.find("priority"); it != j.end() && !it->is_null()) {
+        it->get_to(v.priority.emplace());
+    }
+
+    if (auto flags_it = j.find("flags"); flags_it != j.end() && !flags_it->is_null()) {
+        Config::process_t::scheduler_t::flag_t flags{ };
         for (const auto &f : *flags_it) {
-            auto flag_str = f.get_ref<const std::string &>();
-            for (const auto &[val, name] : scheduler_flags_to_names) {
-                if (name == flag_str) {
-                    flags |= val;
-                    break;
-                }
+            const auto &flag_str = f.get_ref<const std::string &>();
+            auto flag_opt = scheduler_flag_table.from_name(flag_str);
+            if (UNLIKELY(!flag_opt)) {
+                throw std::runtime_error("unknown value: " + std::string(flag_str));
             }
+            flags = flags | *flag_opt;
         }
+
         v.flags = flags;
     }
 
-    if (auto rt_it = j.find("runtime"); rt_it != j.end()) {
-        v.runtime = rt_it->get<uint64_t>();
-    }
-    if (auto dl_it = j.find("deadline"); dl_it != j.end()) {
-        v.deadline = dl_it->get<uint64_t>();
-    }
-    if (auto pr_it = j.find("period"); pr_it != j.end()) {
-        v.period = pr_it->get<uint64_t>();
-    }
-}
-
-void to_json(nlohmann::json &j, const config::process_t::scheduler_t &v)
-{
-    std::string_view policy_str;
-    for (const auto &[val, name] : scheduler_policy_to_string) {
-        if (val == v.policy) {
-            policy_str = name;
-            break;
-        }
-    }
-    if (policy_str.empty()) {
-        throw std::runtime_error("unknown scheduler policy value");
+    if (auto it = j.find("runtime"); it != j.end() && !it->is_null()) {
+        it->get_to(v.runtime.emplace());
     }
 
-    j = nlohmann::json::object({ { "policy", policy_str } });
+    if (auto it = j.find("deadline"); it != j.end() && !it->is_null()) {
+        it->get_to(v.deadline.emplace());
+    }
+
+    if (auto it = j.find("period"); it != j.end() && !it->is_null()) {
+        it->get_to(v.period.emplace());
+    }
 
     if (v.nice) {
-        j["nice"] = *v.nice;
-    }
-    if (v.priority) {
-        j["priority"] = *v.priority;
-    }
-    if (v.flags) {
-        nlohmann::json::array_t flag_arr;
-        for (const auto &[val, name] : scheduler_flags_to_names) {
-            if ((*v.flags & val) == val) {
-                flag_arr.push_back(std::string(name));
-            }
+        if (UNLIKELY(*v.nice < -20 || *v.nice > 19)) {
+            throw std::runtime_error("scheduler.nice must be in range [-20, 19]");
         }
-        j["flags"] = std::move(flag_arr);
     }
-    if (v.runtime) {
-        j["runtime"] = *v.runtime;
+
+    if (v.priority && *v.priority != 0) {
+        if (v.policy != Config::process_t::scheduler_t::policy_t::FIFO
+            && v.policy != Config::process_t::scheduler_t::policy_t::RR) {
+            throw std::runtime_error(
+              "scheduler.priority can only be specified for SCHED_FIFO or SCHED_RR");
+        }
     }
-    if (v.deadline) {
-        j["deadline"] = *v.deadline;
-    }
-    if (v.period) {
-        j["period"] = *v.period;
+
+    if (v.runtime || v.deadline || v.period) {
+        if (v.policy != Config::process_t::scheduler_t::policy_t::DEADLINE) {
+            throw std::runtime_error(
+              "scheduler runtime/deadline/period can only be specified for SCHED_DEADLINE");
+        }
     }
 }
 
-// --- exec_cpu_affinity_t ---
-
-void from_json(const nlohmann::json &j, config::process_t::exec_cpu_affinity_t &v)
+void from_json(const nlohmann::json &j, Config::process_t::exec_cpu_affinity_t &v)
 {
-    if (auto it = j.find("initial"); it != j.end()) {
-        v.initial = it->get<std::string>();
+    if (auto it = j.find("initial"); it != j.end() && !it->is_null()) {
+        it->get_to(v.initial.emplace());
     }
-    if (auto it = j.find("final"); it != j.end()) {
-        v.final = it->get<std::string>();
+
+    if (auto it = j.find("final"); it != j.end() && !it->is_null()) {
+        it->get_to(v.final.emplace());
     }
 }
 
-void to_json(nlohmann::json &j, const config::process_t::exec_cpu_affinity_t &v)
+void from_json(const nlohmann::json &j, Config::process_t &v)
 {
-    j = nlohmann::json::object();
-    if (v.initial) {
-        j["initial"] = *v.initial;
-    }
-    if (v.final) {
-        j["final"] = *v.final;
-    }
-}
-
-// --- process_t ---
-
-void from_json(const nlohmann::json &j, config::process_t &v)
-{
-    if (auto it = j.find("terminal"); it != j.end()) {
-        it->get_to(v.terminal);
+    if (auto it = j.find("terminal"); it != j.end() && !it->is_null()) {
+        it->get_to(v.terminal.emplace());
     }
 
-    if (v.terminal) {
-        if (auto it = j.find("consoleSize"); it != j.end()) {
-            v.console_size = it->get<config::process_t::console_size_t>();
+    if (v.terminal.value_or(false)) {
+        if (auto it = j.find("consoleSize"); it != j.end() && !it->is_null()) {
+            it->get_to(v.console_size.emplace());
         }
     }
 
     j.at("cwd").get_to(v.cwd);
-    if (!v.cwd.is_absolute()) {
+    if (UNLIKELY(!v.cwd.is_absolute())) {
         throw std::runtime_error("process.cwd must be an absolute path, got: " + v.cwd.string());
     }
 
-    if (auto it = j.find("env"); it != j.end()) {
-        it->get_to(v.env);
-        for (const auto &e : *v.env) {
-            if (e.find('=') == std::string::npos) {
-                throw std::runtime_error("invalid env entry: " + e);
-            }
+    if (auto it = j.find("env"); it != j.end() && !it->is_null()) {
+        it->get_to(v.env.emplace());
+        auto invalid = std::find_if(v.env->cbegin(), v.env->cend(), is_invalid_env);
+        if (UNLIKELY(invalid != v.env->cend())) {
+            throw std::runtime_error("process.env contains a invalid env: " + *invalid);
         }
     }
 
     j.at("args").get_to(v.args);
-    if (v.args.empty()) {
+    if (UNLIKELY(v.args.empty())) {
         throw std::runtime_error("process.args must not be empty");
     }
 
-    if (auto it = j.find("rlimits"); it != j.end()) {
-        v.rlimits = it->get<std::vector<config::process_t::rlimit_t>>();
-        std::vector<config::process_t::rlimit_t::type_t> seen_rl;
+    if (auto it = j.find("rlimits"); it != j.end() && !it->is_null()) {
+        it->get_to(v.rlimits.emplace());
+
+        std::bitset<rlimit_type_table.entries.size()> seen;
         for (const auto &rl : *v.rlimits) {
-            if (std::find(seen_rl.begin(), seen_rl.end(), rl.type) != seen_rl.end()) {
-                throw std::runtime_error(std::string(to_string_view(rl.type))
-                                         + ": duplicate rlimit type");
+            const auto type_val = static_cast<size_t>(rl.type);
+            if (UNLIKELY(type_val >= seen.size())) {
+                throw std::runtime_error("invalid rlimit type value out of range");
             }
-            seen_rl.push_back(rl.type);
+
+            if (UNLIKELY(seen.test(type_val))) {
+                throw std::runtime_error(
+                  std::string{ "duplicate rlimit type: " }.append(to_string_view(rl.type)));
+            }
+
+            seen.set(type_val);
         }
     }
 
-    if (auto it = j.find("apparmorProfile"); it != j.end()) {
-        v.apparmor_profile = it->get<std::string>();
+    if (auto it = j.find("apparmorProfile"); it != j.end() && !it->is_null()) {
+        it->get_to(v.apparmor_profile.emplace());
     }
 
 #ifdef LINYAPS_BOX_ENABLE_CAP
-    if (auto it = j.find("capabilities"); it != j.end()) {
-        v.capabilities = it->get<config::process_t::capabilities_t>();
+    if (auto it = j.find("capabilities"); it != j.end() && !it->is_null()) {
+        it->get_to(v.capabilities.emplace());
     }
 #endif
 
-    if (auto it = j.find("noNewPrivileges"); it != j.end()) {
-        it->get_to(v.no_new_privileges);
+    if (auto it = j.find("noNewPrivileges"); it != j.end() && !it->is_null()) {
+        it->get_to(v.no_new_privileges.emplace());
     }
 
-    if (auto it = j.find("oomScoreAdj"); it != j.end()) {
-        v.oom_score_adj = it->get<int>();
+    if (auto it = j.find("oomScoreAdj"); it != j.end() && !it->is_null()) {
+        it->get_to(v.oom_score_adj.emplace());
     }
 
-    if (auto it = j.find("scheduler"); it != j.end()) {
-        v.scheduler = it->get<config::process_t::scheduler_t>();
+    if (auto it = j.find("scheduler"); it != j.end() && !it->is_null()) {
+        it->get_to(v.scheduler.emplace());
     }
 
-    if (auto it = j.find("selinuxLabel"); it != j.end()) {
-        v.selinux_label = it->get<std::string>();
+    if (auto it = j.find("selinuxLabel"); it != j.end() && !it->is_null()) {
+        it->get_to(v.selinux_label.emplace());
     }
 
-    if (auto it = j.find("ioPriority"); it != j.end()) {
-        v.io_priority = it->get<config::process_t::io_priority_t>();
+    if (auto it = j.find("ioPriority"); it != j.end() && !it->is_null()) {
+        it->get_to(v.io_priority.emplace());
     }
 
-    if (auto it = j.find("execCPUAffinity"); it != j.end()) {
-        v.exec_cpu_affinity = it->get<config::process_t::exec_cpu_affinity_t>();
+    if (auto it = j.find("execCPUAffinity"); it != j.end() && !it->is_null()) {
+        it->get_to(v.exec_cpu_affinity.emplace());
     }
 
-    j.at("user").get_to(v.user);
+    if (auto it = j.find("user"); it != j.end() && !it->is_null()) {
+        it->get_to(v.user);
+    } else {
+        v.user = { };
+    }
 }
 
-void to_json(nlohmann::json &j, const config::process_t &v)
-{
-    j = nlohmann::json::object();
-
-    if (v.terminal) {
-        j["terminal"] = true;
-        if (v.console_size) {
-            j["consoleSize"] = *v.console_size;
-        }
-    }
-
-    j["cwd"] = v.cwd.string();
-    j["args"] = v.args;
-
-    if (v.env) {
-        j["env"] = *v.env;
-    }
-    if (v.rlimits) {
-        j["rlimits"] = *v.rlimits;
-    }
-    if (v.apparmor_profile) {
-        j["apparmorProfile"] = *v.apparmor_profile;
-    }
-    if (v.no_new_privileges) {
-        j["noNewPrivileges"] = *v.no_new_privileges;
-    }
-    if (v.oom_score_adj) {
-        j["oomScoreAdj"] = *v.oom_score_adj;
-    }
-    if (v.selinux_label) {
-        j["selinuxLabel"] = *v.selinux_label;
-    }
-    if (v.scheduler) {
-        j["scheduler"] = *v.scheduler;
-    }
-    if (v.io_priority) {
-        j["ioPriority"] = *v.io_priority;
-    }
-    if (v.exec_cpu_affinity) {
-        j["execCPUAffinity"] = *v.exec_cpu_affinity;
-    }
-
-#ifdef LINYAPS_BOX_ENABLE_CAP
-    if (v.capabilities) {
-        j["capabilities"] = *v.capabilities;
-    }
-#endif
-
-    j["user"] = v.user;
-}
-
-// --- id_mapping_t ---
-
-void from_json(const nlohmann::json &j, config::linux_t::id_mapping_t &v)
+void from_json(const nlohmann::json &j, Config::id_mapping_t &v)
 {
     j.at("hostID").get_to(v.host_id);
     j.at("containerID").get_to(v.container_id);
     j.at("size").get_to(v.size);
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::id_mapping_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::namespace_t &v)
 {
-    j = nlohmann::json::object(
-      { { "containerID", v.container_id }, { "hostID", v.host_id }, { "size", v.size } });
-}
-
-// --- namespace_t ---
-
-void from_json(const nlohmann::json &j, config::linux_t::namespace_t &v)
-{
-    auto type_str = j.at("type").get_ref<const std::string &>();
-    const auto *val = find_in_sorted(namespace_type_map, type_str);
-    if (val == nullptr) {
-        throw std::runtime_error("unsupported namespace type: " + type_str);
+    auto type_str = j.at("type").get<std::string_view>();
+    auto opt = namespace_type_table.from_name(type_str);
+    if (UNLIKELY(!opt)) {
+        throw std::runtime_error("unknown namespace type: " + std::string(type_str));
     }
-    v.type_ = *val;
+    v.type_ = *opt;
 
-    if (auto path_it = j.find("path"); path_it != j.end()) {
-        auto path = path_it->get<std::string>();
-        if (path.empty()) {
-            throw std::runtime_error("namespace path must not be empty for type: " + type_str);
+    if (auto path_it = j.find("path"); path_it != j.end() && !path_it->is_null()) {
+        auto path = path_it->get<std::string_view>();
+        if (UNLIKELY(path.empty())) {
+            throw std::runtime_error(
+              std::string{ "namespace path must not be empty for type: " }.append(type_str));
         }
 
-        auto fs_path = std::filesystem::path{ path };
-        if (!fs_path.is_absolute()) {
-            throw std::runtime_error("namespace path must be absolute for type: " + type_str
-                                     + ", got: " + path);
+        auto &fs_path = v.path.emplace(path);
+        if (UNLIKELY(!fs_path.is_absolute())) {
+            throw std::runtime_error("namespace path must be absolute for type: "
+                                     + std::string(type_str) + ", got: " + std::string(path));
         }
-
-        v.path = std::move(fs_path);
     }
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::namespace_t &v)
-{
-    std::string_view type_str;
-    for (const auto &[val, name] : namespace_type_to_string) {
-        if (val == v.type_) {
-            type_str = name;
-            break;
-        }
-    }
-    if (type_str.empty()) {
-        throw std::runtime_error("unsupported namespace type value");
-    }
-
-    j = nlohmann::json::object({ { "type", type_str } });
-    if (v.path) {
-        j["path"] = v.path->string();
-    }
-}
-
-// --- time_offset_t ---
-
-void from_json(const nlohmann::json &j, config::linux_t::time_offset_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::time_offset_t &v)
 {
     j.at("secs").get_to(v.secs);
     j.at("nanosecs").get_to(v.nanosecs);
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::time_offset_t &v)
-{
-    j = nlohmann::json::object({ { "secs", v.secs }, { "nanosecs", v.nanosecs } });
-}
-
-// --- device_t ---
-
-void from_json(const nlohmann::json &j, config::linux_t::device_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::device_t &v)
 {
     j.at("type").get_to(v.type);
     j.at("path").get_to(v.path);
 
-    if (auto it = j.find("fileMode"); it != j.end()) {
-        v.mode = it->get<uint32_t>();
+    if (auto it = j.find("fileMode"); it != j.end() && !it->is_null()) {
+        it->get_to(v.mode.emplace());
     }
-    if (auto it = j.find("major"); it != j.end()) {
-        v.major = it->get<uint32_t>();
+
+    if (auto it = j.find("major"); it != j.end() && !it->is_null()) {
+        it->get_to(v.major.emplace());
     }
-    if (auto it = j.find("minor"); it != j.end()) {
-        v.minor = it->get<uint32_t>();
+
+    if (auto it = j.find("minor"); it != j.end() && !it->is_null()) {
+        it->get_to(v.minor.emplace());
     }
-    if (auto it = j.find("uid"); it != j.end()) {
-        v.uid = it->get<uint32_t>();
+
+    if (auto it = j.find("uid"); it != j.end() && !it->is_null()) {
+        it->get_to(v.uid.emplace());
     }
-    if (auto it = j.find("gid"); it != j.end()) {
-        v.gid = it->get<uint32_t>();
+
+    if (auto it = j.find("gid"); it != j.end() && !it->is_null()) {
+        it->get_to(v.gid.emplace());
     }
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::device_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::network_device_t &v)
 {
-    j = nlohmann::json::object({ { "type", v.type }, { "path", v.path.string() } });
-    if (v.mode) {
-        j["fileMode"] = *v.mode;
-    }
-    if (v.major) {
-        j["major"] = *v.major;
-    }
-    if (v.minor) {
-        j["minor"] = *v.minor;
-    }
-    if (v.uid) {
-        j["uid"] = *v.uid;
-    }
-    if (v.gid) {
-        j["gid"] = *v.gid;
-    }
-}
-
-// --- network_device_t ---
-
-void from_json(const nlohmann::json &j, config::linux_t::network_device_t &v)
-{
-    if (auto it = j.find("name"); it != j.end()) {
-        v.name = it->get<std::string>();
-    }
-}
-
-void to_json(nlohmann::json &j, const config::linux_t::network_device_t &v)
-{
-    j = nlohmann::json::object();
-    if (v.name) {
-        j["name"] = *v.name;
+    if (auto it = j.find("name"); it != j.end() && !it->is_null()) {
+        it->get_to(v.name.emplace());
     }
 }
 
 // --- allowed_device_t ---
 
-void from_json(const nlohmann::json &j, config::linux_t::allowed_device_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::resources_t::device_t &v)
 {
     j.at("allow").get_to(v.allow);
-    if (auto it = j.find("type"); it != j.end()) {
-        v.type = it->get<std::string>();
+    if (auto it = j.find("type"); it != j.end() && !it->is_null()) {
+        it->get_to(v.type.emplace());
     }
-    if (auto it = j.find("major"); it != j.end()) {
-        v.major = it->get<int64_t>();
+
+    if (auto it = j.find("major"); it != j.end() && !it->is_null()) {
+        it->get_to(v.major.emplace());
     }
-    if (auto it = j.find("minor"); it != j.end()) {
-        v.minor = it->get<int64_t>();
+
+    if (auto it = j.find("minor"); it != j.end() && !it->is_null()) {
+        it->get_to(v.minor.emplace());
     }
-    if (auto it = j.find("access"); it != j.end()) {
-        v.access = it->get<std::string>();
+
+    if (auto it = j.find("access"); it != j.end() && !it->is_null()) {
+        it->get_to(v.access.emplace());
     }
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::allowed_device_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::resources_t::memory_t &v)
 {
-    j = nlohmann::json::object({ { "allow", v.allow } });
-    if (v.type) {
-        j["type"] = *v.type;
+    if (auto it = j.find("limit"); it != j.end() && !it->is_null()) {
+        it->get_to(v.limit.emplace());
     }
-    if (v.major) {
-        j["major"] = *v.major;
+
+    if (auto it = j.find("reservation"); it != j.end() && !it->is_null()) {
+        it->get_to(v.reservation.emplace());
     }
-    if (v.minor) {
-        j["minor"] = *v.minor;
+    if (auto it = j.find("swap"); it != j.end() && !it->is_null()) {
+        it->get_to(v.swap.emplace());
     }
-    if (v.access) {
-        j["access"] = *v.access;
+
+    if (auto it = j.find("kernel"); it != j.end() && !it->is_null()) {
+        it->get_to(v.kernel.emplace());
+    }
+
+    if (auto it = j.find("kernelTCP"); it != j.end() && !it->is_null()) {
+        it->get_to(v.kernel_tcp.emplace());
+    }
+
+    if (auto it = j.find("swappiness"); it != j.end() && !it->is_null()) {
+        it->get_to(v.swappiness.emplace());
+    }
+
+    if (auto it = j.find("disableOOMKiller"); it != j.end() && !it->is_null()) {
+        it->get_to(v.disable_OOM_killer.emplace());
+    }
+
+    if (auto it = j.find("useHierarchy"); it != j.end() && !it->is_null()) {
+        it->get_to(v.use_hierarchy.emplace());
+    }
+
+    if (auto it = j.find("checkBeforeUpdate"); it != j.end() && !it->is_null()) {
+        it->get_to(v.check_before_update.emplace());
     }
 }
 
-// --- memory_t ---
-
-void from_json(const nlohmann::json &j, config::linux_t::memory_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::resources_t::cpu_t &v)
 {
-    if (auto it = j.find("limit"); it != j.end()) {
-        v.limit = it->get<int64_t>();
+    if (auto it = j.find("shares"); it != j.end() && !it->is_null()) {
+        it->get_to(v.shares.emplace());
     }
-    if (auto it = j.find("reservation"); it != j.end()) {
-        v.reservation = it->get<int64_t>();
-    }
-    if (auto it = j.find("swap"); it != j.end()) {
-        v.swap = it->get<int64_t>();
-    }
-    if (auto it = j.find("kernel"); it != j.end()) {
-        v.kernel = it->get<int64_t>();
-    }
-    if (auto it = j.find("kernelTCP"); it != j.end()) {
-        v.kernel_tcp = it->get<int64_t>();
-    }
-    if (auto it = j.find("swappiness"); it != j.end()) {
-        v.swappiness = it->get<uint64_t>();
-    }
-    if (auto it = j.find("disableOOMKiller"); it != j.end()) {
-        v.disable_OOM_killer = it->get<bool>();
-    }
-    if (auto it = j.find("useHierarchy"); it != j.end()) {
-        v.use_hierarchy = it->get<bool>();
-    }
-    if (auto it = j.find("checkBeforeUpdate"); it != j.end()) {
-        v.check_before_update = it->get<bool>();
-    }
-}
 
-void to_json(nlohmann::json &j, const config::linux_t::memory_t &v)
-{
-    j = nlohmann::json::object();
-    if (v.limit) {
-        j["limit"] = *v.limit;
+    if (auto it = j.find("quota"); it != j.end() && !it->is_null()) {
+        it->get_to(v.quota.emplace());
     }
-    if (v.reservation) {
-        j["reservation"] = *v.reservation;
-    }
-    if (v.swap) {
-        j["swap"] = *v.swap;
-    }
-    if (v.kernel) {
-        j["kernel"] = *v.kernel;
-    }
-    if (v.kernel_tcp) {
-        j["kernelTCP"] = *v.kernel_tcp;
-    }
-    if (v.swappiness) {
-        j["swappiness"] = *v.swappiness;
-    }
-    if (v.disable_OOM_killer) {
-        j["disableOOMKiller"] = *v.disable_OOM_killer;
-    }
-    if (v.use_hierarchy) {
-        j["useHierarchy"] = *v.use_hierarchy;
-    }
-    if (v.check_before_update) {
-        j["checkBeforeUpdate"] = *v.check_before_update;
-    }
-}
 
-// --- cpu_t ---
+    if (auto it = j.find("burst"); it != j.end() && !it->is_null()) {
+        it->get_to(v.burst.emplace());
+    }
 
-void from_json(const nlohmann::json &j, config::linux_t::cpu_t &v)
-{
-    if (auto it = j.find("shares"); it != j.end()) {
-        v.shares = it->get<uint64_t>();
+    if (auto it = j.find("period"); it != j.end() && !it->is_null()) {
+        it->get_to(v.period.emplace());
     }
-    if (auto it = j.find("quota"); it != j.end()) {
-        v.quota = it->get<int64_t>();
+
+    if (auto it = j.find("realtimeRuntime"); it != j.end() && !it->is_null()) {
+        it->get_to(v.realtime_runtime.emplace());
     }
-    if (auto it = j.find("burst"); it != j.end()) {
-        v.burst = it->get<uint64_t>();
+    if (auto it = j.find("realtimePeriod"); it != j.end() && !it->is_null()) {
+        it->get_to(v.realtime_period.emplace());
     }
-    if (auto it = j.find("period"); it != j.end()) {
-        v.period = it->get<uint64_t>();
-    }
-    if (auto it = j.find("realtimeRuntime"); it != j.end()) {
-        v.realtime_runtime = it->get<int64_t>();
-    }
-    if (auto it = j.find("realtimePeriod"); it != j.end()) {
-        v.realtime_period = it->get<uint64_t>();
-    }
-    if (auto it = j.find("cpus"); it != j.end()) {
+
+    if (auto it = j.find("cpus"); it != j.end() && !it->is_null()) {
         v.cpus = parse_range_list(it->get_ref<const std::string &>());
     }
-    if (auto it = j.find("mems"); it != j.end()) {
-        v.mems = it->get<std::string>();
+
+    if (auto it = j.find("mems"); it != j.end() && !it->is_null()) {
+        v.mems = parse_range_list(it->get_ref<const std::string &>());
     }
-    if (auto it = j.find("idle"); it != j.end()) {
+
+    if (auto it = j.find("idle"); it != j.end() && !it->is_null()) {
+        // TODO: move this logic to converter?
         auto val = it->get<int64_t>();
-        v.idle =
-          (val == 1) ? config::linux_t::cpu_t::idle_t::IDLE : config::linux_t::cpu_t::idle_t::NONE;
+        v.idle.emplace((val == 1) ? Config::linux_t::resources_t::cpu_t::idle_t::IDLE
+                                  : Config::linux_t::resources_t::cpu_t::idle_t::NONE);
     }
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::cpu_t &v)
-{
-    j = nlohmann::json::object();
-    if (v.shares) {
-        j["shares"] = *v.shares;
-    }
-    if (v.quota) {
-        j["quota"] = *v.quota;
-    }
-    if (v.burst) {
-        j["burst"] = *v.burst;
-    }
-    if (v.period) {
-        j["period"] = *v.period;
-    }
-    if (v.realtime_runtime) {
-        j["realtimeRuntime"] = *v.realtime_runtime;
-    }
-    if (v.realtime_period) {
-        j["realtimePeriod"] = *v.realtime_period;
-    }
-    if (v.cpus) {
-        j["cpus"] = format_range_list(*v.cpus);
-    }
-    if (v.mems) {
-        j["mems"] = *v.mems;
-    }
-    if (v.idle) {
-        j["idle"] = (*v.idle == config::linux_t::cpu_t::idle_t::IDLE) ? 1 : 0;
-    }
-}
-
-// --- block_io_t ---
-
-void from_json(const nlohmann::json &j, config::linux_t::block_io_t::weight_device_t &v)
+void from_json(const nlohmann::json &j,
+               Config::linux_t::resources_t::block_io_t::weight_device_t &v)
 {
     j.at("major").get_to(v.major);
     j.at("minor").get_to(v.minor);
-    if (auto it = j.find("weight"); it != j.end()) {
-        v.weight = it->get<uint16_t>();
+
+    if (auto it = j.find("weight"); it != j.end() && !it->is_null()) {
+        it->get_to(v.weight.emplace());
     }
-    if (auto it = j.find("leafWeight"); it != j.end()) {
-        v.leaf_weight = it->get<uint16_t>();
+
+    if (auto it = j.find("leafWeight"); it != j.end() && !it->is_null()) {
+        it->get_to(v.leaf_weight.emplace());
     }
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::block_io_t::weight_device_t &v)
-{
-    j = nlohmann::json::object({ { "major", v.major }, { "minor", v.minor } });
-    if (v.weight) {
-        j["weight"] = *v.weight;
-    }
-    if (v.leaf_weight) {
-        j["leafWeight"] = *v.leaf_weight;
-    }
-}
-
-void from_json(const nlohmann::json &j, config::linux_t::block_io_t::throttle_device_t &v)
+void from_json(const nlohmann::json &j,
+               Config::linux_t::resources_t::block_io_t::throttle_device_t &v)
 {
     j.at("major").get_to(v.major);
     j.at("minor").get_to(v.minor);
     j.at("rate").get_to(v.rate);
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::block_io_t::throttle_device_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::resources_t::block_io_t &v)
 {
-    j = nlohmann::json::object({ { "major", v.major }, { "minor", v.minor }, { "rate", v.rate } });
-}
+    if (auto it = j.find("weight"); it != j.end() && !it->is_null()) {
+        it->get_to(v.weight.emplace());
+    }
 
-void from_json(const nlohmann::json &j, config::linux_t::block_io_t &v)
-{
-    if (auto it = j.find("weight"); it != j.end()) {
-        v.weight = it->get<uint16_t>();
+    if (auto it = j.find("leafWeight"); it != j.end() && !it->is_null()) {
+        it->get_to(v.leaf_weight.emplace());
     }
-    if (auto it = j.find("leafWeight"); it != j.end()) {
-        v.leaf_weight = it->get<uint16_t>();
+
+    if (auto it = j.find("weightDevice"); it != j.end() && !it->is_null()) {
+        it->get_to(v.weight_devices.emplace());
     }
-    if (auto it = j.find("weightDevice"); it != j.end()) {
-        v.weight_devices = it->get<std::vector<config::linux_t::block_io_t::weight_device_t>>();
+
+    if (auto it = j.find("throttleReadBpsDevice"); it != j.end() && !it->is_null()) {
+        it->get_to(v.throttle_read_bps_device.emplace());
     }
-    if (auto it = j.find("throttleReadBpsDevice"); it != j.end()) {
-        v.throttle_read_bps_device =
-          it->get<std::vector<config::linux_t::block_io_t::throttle_device_t>>();
+
+    if (auto it = j.find("throttleWriteBpsDevice"); it != j.end() && !it->is_null()) {
+        it->get_to(v.throttle_write_bps_device.emplace());
     }
-    if (auto it = j.find("throttleWriteBpsDevice"); it != j.end()) {
-        v.throttle_write_bps_device =
-          it->get<std::vector<config::linux_t::block_io_t::throttle_device_t>>();
+
+    if (auto it = j.find("throttleReadIOPSDevice"); it != j.end() && !it->is_null()) {
+        it->get_to(v.throttle_read_iops_device.emplace());
     }
-    if (auto it = j.find("throttleReadIOPSDevice"); it != j.end()) {
-        v.throttle_read_iops_device =
-          it->get<std::vector<config::linux_t::block_io_t::throttle_device_t>>();
-    }
-    if (auto it = j.find("throttleWriteIOPSDevice"); it != j.end()) {
-        v.throttle_write_iops_device =
-          it->get<std::vector<config::linux_t::block_io_t::throttle_device_t>>();
+
+    if (auto it = j.find("throttleWriteIOPSDevice"); it != j.end() && !it->is_null()) {
+        it->get_to(v.throttle_write_iops_device.emplace());
     }
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::block_io_t &v)
-{
-    j = nlohmann::json::object();
-    if (v.weight) {
-        j["weight"] = *v.weight;
-    }
-    if (v.leaf_weight) {
-        j["leafWeight"] = *v.leaf_weight;
-    }
-    if (v.weight_devices) {
-        j["weightDevice"] = *v.weight_devices;
-    }
-    if (v.throttle_read_bps_device) {
-        j["throttleReadBpsDevice"] = *v.throttle_read_bps_device;
-    }
-    if (v.throttle_write_bps_device) {
-        j["throttleWriteBpsDevice"] = *v.throttle_write_bps_device;
-    }
-    if (v.throttle_read_iops_device) {
-        j["throttleReadIOPSDevice"] = *v.throttle_read_iops_device;
-    }
-    if (v.throttle_write_iops_device) {
-        j["throttleWriteIOPSDevice"] = *v.throttle_write_iops_device;
-    }
-}
-
-// --- hugepage_limit_t ---
-
-void from_json(const nlohmann::json &j, config::linux_t::hugepage_limit_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::resources_t::hugepage_limit_t &v)
 {
     j.at("pageSize").get_to(v.page_size);
     j.at("limit").get_to(v.limit);
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::hugepage_limit_t &v)
-{
-    j = nlohmann::json::object({ { "pageSize", v.page_size }, { "limit", v.limit } });
-}
-
-// --- network_t::priority_t ---
-
-void from_json(const nlohmann::json &j, config::linux_t::network_t::priority_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::resources_t::network_t::priority_t &v)
 {
     j.at("name").get_to(v.name);
     j.at("priority").get_to(v.priority);
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::network_t::priority_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::resources_t::network_t &v)
 {
-    j = nlohmann::json::object({ { "name", v.name }, { "priority", v.priority } });
-}
-
-// --- network_t ---
-
-void from_json(const nlohmann::json &j, config::linux_t::network_t &v)
-{
-    if (auto it = j.find("classID"); it != j.end()) {
-        v.class_id = it->get<uint32_t>();
+    if (auto it = j.find("classID"); it != j.end() && !it->is_null()) {
+        it->get_to(v.class_id.emplace());
     }
-    if (auto it = j.find("priorities"); it != j.end()) {
-        v.priorities = it->get<std::vector<config::linux_t::network_t::priority_t>>();
+
+    if (auto it = j.find("priorities"); it != j.end() && !it->is_null()) {
+        it->get_to(v.priorities.emplace());
     }
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::network_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::resources_t::pids_t &v)
 {
-    j = nlohmann::json::object();
-    if (v.class_id) {
-        j["classID"] = *v.class_id;
-    }
-    if (v.priorities) {
-        j["priorities"] = *v.priorities;
+    if (auto it = j.find("limit"); it != j.end() && !it->is_null()) {
+        it->get_to(v.limit.emplace());
     }
 }
 
-// --- pids_t ---
-
-void from_json(const nlohmann::json &j, config::linux_t::pids_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::resources_t::rdma_t &v)
 {
-    if (auto it = j.find("limit"); it != j.end()) {
-        v.limit = it->get<int64_t>();
+    if (auto it = j.find("hcaHandles"); it != j.end() && !it->is_null()) {
+        it->get_to(v.hca_handles.emplace());
+    }
+
+    if (auto it = j.find("hcaObjects"); it != j.end() && !it->is_null()) {
+        it->get_to(v.hca_objects.emplace());
     }
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::pids_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::intel_rdt_t &v)
 {
-    j = nlohmann::json::object();
-    if (v.limit) {
-        j["limit"] = *v.limit;
+    if (auto it = j.find("closID"); it != j.end() && !it->is_null()) {
+        it->get_to(v.clos_id.emplace());
+    }
+
+    if (auto it = j.find("l3CacheSchema"); it != j.end() && !it->is_null()) {
+        it->get_to(v.l3_cache_schema.emplace());
+    }
+
+    if (auto it = j.find("memBwSchema"); it != j.end() && !it->is_null()) {
+        it->get_to(v.memory_bandwidth_schema.emplace());
+    }
+
+    if (auto it = j.find("schemata"); it != j.end() && !it->is_null()) {
+        it->get_to(v.schemata.emplace());
+    }
+
+    if (auto it = j.find("enableMonitoring"); it != j.end() && !it->is_null()) {
+        it->get_to(v.enable_monitoring.emplace());
     }
 }
 
-// --- rdma_t ---
-
-void from_json(const nlohmann::json &j, config::linux_t::rdma_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::resources_t &v)
 {
-    if (auto it = j.find("hcaHandles"); it != j.end()) {
-        v.hca_handles = it->get<uint32_t>();
+    if (auto it = j.find("unified"); it != j.end() && !it->is_null()) {
+        it->get_to(v.unified.emplace());
     }
-    if (auto it = j.find("hcaObjects"); it != j.end()) {
-        v.hca_objects = it->get<uint32_t>();
+
+    if (auto it = j.find("devices"); it != j.end() && !it->is_null()) {
+        it->get_to(v.devices.emplace());
+    }
+
+    if (auto it = j.find("pids"); it != j.end() && !it->is_null()) {
+        it->get_to(v.pids.emplace());
+    }
+
+    if (auto it = j.find("memory"); it != j.end() && !it->is_null()) {
+        it->get_to(v.memory.emplace());
+    }
+
+    if (auto it = j.find("cpu"); it != j.end() && !it->is_null()) {
+        it->get_to(v.cpu.emplace());
+    }
+
+    if (auto it = j.find("hugepageLimits"); it != j.end() && !it->is_null()) {
+        it->get_to(v.hugepage_limits.emplace());
+    }
+
+    if (auto it = j.find("blockIO"); it != j.end() && !it->is_null()) {
+        it->get_to(v.block_io.emplace());
+    }
+
+    if (auto it = j.find("network"); it != j.end() && !it->is_null()) {
+        it->get_to(v.network.emplace());
+    }
+
+    if (auto it = j.find("rdma"); it != j.end() && !it->is_null()) {
+        it->get_to(v.rdma.emplace());
     }
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::rdma_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::memory_policy_t &v)
 {
-    j = nlohmann::json::object();
-    if (v.hca_handles) {
-        j["hcaHandles"] = *v.hca_handles;
+    auto mode_name = j.at("mode").get<std::string_view>();
+    auto mode_opt = memory_policy_mode_table.from_name(mode_name);
+    if (UNLIKELY(!mode_opt)) {
+        throw std::runtime_error("unknown value: " + std::string(mode_name));
     }
-    if (v.hca_objects) {
-        j["hcaObjects"] = *v.hca_objects;
-    }
-}
+    v.mode = *mode_opt;
 
-// --- intel_rdt_t ---
-
-void from_json(const nlohmann::json &j, config::linux_t::intel_rdt_t &v)
-{
-    if (auto it = j.find("closID"); it != j.end()) {
-        v.clos_id = it->get<std::string>();
-    }
-    if (auto it = j.find("l3CacheSchema"); it != j.end()) {
-        v.l3_cache_schema = it->get<std::string>();
-    }
-    if (auto it = j.find("memBwSchema"); it != j.end()) {
-        v.memory_bandwidth_schema = it->get<std::string>();
-    }
-    if (auto it = j.find("schemata"); it != j.end()) {
-        v.schemata = it->get<std::vector<std::string>>();
-    }
-    if (auto it = j.find("enableMonitoring"); it != j.end()) {
-        v.enable_monitoring = it->get<bool>();
-    }
-}
-
-void to_json(nlohmann::json &j, const config::linux_t::intel_rdt_t &v)
-{
-    j = nlohmann::json::object();
-    if (v.clos_id) {
-        j["closID"] = *v.clos_id;
-    }
-    if (v.l3_cache_schema) {
-        j["l3CacheSchema"] = *v.l3_cache_schema;
-    }
-    if (v.memory_bandwidth_schema) {
-        j["memBwSchema"] = *v.memory_bandwidth_schema;
-    }
-    if (v.schemata) {
-        j["schemata"] = *v.schemata;
-    }
-    if (v.enable_monitoring) {
-        j["enableMonitoring"] = *v.enable_monitoring;
-    }
-}
-
-// --- memory_policy_t ---
-
-void from_json(const nlohmann::json &j, config::linux_t::memory_policy_t &v)
-{
-    auto mode_str = j.at("mode").get_ref<const std::string &>();
-    auto *val = find_in_sorted(memory_policy_mode_map, mode_str);
-    if (!val) {
-        throw std::runtime_error("unknown memory policy mode: " + mode_str);
-    }
-    v.mode = *val;
-
-    if (auto nodes_it = j.find("nodes"); nodes_it != j.end()) {
-        auto nodes_str = nodes_it->get_ref<const std::string &>();
-        auto parsed = parse_range_list(nodes_str);
-        v.nodes = std::vector<int>(parsed.begin(), parsed.end());
+    if (auto nodes_it = j.find("nodes"); nodes_it != j.end() && !nodes_it->is_null()) {
+        v.nodes = parse_range_list(nodes_it->get<std::string_view>());
     }
 
-    if (auto flags_it = j.find("flags"); flags_it != j.end()) {
-        uint16_t combined = 0;
+    if (auto flags_it = j.find("flags"); flags_it != j.end() && !flags_it->is_null()) {
+        Config::linux_t::memory_policy_t::flag_t flags{ };
         for (const auto &f : *flags_it) {
-            auto flag_str = f.get_ref<const std::string &>();
-            for (const auto &[val, name] : memory_policy_flags_to_names) {
-                if (name == flag_str) {
-                    combined |= val;
-                    break;
-                }
+            const auto &flag_str = f.get_ref<const std::string &>();
+            auto flag_opt = memory_policy_flag_table.from_name(flag_str);
+            if (UNLIKELY(!flag_opt)) {
+                throw std::runtime_error("unknown value: " + std::string(flag_str));
             }
+            flags = flags | *flag_opt;
         }
-        v.flags = static_cast<config::linux_t::memory_policy_t::flag_t>(combined);
+
+        v.flags = flags;
     }
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::memory_policy_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::personality_t &v)
 {
-    std::string_view mode_str;
-    for (const auto &[val, name] : memory_policy_mode_to_string) {
-        if (val == v.mode) {
-            mode_str = name;
-            break;
-        }
+    auto domain_name = j.at("domain").get<std::string_view>();
+    auto domain_opt = personality_domain_table.from_name(domain_name);
+    if (UNLIKELY(!domain_opt)) {
+        throw std::runtime_error("unknown value: " + std::string(domain_name));
     }
-    if (mode_str.empty()) {
-        throw std::runtime_error("unknown memory policy mode value");
-    }
+    v.domain = *domain_opt;
 
-    j = nlohmann::json::object({ { "mode", mode_str } });
-
-    if (v.nodes) {
-        std::vector<unsigned int> unsigned_nodes(v.nodes->begin(), v.nodes->end());
-        j["nodes"] = format_range_list(unsigned_nodes);
-    }
-    if (v.flags) {
-        auto raw = static_cast<uint16_t>(*v.flags);
-        nlohmann::json::array_t flag_arr;
-        for (const auto &[val, name] : memory_policy_flags_to_names) {
-            if ((raw & val) == val) {
-                flag_arr.push_back(std::string(name));
-            }
-        }
-        j["flags"] = std::move(flag_arr);
+    if (auto flags_it = j.find("flags"); flags_it != j.end() && !flags_it->is_null()) {
+        flags_it->get_to(v.flags.emplace());
     }
 }
-
-// --- personality_t ---
-
-void from_json(const nlohmann::json &j, config::linux_t::personality_t &v)
-{
-    auto domain_str = j.at("domain").get_ref<const std::string &>();
-    auto *val = find_in_sorted(personality_domain_map, domain_str);
-    if (!val) {
-        throw std::runtime_error("unknown personality domain: " + domain_str);
-    }
-    v.domain = *val;
-
-    if (auto flags_it = j.find("flags"); flags_it != j.end()) {
-        v.flags = flags_it->get<std::vector<std::string>>();
-    }
-}
-
-void to_json(nlohmann::json &j, const config::linux_t::personality_t &v)
-{
-    std::string_view domain_str;
-    for (const auto &[val, name] : personality_domain_to_string) {
-        if (val == v.domain) {
-            domain_str = name;
-            break;
-        }
-    }
-    if (domain_str.empty()) {
-        throw std::runtime_error("unknown personality domain value");
-    }
-
-    j = nlohmann::json::object({ { "domain", domain_str } });
-    if (v.flags) {
-        j["flags"] = *v.flags;
-    }
-}
-
-// --- seccomp_t ---
 
 #ifdef LINYAPS_BOX_ENABLE_SECCOMP
-void from_json(const nlohmann::json &j, config::linux_t::seccomp_t::syscall_t::arg_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::seccomp_t::syscall_t::arg_t &v)
 {
     j.at("index").get_to(v.index);
     j.at("value").get_to(v.value);
-    v.value_two = j.value("valueTwo", uint64_t{ 0 });
 
-    auto op_str = j.at("op").get_ref<const std::string &>();
-    auto *val = find_in_sorted(seccomp_op_map, op_str);
-    if (!val) {
-        throw std::runtime_error("unknown seccomp op: " + op_str);
+    if (auto value_two_it = j.find("valueTwo");
+        value_two_it != j.end() && !value_two_it->is_null()) {
+        value_two_it->get_to(v.value_two.emplace());
     }
-    v.op = *val;
+
+    auto op_name = j.at("op").get<std::string_view>();
+    auto op_opt = seccomp_op_table.from_name(op_name);
+    if (UNLIKELY(!op_opt)) {
+        throw std::runtime_error("unknown value: " + std::string(op_name));
+    }
+    v.op = *op_opt;
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::seccomp_t::syscall_t::arg_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::seccomp_t::syscall_t &v)
 {
-    std::string_view op_str;
-    for (const auto &[val, name] : seccomp_op_to_string) {
-        if (val == v.op) {
-            op_str = name;
-            break;
+    j.at("names").get_to(v.names);
+    if (UNLIKELY(v.names.empty())) {
+        throw std::runtime_error("seccomp syscall names must not be empty");
+    }
+
+    using action_t = Config::linux_t::seccomp_t::action_t;
+    {
+        auto action_name = j.at("action").get<std::string_view>();
+        auto action_opt = seccomp_action_table.from_name(action_name);
+        if (UNLIKELY(!action_opt)) {
+            throw std::runtime_error("unknown value: " + std::string(action_name));
+        }
+        v.action = *action_opt;
+    }
+
+    if (auto it = j.find("errnoRet"); it != j.end() && !it->is_null()) {
+        it->get_to(v.errno_ret.emplace());
+        if (UNLIKELY(v.action != action_t::ERRNO && v.action != action_t::TRACE)) {
+            throw std::runtime_error(
+              "seccomp syscall errnoRet is only valid with SCMP_ACT_ERRNO or SCMP_ACT_TRACE");
         }
     }
-    if (op_str.empty()) {
-        throw std::runtime_error("unknown seccomp op value");
-    }
 
-    j = nlohmann::json::object({ { "index", v.index }, { "value", v.value }, { "op", op_str } });
-    if (v.value_two != 0) {
-        j["valueTwo"] = v.value_two;
+    if (auto it = j.find("args"); it != j.end() && !it->is_null()) {
+        it->get_to(v.args.emplace());
     }
 }
 
-void from_json(const nlohmann::json &j, config::linux_t::seccomp_t::syscall_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t::seccomp_t &v)
 {
-    j.at("names").get_to(v.name);
-    j.at("action").get_to(v.action);
+    using action_t = Config::linux_t::seccomp_t::action_t;
+    {
+        auto action_name = j.at("defaultAction").get<std::string_view>();
+        auto action_opt = seccomp_action_table.from_name(action_name);
+        if (UNLIKELY(!action_opt)) {
+            throw std::runtime_error("unknown value: " + std::string(action_name));
+        }
+        v.default_action = *action_opt;
+    }
 
-    if (auto it = j.find("errnoRet"); it != j.end()) {
-        v.errno_ret = it->get<uint>();
+    if (auto it = j.find("defaultErrnoRet"); it != j.end() && !it->is_null()) {
+        it->get_to(v.default_errno_ret.emplace());
     }
-    if (auto it = j.find("args"); it != j.end()) {
-        v.args = it->get<std::vector<config::linux_t::seccomp_t::syscall_t::arg_t>>();
-    }
-}
 
-void to_json(nlohmann::json &j, const config::linux_t::seccomp_t::syscall_t &v)
-{
-    j = nlohmann::json::object({ { "names", v.name }, { "action", v.action } });
-    if (v.errno_ret) {
-        j["errnoRet"] = *v.errno_ret;
+    if (UNLIKELY(v.default_errno_ret && v.default_action != action_t::ERRNO
+                 && v.default_action != action_t::TRACE)) {
+        throw std::runtime_error(
+          "seccomp defaultErrnoRet is only valid with SCMP_ACT_ERRNO or SCMP_ACT_TRACE");
     }
-    if (v.args) {
-        j["args"] = *v.args;
-    }
-}
 
-void from_json(const nlohmann::json &j, config::linux_t::seccomp_t &v)
-{
-    j.at("defaultAction").get_to(v.default_action);
-
-    if (auto it = j.find("defaultErrnoRet"); it != j.end()) {
-        v.default_errno_ret = it->get<uint>();
-    }
-    if (auto it = j.find("architectures"); it != j.end()) {
-        std::vector<config::linux_t::seccomp_t::arch_t> archs;
+    if (auto it = j.find("architectures"); it != j.end() && !it->is_null()) {
+        std::vector<Config::linux_t::seccomp_t::arch_t> archs;
         archs.reserve(it->size());
         for (const auto &elem : *it) {
-            auto arch_str = elem.get_ref<const std::string &>();
-            auto *arch_val = find_in_sorted(seccomp_arch_map, arch_str);
-            if (!arch_val) {
-                throw std::runtime_error("unknown seccomp arch: " + arch_str);
+            auto arch_str = elem.get<std::string_view>();
+            auto arch_opt = seccomp_arch_table.from_name(arch_str);
+            if (UNLIKELY(!arch_opt)) {
+                throw std::runtime_error("unknown architecture: " + std::string(arch_str));
             }
-            archs.push_back(*arch_val);
+            archs.push_back(*arch_opt);
         }
+
         v.architectures = std::move(archs);
     }
-    if (auto it = j.find("flags"); it != j.end()) {
-        std::underlying_type_t<config::linux_t::seccomp_t::flag_t> combined = 0;
+
+    if (auto it = j.find("flags"); it != j.end() && !it->is_null()) {
+        Config::linux_t::seccomp_t::flag_t flags{ };
         for (const auto &elem : *it) {
-            auto flag_str = elem.get_ref<const std::string &>();
-            auto *flag_val = find_in_sorted(seccomp_flag_map, flag_str);
-            if (flag_val) {
-                combined |= static_cast<std::underlying_type_t<config::linux_t::seccomp_t::flag_t>>(
-                  *flag_val);
+            auto flag_str = elem.get<std::string_view>();
+            auto flag_opt = seccomp_flag_table.from_name(flag_str);
+            if (UNLIKELY(!flag_opt)) {
+                throw std::runtime_error("unknown value: " + std::string(flag_str));
             }
+
+            flags = flags | *flag_opt;
         }
-        v.flags = static_cast<config::linux_t::seccomp_t::flag_t>(combined);
+
+        v.flags = flags;
     }
-    if (auto it = j.find("listenerPath"); it != j.end()) {
-        v.listener_path = it->get<std::filesystem::path>();
+
+    if (auto it = j.find("listenerPath"); it != j.end() && !it->is_null()) {
+        it->get_to(v.listener_path.emplace());
     }
-    if (auto it = j.find("listenerMetadata"); it != j.end()) {
-        v.listener_metadata = it->get<std::string>();
+
+    if (auto it = j.find("listenerMetadata"); it != j.end() && !it->is_null()) {
+        it->get_to(v.listener_metadata.emplace());
     }
-    if (auto it = j.find("syscalls"); it != j.end()) {
-        v.syscalls = it->get<std::vector<config::linux_t::seccomp_t::syscall_t>>();
+
+    if (UNLIKELY(v.default_action == action_t::NOTIFY && !v.listener_path)) {
+        throw std::runtime_error("seccomp SCMP_ACT_NOTIFY requires listenerPath");
+    }
+
+    if (auto it = j.find("syscalls"); it != j.end() && !it->is_null()) {
+        it->get_to(v.syscalls.emplace());
+    }
+
+    if (UNLIKELY(v.listener_metadata && !v.listener_path)) {
+        throw std::runtime_error("seccomp listenerMetadata requires listenerPath to be set");
     }
 }
 
-void to_json(nlohmann::json &j, const config::linux_t::seccomp_t &v)
-{
-    j = nlohmann::json::object({ { "defaultAction", v.default_action } });
-
-    if (v.default_errno_ret) {
-        j["defaultErrnoRet"] = *v.default_errno_ret;
-    }
-    if (v.architectures) {
-        nlohmann::json::array_t arch_arr;
-        arch_arr.reserve(v.architectures->size());
-        for (auto arch : *v.architectures) {
-            std::string_view arch_str;
-            for (const auto &[av, an] : seccomp_arch_to_string) {
-                if (av == arch) {
-                    arch_str = an;
-                    break;
-                }
-            }
-            if (arch_str.empty()) {
-                throw std::runtime_error("unknown seccomp arch value");
-            }
-            arch_arr.push_back(std::string(arch_str));
-        }
-        j["architectures"] = std::move(arch_arr);
-    }
-    if (v.flags) {
-        nlohmann::json::array_t flag_arr;
-        auto raw =
-          static_cast<std::underlying_type_t<config::linux_t::seccomp_t::flag_t>>(*v.flags);
-        for (const auto &[fv, fname] : seccomp_flag_to_string) {
-            if (raw & static_cast<std::underlying_type_t<config::linux_t::seccomp_t::flag_t>>(fv)) {
-                flag_arr.push_back(std::string(fname));
-            }
-        }
-        j["flags"] = std::move(flag_arr);
-    }
-    if (v.listener_path) {
-        j["listenerPath"] = v.listener_path->string();
-    }
-    if (v.listener_metadata) {
-        j["listenerMetadata"] = *v.listener_metadata;
-    }
-    if (v.syscalls) {
-        j["syscalls"] = *v.syscalls;
-    }
-}
 #endif
-// --- linux_t ---
 
-void from_json(const nlohmann::json &j, config::linux_t &v)
+void from_json(const nlohmann::json &j, Config::linux_t &v)
 {
-    if (auto it = j.find("uidMappings"); it != j.end()) {
-        v.uid_mappings = it->get<std::vector<config::linux_t::id_mapping_t>>();
+    if (auto it = j.find("uidMappings"); it != j.end() && !it->is_null()) {
+        it->get_to(v.uid_mappings.emplace());
     }
 
-    if (auto it = j.find("gidMappings"); it != j.end()) {
-        v.gid_mappings = it->get<std::vector<config::linux_t::id_mapping_t>>();
+    if (auto it = j.find("gidMappings"); it != j.end() && !it->is_null()) {
+        it->get_to(v.gid_mappings.emplace());
     }
 
-    if (auto it = j.find("namespaces"); it != j.end()) {
-        v.namespaces = it->get<std::vector<config::linux_t::namespace_t>>();
+    if (auto it = j.find("namespaces"); it != j.end() && !it->is_null()) {
+        it->get_to(v.namespaces.emplace());
 
-        auto seen{ config::linux_t::namespace_t::type::NONE };
+        auto seen{ 0U };
         for (const auto &ns : *v.namespaces) {
-            if ((seen & ns.type_) != config::linux_t::namespace_t::type::NONE) {
-                throw std::runtime_error(std::string(to_string_view(ns.type_))
-                                         + ": duplicate namespace type");
+            // no need to use std::bitset
+            auto val = static_cast<unsigned int>(ns.type_);
+            if (UNLIKELY((seen & val) != 0)) {
+                throw std::runtime_error(
+                  std::string{ namespace_type_table.to_name(ns.type_).value_or("unknown") }
+                  + ": duplicate namespace type");
             }
 
-            seen = seen | ns.type_;
+            seen |= val;
         }
     }
 
-    if (auto it = j.find("devices"); it != j.end()) {
-        v.devices = it->get<std::vector<config::linux_t::device_t>>();
+    if (auto it = j.find("devices"); it != j.end() && !it->is_null()) {
+        it->get_to(v.devices.emplace());
     }
 
-    if (auto it = j.find("netDevices"); it != j.end()) {
-        v.network_devices = it->get<std::vector<config::linux_t::network_device_t>>();
+    if (auto it = j.find("netDevices"); it != j.end() && !it->is_null()) {
+        it->get_to(v.network_devices.emplace());
     }
 
-    if (auto it = j.find("cgroupsPath"); it != j.end()) {
-        v.cgroups_path = it->get<std::string>();
+    if (auto it = j.find("cgroupsPath"); it != j.end() && !it->is_null()) {
+        it->get_to(v.cgroups_path.emplace());
     }
 
-    if (auto it = j.find("maskedPaths"); it != j.end()) {
-        v.masked_paths = it->get<std::vector<std::filesystem::path>>();
+    if (auto it = j.find("maskedPaths"); it != j.end() && !it->is_null()) {
+        it->get_to(v.masked_paths.emplace());
     }
 
-    if (auto it = j.find("readonlyPaths"); it != j.end()) {
-        v.readonly_paths = it->get<std::vector<std::filesystem::path>>();
+    if (auto it = j.find("readonlyPaths"); it != j.end() && !it->is_null()) {
+        it->get_to(v.readonly_paths.emplace());
     }
 
-    if (auto it = j.find("mountLabel"); it != j.end()) {
-        v.mount_label = it->get<std::string>();
+    if (auto it = j.find("mountLabel"); it != j.end() && !it->is_null()) {
+        it->get_to(v.mount_label.emplace());
     }
 
-    if (auto it = j.find("rootfsPropagation"); it != j.end()) {
-        auto val = it->get_ref<const std::string &>();
-        auto *prop_val = find_in_sorted(rootfs_propagation_map, val);
-        if (!prop_val) {
-            throw std::runtime_error("unsupported rootfs propagation: " + val);
-        }
-        v.rootfs_propagation = static_cast<config::linux_t::rootfs_propagation_t>(*prop_val);
-    }
+    if (auto it = j.find("rootfsPropagation"); it != j.end() && !it->is_null()) {
+        auto prop_name = it->get<std::string_view>();
 
-    if (auto it = j.find("sysctl"); it != j.end()) {
-        v.sysctl = it->get<std::unordered_map<std::string, std::string>>();
-    }
+        struct
+        {
+            const char *name;
+            unsigned long value;
+        } const table[]{
+            { "private", MS_PRIVATE },       { "rprivate", MS_PRIVATE | MS_REC },
+            { "shared", MS_SHARED },         { "rshared", MS_SHARED | MS_REC },
+            { "slave", MS_SLAVE },           { "rslave", MS_SLAVE | MS_REC },
+            { "unbindable", MS_UNBINDABLE }, { "runbindable", MS_UNBINDABLE | MS_REC },
+        };
 
-    if (auto it = j.find("timeOffsets"); it != j.end()) {
-        std::unordered_map<std::string, config::linux_t::time_offset_t> offsets;
-        for (auto &[clock_name, offset_json] : it->items()) {
-            offsets[clock_name] = offset_json.get<config::linux_t::time_offset_t>();
-        }
-        v.time_offsets = std::move(offsets);
-    }
-
-    if (auto it = j.find("personality"); it != j.end()) {
-        v.personality = it->get<config::linux_t::personality_t>();
-    }
-
-    if (auto it = j.find("memoryPolicy"); it != j.end()) {
-        v.memory_policy = it->get<config::linux_t::memory_policy_t>();
-    }
-
-    if (auto it = j.find("intelRdt"); it != j.end()) {
-        v.intel_rdt = it->get<config::linux_t::intel_rdt_t>();
-    }
-
-    // Resources sub-object
-    if (auto res_it = j.find("resources"); res_it != j.end()) {
-        const auto &r = *res_it;
-
-        if (auto it = r.find("unified"); it != r.end()) {
-            v.unified = it->get<std::unordered_map<std::string, std::string>>();
-        }
-        if (auto it = r.find("devices"); it != r.end()) {
-            v.allowed_devices = it->get<std::vector<config::linux_t::allowed_device_t>>();
-        }
-        if (auto it = r.find("pids"); it != r.end()) {
-            v.pids = it->get<config::linux_t::pids_t>();
-        }
-        if (auto it = r.find("memory"); it != r.end()) {
-            v.memory = it->get<config::linux_t::memory_t>();
-        }
-        if (auto it = r.find("cpu"); it != r.end()) {
-            v.cpu = it->get<config::linux_t::cpu_t>();
-        }
-        if (auto it = r.find("hugepageLimits"); it != r.end()) {
-            v.hugepage_limits = it->get<std::vector<config::linux_t::hugepage_limit_t>>();
-        }
-        if (auto it = r.find("blockIO"); it != r.end()) {
-            v.block_io = it->get<config::linux_t::block_io_t>();
-        }
-        if (auto it = r.find("network"); it != r.end()) {
-            v.network = it->get<config::linux_t::network_t>();
-        }
-        if (auto it = r.find("rdma"); it != r.end()) {
-            v.rdma = it->get<std::unordered_map<std::string, config::linux_t::rdma_t>>();
-        }
-    }
-
-#ifdef LINYAPS_BOX_ENABLE_SECCOMP
-    if (auto it = j.find("seccomp"); it != j.end()) {
-        v.seccomp = it->get<config::linux_t::seccomp_t>();
-    }
-#endif
-}
-
-void to_json(nlohmann::json &j, const config::linux_t &v)
-{
-    j = nlohmann::json::object();
-
-    if (v.uid_mappings) {
-        j["uidMappings"] = *v.uid_mappings;
-    }
-    if (v.gid_mappings) {
-        j["gidMappings"] = *v.gid_mappings;
-    }
-    if (v.namespaces) {
-        j["namespaces"] = *v.namespaces;
-    }
-    if (v.devices) {
-        j["devices"] = *v.devices;
-    }
-    if (v.network_devices) {
-        j["netDevices"] = *v.network_devices;
-    }
-    if (v.cgroups_path) {
-        j["cgroupsPath"] = *v.cgroups_path;
-    }
-    if (v.masked_paths) {
-        j["maskedPaths"] = *v.masked_paths;
-    }
-    if (v.readonly_paths) {
-        j["readonlyPaths"] = *v.readonly_paths;
-    }
-    if (v.mount_label) {
-        j["mountLabel"] = *v.mount_label;
-    }
-    if (v.rootfs_propagation) {
-        auto raw = static_cast<unsigned int>(*v.rootfs_propagation);
-        for (const auto &[val, name] : rootfs_propagation_to_string) {
-            if (val == raw) {
-                j["rootfsPropagation"] = name;
+        bool found = false;
+        for (const auto &entry : table) {
+            if (prop_name == entry.name) {
+                v.rootfs_propagation = entry.value;
+                found = true;
                 break;
             }
         }
-    }
-    if (v.sysctl) {
-        j["sysctl"] = *v.sysctl;
-    }
-    if (v.time_offsets) {
-        nlohmann::json offsets_obj = nlohmann::json::object();
-        for (const auto &[clock, offset] : *v.time_offsets) {
-            offsets_obj[clock] = offset;
+
+        if (UNLIKELY(!found)) {
+            throw std::runtime_error("unknown value: " + std::string(prop_name));
         }
-        j["timeOffsets"] = std::move(offsets_obj);
+    } else {
+        v.rootfs_propagation = MS_PRIVATE | MS_REC;
     }
-    if (v.personality) {
-        j["personality"] = *v.personality;
+
+    if (auto it = j.find("sysctl"); it != j.end() && !it->is_null()) {
+        it->get_to(v.sysctl.emplace());
     }
-    if (v.memory_policy) {
-        j["memoryPolicy"] = *v.memory_policy;
+
+    if (auto it = j.find("timeOffsets"); it != j.end() && !it->is_null()) {
+        auto &offsets = v.time_offsets.emplace();
+        for (const auto &[clock_name, offset_json] : it->items()) {
+            auto [it, ignored] =
+              offsets.try_emplace(clock_name, offset_json.get<Config::linux_t::time_offset_t>());
+            if (UNLIKELY(!ignored)) {
+                throw std::runtime_error("duplicated timeOffset :" + offset_json.dump());
+            }
+        }
     }
-    if (v.intel_rdt) {
-        j["intelRdt"] = *v.intel_rdt;
+
+    if (auto it = j.find("personality"); it != j.end() && !it->is_null()) {
+        it->get_to(v.personality.emplace());
     }
+
+    if (auto it = j.find("memoryPolicy"); it != j.end() && !it->is_null()) {
+        it->get_to(v.memory_policy.emplace());
+    }
+
+    if (auto it = j.find("intelRdt"); it != j.end() && !it->is_null()) {
+        it->get_to(v.intel_rdt.emplace());
+    }
+
+    if (auto it = j.find("resources"); it != j.end() && !it->is_null()) {
+        it->get_to(v.resources.emplace());
+    }
+
 #ifdef LINYAPS_BOX_ENABLE_SECCOMP
-    if (v.seccomp) {
-        j["seccomp"] = *v.seccomp;
+    if (auto it = j.find("seccomp"); it != j.end() && !it->is_null()) {
+        it->get_to(v.seccomp.emplace());
     }
 #endif
-
-    // Resources sub-object
-    bool has_resources = v.unified || v.allowed_devices || v.pids || v.memory || v.cpu
-      || v.hugepage_limits || v.block_io || v.network || v.rdma;
-    if (has_resources) {
-        nlohmann::json res = nlohmann::json::object();
-        if (v.unified) {
-            res["unified"] = *v.unified;
-        }
-        if (v.allowed_devices) {
-            res["devices"] = *v.allowed_devices;
-        }
-        if (v.pids) {
-            res["pids"] = *v.pids;
-        }
-        if (v.memory) {
-            res["memory"] = *v.memory;
-        }
-        if (v.cpu) {
-            res["cpu"] = *v.cpu;
-        }
-        if (v.hugepage_limits) {
-            res["hugepageLimits"] = *v.hugepage_limits;
-        }
-        if (v.block_io) {
-            res["blockIO"] = *v.block_io;
-        }
-        if (v.network) {
-            res["network"] = *v.network;
-        }
-        if (v.rdma) {
-            res["rdma"] = *v.rdma;
-        }
-        j["resources"] = std::move(res);
-    }
 }
 
-// --- hook_t ---
-
-void from_json(const nlohmann::json &j, config::hooks_t::hook_t &v)
+void from_json(const nlohmann::json &j, Config::hooks_t::hook_t &v)
 {
     j.at("path").get_to(v.path);
-    if (!v.path.is_absolute()) {
+    if (UNLIKELY(!v.path.is_absolute())) {
         throw std::runtime_error("hook path must be absolute");
     }
 
-    if (auto it = j.find("args"); it != j.end()) {
-        v.args = it->get<std::vector<std::string>>();
+    if (auto it = j.find("args"); it != j.end() && !it->is_null()) {
+        it->get_to(v.args.emplace());
     }
 
-    if (auto it = j.find("env"); it != j.end()) {
-        std::unordered_map<std::string, std::string> env;
-        for (auto &e : it->get<std::vector<std::string>>()) {
-            auto pos = e.find('=');
-            if (pos == std::string::npos) {
-                throw std::runtime_error("invalid env entry: " + e);
-            }
-            auto key = e.substr(0, pos);
-            e.erase(0, pos + 1);
-            env[std::move(key)] = std::move(e);
+    if (auto it = j.find("env"); it != j.end() && !it->is_null()) {
+        const auto &env = it->get_to(v.env.emplace());
+        auto invalid = std::find_if(env.cbegin(), env.cend(), is_invalid_env);
+        if (UNLIKELY(invalid != v.env->cend())) {
+            throw std::runtime_error("hook.env contains a invalid env: " + *invalid);
         }
-        v.env = std::move(env);
     }
 
-    if (auto it = j.find("timeout"); it != j.end()) {
-        v.timeout = it->get<int>();
-        if (v.timeout.value() <= 0) {
+    if (auto it = j.find("timeout"); it != j.end() && !it->is_null()) {
+        it->get_to(v.timeout.emplace());
+        if (UNLIKELY(v.timeout.value() <= 0)) {
             throw std::runtime_error("hook timeout must be greater than zero");
         }
     }
 }
 
-void to_json(nlohmann::json &j, const config::hooks_t::hook_t &v)
+void from_json(const nlohmann::json &j, Config::hooks_t &v)
 {
-    j = nlohmann::json::object({ { "path", v.path.string() } });
-
-    if (v.args) {
-        j["args"] = *v.args;
+    if (auto it = j.find("prestart"); it != j.end() && !it->is_null()) {
+        it->get_to(v.prestart.emplace());
     }
 
-    if (v.env) {
-        nlohmann::json::array_t env_arr;
-        env_arr.reserve(v.env->size());
-        std::transform(v.env->begin(),
-                       v.env->end(),
-                       std::back_inserter(env_arr),
-                       [](const auto &pair) {
-                           return pair.first + "=" + pair.second;
-                       });
-        j["env"] = std::move(env_arr);
+    if (auto it = j.find("createRuntime"); it != j.end() && !it->is_null()) {
+        it->get_to(v.create_runtime.emplace());
     }
 
-    if (v.timeout) {
-        j["timeout"] = *v.timeout;
+    if (auto it = j.find("createContainer"); it != j.end() && !it->is_null()) {
+        it->get_to(v.create_container.emplace());
+    }
+
+    if (auto it = j.find("startContainer"); it != j.end() && !it->is_null()) {
+        it->get_to(v.start_container.emplace());
+    }
+
+    if (auto it = j.find("poststart"); it != j.end() && !it->is_null()) {
+        it->get_to(v.poststart.emplace());
+    }
+
+    if (auto it = j.find("poststop"); it != j.end() && !it->is_null()) {
+        it->get_to(v.poststop.emplace());
     }
 }
 
-// --- hooks_t ---
-
-void from_json(const nlohmann::json &j, config::hooks_t &v)
-{
-    auto get_hooks = [&j](const char *key) -> std::optional<std::vector<config::hooks_t::hook_t>> {
-        auto it = j.find(key);
-        if (it == j.end()) {
-            return std::nullopt;
-        }
-        return it->get<std::vector<config::hooks_t::hook_t>>();
-    };
-
-    v.prestart = get_hooks("prestart");
-    v.create_runtime = get_hooks("createRuntime");
-    v.create_container = get_hooks("createContainer");
-    v.start_container = get_hooks("startContainer");
-    v.poststart = get_hooks("poststart");
-    v.poststop = get_hooks("poststop");
-}
-
-void to_json(nlohmann::json &j, const config::hooks_t &v)
-{
-    j = nlohmann::json::object();
-    if (v.prestart) {
-        j["prestart"] = *v.prestart;
-    }
-    if (v.create_runtime) {
-        j["createRuntime"] = *v.create_runtime;
-    }
-    if (v.create_container) {
-        j["createContainer"] = *v.create_container;
-    }
-    if (v.start_container) {
-        j["startContainer"] = *v.start_container;
-    }
-    if (v.poststart) {
-        j["poststart"] = *v.poststart;
-    }
-    if (v.poststop) {
-        j["poststop"] = *v.poststop;
-    }
-}
-
-// --- mount_t ---
-
-void from_json(const nlohmann::json &j, config::mount_t &v)
+void from_json(const nlohmann::json &j, Config::mount_t &v)
 {
     j.at("destination").get_to(v.destination);
 
-    if (auto it = j.find("source"); it != j.end()) {
-        v.source = it->get<std::string>();
+    if (auto it = j.find("source"); it != j.end() && !it->is_null()) {
+        it->get_to(v.source.emplace());
     }
-    if (auto it = j.find("type"); it != j.end()) {
-        v.type = it->get<std::string>();
+    if (auto it = j.find("type"); it != j.end() && !it->is_null()) {
+        it->get_to(v.type.emplace());
     }
-    if (auto it = j.find("uidMappings"); it != j.end()) {
-        v.uid_mappings = it->get<std::vector<config::linux_t::id_mapping_t>>();
+    if (auto it = j.find("uidMappings"); it != j.end() && !it->is_null()) {
+        it->get_to(v.uid_mappings.emplace());
     }
-    if (auto it = j.find("gidMappings"); it != j.end()) {
-        v.gid_mappings = it->get<std::vector<config::linux_t::id_mapping_t>>();
+    if (auto it = j.find("gidMappings"); it != j.end() && !it->is_null()) {
+        it->get_to(v.gid_mappings.emplace());
     }
 
-    if (auto it = j.find("options"); it != j.end()) {
+    if (auto it = j.find("options"); it != j.end() && !it->is_null()) {
         auto options = it->get<std::vector<std::string>>();
-        std::tie(v.flags, v.propagation_flags, v.extension_flags, v.data) =
+        std::tie(v.vfs_flags, v.propagation_flags, v.rec_attr, v.extension_flags, v.idmap, v.data) =
           parse_mount_options(options);
     }
 }
 
-void to_json(nlohmann::json &j, const config::mount_t &v)
-{
-    j = nlohmann::json::object({ { "destination", v.destination.string() } });
-
-    if (v.source) {
-        j["source"] = *v.source;
-    }
-    if (v.type) {
-        j["type"] = *v.type;
-    }
-    if (v.uid_mappings) {
-        j["uidMappings"] = *v.uid_mappings;
-    }
-    if (v.gid_mappings) {
-        j["gidMappings"] = *v.gid_mappings;
-    }
-
-    auto options = to_mount_options(v.flags, v.propagation_flags, v.extension_flags, v.data);
-    if (!options.empty()) {
-        j["options"] = std::move(options);
-    }
-}
-
-// --- root_t ---
-
-void from_json(const nlohmann::json &j, config::root_t &v)
+void from_json(const nlohmann::json &j, Config::root_t &v)
 {
     j.at("path").get_to(v.path);
     v.readonly = j.value("readonly", false);
 }
 
-void to_json(nlohmann::json &j, const config::root_t &v)
-{
-    j = nlohmann::json::object({ { "path", v.path.string() }, { "readonly", v.readonly } });
-}
-
-// --- config (top-level) ---
-
-void from_json(const nlohmann::json &j, config &v)
+void from_json(const nlohmann::json &j, Config &v)
 {
     auto semver = linyaps_box::utils::semver(j.at("ociVersion").get_ref<const std::string &>());
-    if (!linyaps_box::utils::semver(config::oci_version).is_compatible_with(semver)) {
+    if (UNLIKELY(!linyaps_box::utils::semver(Config::oci_version).is_compatible_with(semver))) {
         throw std::runtime_error("unsupported OCI version: " + semver.to_string());
     }
 
-    j.at("process").get_to(v.process);
-
-    if (auto it = j.find("hostname"); it != j.end()) {
-        v.hostname = it->get<std::string>();
+    if (auto it = j.find("process"); it != j.end() && !it->is_null()) {
+        it->get_to(v.process.emplace());
     }
 
-    if (auto it = j.find("domainname"); it != j.end()) {
-        v.domainname = it->get<std::string>();
+    if (auto it = j.find("hostname"); it != j.end() && !it->is_null()) {
+        it->get_to(v.hostname.emplace());
     }
 
-    if (auto it = j.find("linux"); it != j.end()) {
-        v.linux = it->get<config::linux_t>();
+    if (auto it = j.find("domainname"); it != j.end() && !it->is_null()) {
+        it->get_to(v.domainname.emplace());
     }
 
-    if (auto it = j.find("hooks"); it != j.end()) {
-        v.hooks = it->get<config::hooks_t>();
+    if (auto it = j.find("linux"); it != j.end() && !it->is_null()) {
+        it->get_to(v.linux.emplace());
     }
 
-    if (auto it = j.find("mounts"); it != j.end()) {
-        v.mounts = it->get<std::vector<config::mount_t>>();
+    if (auto it = j.find("hooks"); it != j.end() && !it->is_null()) {
+        it->get_to(v.hooks.emplace());
     }
 
-    if (!j.contains("root")) {
-        throw std::runtime_error("root must be specified");
+    if (auto it = j.find("mounts"); it != j.end() && !it->is_null()) {
+        it->get_to(v.mounts);
     }
-    j.at("root").get_to(v.root);
 
-    if (auto it = j.find("annotations"); it != j.end()) {
-        v.annotations = it->get<std::unordered_map<std::string, std::string>>();
+    if (auto it = j.find("root"); it != j.end() && !it->is_null()) {
+        it->get_to(v.root.emplace());
+    }
+
+    if (auto it = j.find("annotations"); it != j.end() && !it->is_null()) {
+        it->get_to(v.annotations.emplace());
     }
 }
 
-void to_json(nlohmann::json &j, const config &v)
+auto to_string_view(Config::linux_t::namespace_t::type type) noexcept -> std::string_view
 {
-    j = nlohmann::json::object({ { "ociVersion", config::oci_version } });
-
-    j["process"] = v.process;
-
-    if (v.hostname) {
-        j["hostname"] = *v.hostname;
-    }
-    if (v.domainname) {
-        j["domainname"] = *v.domainname;
-    }
-    if (v.linux) {
-        j["linux"] = *v.linux;
-    }
-    if (v.hooks) {
-        j["hooks"] = *v.hooks;
-    }
-    if (!v.mounts.empty()) {
-        j["mounts"] = v.mounts;
-    }
-    j["root"] = v.root;
-    if (v.annotations) {
-        j["annotations"] = *v.annotations;
-    }
+    return namespace_type_table.to_name(type).value_or(std::string_view{ });
 }
 
-} // namespace linyaps_box
-
-linyaps_box::config linyaps_box::config::parse(std::string_view content)
-{
-    return nlohmann::json::parse(content).get<linyaps_box::config>();
-}
-
-auto linyaps_box::to_string_view(linyaps_box::config::linux_t::namespace_t::type type) noexcept
+auto to_string_view(linyaps_box::Config::process_t::rlimit_t::type_t type) noexcept
   -> std::string_view
 {
-    for (const auto &[val, name] : namespace_type_to_string) {
-        if (val == type) {
-            return name;
-        }
-    }
-
-    __builtin_unreachable();
+    return rlimit_type_table.to_name(type).value_or(std::string_view{ });
 }
 
-void linyaps_box::validate_namespace_path(const linyaps_box::config::linux_t::namespace_t &ns)
+auto validate_namespace_path(const Config::linux_t::namespace_t &ns) -> void
 {
     if (!ns.path) {
         return;
@@ -2215,35 +1459,45 @@ void linyaps_box::validate_namespace_path(const linyaps_box::config::linux_t::na
     auto fs_path = ns.path.value();
     std::error_code ec;
     auto target = std::filesystem::read_symlink(fs_path, ec);
-    if (ec) {
+    if (UNLIKELY(!!ec)) {
         throw std::runtime_error("namespace path " + fs_path.string()
                                  + " does not exist or is not accessible");
     }
 
     auto target_str = target.string();
-    auto colon_pos = target_str.find(':');
-    if (colon_pos == std::string::npos) {
+    auto target_view = std::string_view{ target_str };
+
+    auto colon_pos = target_view.find(':');
+    if (UNLIKELY(colon_pos == std::string_view::npos)) {
         throw std::runtime_error("namespace path " + fs_path.string()
                                  + " does not appear to be a namespace file");
     }
 
-    auto ns_type_from_path = target_str.substr(0, colon_pos);
-    auto expected_str = linyaps_box::to_string_view(ns.type_);
-    if (ns_type_from_path != expected_str) {
+    auto ns_type_from_path = target_view.substr(0, colon_pos);
+    auto expected_str = namespace_type_table.to_name(ns.type_).value();
+    if (UNLIKELY(ns_type_from_path != expected_str)) {
         throw std::runtime_error("namespace path " + fs_path.string() + " is associated with '"
-                                 + ns_type_from_path + "' namespace, not '"
+                                 + std::string(ns_type_from_path) + "' namespace, not '"
                                  + std::string(expected_str) + "'");
     }
 }
 
-auto linyaps_box::to_string_view(linyaps_box::config::process_t::rlimit_t::type_t type) noexcept
-  -> std::string_view
+auto Config::parse(std::string_view content) -> Config
 {
-    for (const auto &[val, name] : rlimit_type_to_string) {
-        if (val == type) {
-            return name;
-        }
+    return nlohmann::json::parse(content).get<Config>();
+}
+
+auto Config::parse(const std::filesystem::path &path) -> Config
+{
+    std::ifstream stream{ path, std::ios::binary | std::ios::in };
+    if (UNLIKELY(!stream.is_open())) {
+        throw std::filesystem::filesystem_error(
+          "failed to open config file",
+          path,
+          std::make_error_code(static_cast<std::errc>(errno)));
     }
 
-    __builtin_unreachable();
+    return nlohmann::json::parse(stream).get<Config>();
 }
+
+} // namespace linyaps_box

--- a/src/linyaps_box/config.h
+++ b/src/linyaps_box/config.h
@@ -5,47 +5,53 @@
 #pragma once
 
 #include <linux/ioprio.h>
-#include <numaif.h>
+#include <linux/mempolicy.h>
+#include <linux/sched.h>
 #include <sys/mount.h>
 
 #include <filesystem>
 #include <optional>
+#include <string>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
 #include <sys/resource.h>
 #include <sys/types.h>
 
-#ifdef LINYAPS_BOX_ENABLE_CAP
-#  include <sys/capability.h>
-#endif
-
 #ifdef LINYAPS_BOX_ENABLE_SECCOMP
 #  include <seccomp.h>
 #endif
 
-// Compatible with linux kernel which is under 5.10
-#ifndef MS_NOSYMFOLLOW
-#  define MS_NOSYMFOLLOW 256
+#ifdef LINYAPS_BOX_ENABLE_CAP
+#  include <sys/capability.h>
 #endif
+
+#include "linyaps_box/utils/enum_traits.h"
+#include "nlohmann/json_fwd.hpp"
+
+// clang-format off
+#include "linyaps_box/config/kernel_fallbacks.h"
+// clang-format on
 
 namespace linyaps_box {
 
-struct config
+struct Config
 {
     static constexpr auto oci_version = "1.3.0";
 
-    static auto parse(std::string_view content) -> config;
+    static auto parse(std::string_view content) -> Config;
+    static auto parse(const std::filesystem::path &path) -> Config;
 
     struct process_t
     {
-        bool terminal{ false };
+        std::optional<bool> terminal;
 
         struct console_size_t
         {
-            unsigned short height{ 0 };
-            unsigned short width{ 0 };
+            unsigned short height;
+            unsigned short width;
         };
 
         std::optional<console_size_t> console_size;
@@ -62,6 +68,7 @@ struct config
                 CPU = RLIMIT_CPU,
                 DATA = RLIMIT_DATA,
                 FSIZE = RLIMIT_FSIZE,
+                LOCKS = RLIMIT_LOCKS,
                 MEMLOCK = RLIMIT_MEMLOCK,
                 MSGQUEUE = RLIMIT_MSGQUEUE,
                 NICE = RLIMIT_NICE,
@@ -82,7 +89,6 @@ struct config
         std::optional<std::vector<rlimit_t>> rlimits;
         std::optional<std::string> apparmor_profile;
 
-        // TODO: not use cap_value_t directly
 #ifdef LINYAPS_BOX_ENABLE_CAP
         struct capabilities_t
         {
@@ -94,7 +100,7 @@ struct config
         };
 
         std::optional<capabilities_t> capabilities;
-#endif
+#endif // LINYAPS_BOX_ENABLE_CAP
 
         std::optional<bool> no_new_privileges;
         std::optional<int> oom_score_adj;
@@ -106,7 +112,7 @@ struct config
                 FIFO = SCHED_FIFO,
                 RR = SCHED_RR,
                 BATCH = SCHED_BATCH,
-                ISO = SCHED_ISO,
+                ISO = kernel::sched_iso,
                 IDLE = SCHED_IDLE,
                 DEADLINE = SCHED_DEADLINE,
             };
@@ -121,10 +127,11 @@ struct config
                 DL_OVERRUN = SCHED_FLAG_DL_OVERRUN,
                 KEEP_POLICY = SCHED_FLAG_KEEP_POLICY,
                 KEEP_PARAMS = SCHED_FLAG_KEEP_PARAMS,
-                UTIL_CLAMP_MIN = SCHED_FLAG_UTIL_CLAMP_MIN,
-                UTIL_CLAMP_MAX = SCHED_FLAG_UTIL_CLAMP_MAX,
+                UTIL_CLAMP_MIN = static_cast<uint8_t>(kernel::sched_flag_util_clamp_min),
+                UTIL_CLAMP_MAX = static_cast<uint8_t>(kernel::sched_flag_util_clamp_max),
             };
-            std::optional<int> flags;
+
+            std::optional<flag_t> flags;
 
             std::optional<uint64_t> runtime;
             std::optional<uint64_t> deadline;
@@ -164,21 +171,72 @@ struct config
             std::optional<std::vector<gid_t>> additional_gids;
         };
 
+        // TODO: maybe user should be optional?
         user_t user;
     };
 
-    // this is required when start is called
-    process_t process;
+    std::optional<process_t> process;
 
     std::optional<std::string> hostname;
     std::optional<std::string> domainname;
+
+    struct id_mapping_t
+    {
+        uid_t host_id;
+        uid_t container_id;
+        size_t size;
+    };
+
+    struct mount_t
+    {
+        enum class extension : std::uint8_t {
+            NONE = 0,
+            COPY_SYMLINK = (1U << 0U),
+            TMPCOPYUP = (1U << 1U),
+        };
+
+        enum class idmap_type : std::uint8_t { IDMAP, RIDMAP };
+
+        // VFS mount(2) flags — passed directly to mount()'s 4th argument.
+        // Does NOT contain propagation flags; see propagation_flags.
+        unsigned long vfs_flags{ 0 };
+
+        // Propagation flags — applied via separate mount(2) call after the main mount.
+        // Bitmask of MS_PRIVATE, MS_SHARED, MS_SLAVE, MS_UNBINDABLE, optionally OR-ed with MS_REC.
+        unsigned long propagation_flags{ 0 };
+
+        // Recursive mount_setattr attributes — applied via mount_setattr(AT_RECURSIVE).
+        // TODO: implement mount_setattr.
+        struct recursive_attr
+        {
+            uint64_t set{ 0 };
+            uint64_t clr{ 0 };
+        };
+
+        std::optional<recursive_attr> rec_attr;
+
+        // Runtime extension flags — bitmap of extension values.
+        extension extension_flags{ extension::NONE };
+
+        // ID mapping type — idmap/ridmap, mutually exclusive.
+        std::optional<idmap_type> idmap;
+
+        std::optional<std::string> source;
+        std::filesystem::path destination;
+        std::optional<std::string> type;
+        std::string data;
+
+        std::optional<std::vector<Config::id_mapping_t>> uid_mappings;
+        std::optional<std::vector<Config::id_mapping_t>> gid_mappings;
+    };
+
+    std::vector<mount_t> mounts;
 
     struct linux_t
     {
         struct namespace_t
         {
             enum class type : unsigned int {
-                NONE = 0,
                 IPC = CLONE_NEWIPC,
                 UTS = CLONE_NEWUTS,
                 MOUNT = CLONE_NEWNS,
@@ -186,7 +244,7 @@ struct config
                 NET = CLONE_NEWNET,
                 USER = CLONE_NEWUSER,
                 CGROUP = CLONE_NEWCGROUP,
-                TIME = CLONE_NEWTIME,
+                TIME = kernel::clone_newtime,
             };
 
             type type_;
@@ -195,15 +253,8 @@ struct config
 
         std::optional<std::vector<namespace_t>> namespaces;
 
-        struct id_mapping_t
-        {
-            uid_t host_id;
-            uid_t container_id;
-            size_t size;
-        };
-
-        std::optional<std::vector<id_mapping_t>> uid_mappings;
-        std::optional<std::vector<id_mapping_t>> gid_mappings;
+        std::optional<std::vector<Config::id_mapping_t>> uid_mappings;
+        std::optional<std::vector<Config::id_mapping_t>> gid_mappings;
 
         struct time_offset_t
         {
@@ -217,7 +268,6 @@ struct config
         {
             std::string type;
             std::filesystem::path path;
-            // REQUIRED unless type is 'p'
             std::optional<uint32_t> major;
             std::optional<uint32_t> minor;
             std::optional<uint32_t> mode;
@@ -232,120 +282,125 @@ struct config
             std::optional<std::string> name;
         };
 
-        std::optional<std::vector<network_device_t>> network_devices;
+        std::optional<std::unordered_map<std::string, network_device_t>> network_devices;
         std::optional<std::string> cgroups_path;
 
-        struct allowed_device_t
+        struct resources_t
         {
-            bool allow;
-            std::optional<std::string> type;
-            std::optional<int64_t> major;
-            std::optional<int64_t> minor;
-            std::optional<std::string> access;
-        };
-
-        std::optional<std::vector<allowed_device_t>> allowed_devices;
-
-        struct memory_t
-        {
-            std::optional<int64_t> limit;
-            std::optional<int64_t> reservation;
-            std::optional<int64_t> swap;
-            std::optional<int64_t> kernel;
-            std::optional<int64_t> kernel_tcp;
-            std::optional<uint64_t> swappiness;
-            std::optional<bool> disable_OOM_killer;
-            std::optional<bool> use_hierarchy;
-            std::optional<bool> check_before_update;
-        };
-
-        std::optional<memory_t> memory;
-
-        struct cpu_t
-        {
-            enum class idle_t : uint8_t { NONE = 0, IDLE = 1 };
-            std::optional<uint64_t> shares;
-            std::optional<int64_t> quota;
-            std::optional<uint64_t> burst;
-            std::optional<uint64_t> period;
-            std::optional<int64_t> realtime_runtime;
-            std::optional<uint64_t> realtime_period;
-            std::optional<std::vector<uint>> cpus;
-            std::optional<std::string> mems;
-            std::optional<idle_t> idle;
-        };
-
-        std::optional<cpu_t> cpu;
-
-        struct block_io_t
-        {
-            std::optional<uint16_t> weight;
-            std::optional<uint16_t> leaf_weight;
-
-            struct weight_device_t
+            struct device_t
             {
-                int64_t major;
-                int64_t minor;
+                bool allow;
+                std::optional<std::string> type;
+                std::optional<int64_t> major;
+                std::optional<int64_t> minor;
+                std::optional<std::string> access;
+            };
+
+            std::optional<std::vector<device_t>> devices;
+
+            struct memory_t
+            {
+                std::optional<int64_t> limit;
+                std::optional<int64_t> reservation;
+                std::optional<int64_t> swap;
+                std::optional<int64_t> kernel;
+                std::optional<int64_t> kernel_tcp;
+                std::optional<uint64_t> swappiness;
+                std::optional<bool> disable_OOM_killer;
+                std::optional<bool> use_hierarchy;
+                std::optional<bool> check_before_update;
+            };
+
+            std::optional<memory_t> memory;
+
+            struct cpu_t
+            {
+                enum class idle_t : uint8_t { NONE = 0, IDLE = 1 };
+                std::optional<uint64_t> shares;
+                std::optional<int64_t> quota;
+                std::optional<uint64_t> burst;
+                std::optional<uint64_t> period;
+                std::optional<int64_t> realtime_runtime;
+                std::optional<uint64_t> realtime_period;
+                std::optional<std::vector<unsigned int>> cpus;
+                std::optional<std::vector<unsigned int>> mems;
+                std::optional<idle_t> idle;
+            };
+
+            std::optional<cpu_t> cpu;
+
+            struct block_io_t
+            {
                 std::optional<uint16_t> weight;
                 std::optional<uint16_t> leaf_weight;
+
+                struct weight_device_t
+                {
+                    int64_t major;
+                    int64_t minor;
+                    std::optional<uint16_t> weight;
+                    std::optional<uint16_t> leaf_weight;
+                };
+
+                std::optional<std::vector<weight_device_t>> weight_devices;
+
+                struct throttle_device_t
+                {
+                    int64_t major;
+                    int64_t minor;
+                    uint64_t rate;
+                };
+
+                std::optional<std::vector<throttle_device_t>> throttle_read_bps_device;
+                std::optional<std::vector<throttle_device_t>> throttle_write_bps_device;
+                std::optional<std::vector<throttle_device_t>> throttle_read_iops_device;
+                std::optional<std::vector<throttle_device_t>> throttle_write_iops_device;
             };
 
-            std::optional<std::vector<weight_device_t>> weight_devices;
+            std::optional<block_io_t> block_io;
 
-            struct throttle_device_t
+            struct hugepage_limit_t
             {
-                int64_t major;
-                int64_t minor;
-                uint64_t rate;
+                std::string page_size;
+                uint64_t limit;
             };
 
-            std::optional<std::vector<throttle_device_t>> throttle_read_bps_device;
-            std::optional<std::vector<throttle_device_t>> throttle_write_bps_device;
-            std::optional<std::vector<throttle_device_t>> throttle_read_iops_device;
-            std::optional<std::vector<throttle_device_t>> throttle_write_iops_device;
-        };
+            std::optional<std::vector<hugepage_limit_t>> hugepage_limits;
 
-        std::optional<block_io_t> block_io;
-
-        struct hugepage_limit_t
-        {
-            std::string page_size;
-            uint64_t limit;
-        };
-
-        std::optional<std::vector<hugepage_limit_t>> hugepage_limits;
-
-        struct network_t
-        {
-            std::optional<uint32_t> class_id;
-
-            struct priority_t
+            struct network_t
             {
-                std::string name;
-                uint32_t priority;
+                std::optional<uint32_t> class_id;
+
+                struct priority_t
+                {
+                    std::string name;
+                    uint32_t priority;
+                };
+
+                std::optional<std::vector<priority_t>> priorities;
             };
 
-            std::optional<std::vector<priority_t>> priorities;
+            std::optional<network_t> network;
+
+            struct pids_t
+            {
+                std::optional<int64_t> limit;
+            };
+
+            std::optional<pids_t> pids;
+
+            struct rdma_t
+            {
+                std::optional<uint32_t> hca_handles;
+                std::optional<uint32_t> hca_objects;
+            };
+
+            std::optional<std::unordered_map<std::string, rdma_t>> rdma;
+
+            std::optional<std::unordered_map<std::string, std::string>> unified;
         };
 
-        std::optional<network_t> network;
-
-        struct pids_t
-        {
-            std::optional<int64_t> limit;
-        };
-
-        std::optional<pids_t> pids;
-
-        struct rdma_t
-        {
-            std::optional<uint32_t> hca_handles;
-            std::optional<uint32_t> hca_objects;
-        };
-
-        std::optional<std::unordered_map<std::string, rdma_t>> rdma;
-
-        std::optional<std::unordered_map<std::string, std::string>> unified;
+        std::optional<resources_t> resources;
 
         struct intel_rdt_t
         {
@@ -364,19 +419,19 @@ struct config
                 DEFAULT = MPOL_DEFAULT,
                 BIND = MPOL_BIND,
                 INTERLEAVE = MPOL_INTERLEAVE,
-                WEIGHTED_INTERLEAVE = MPOL_WEIGHTED_INTERLEAVE,
+                WEIGHTED_INTERLEAVE = static_cast<int>(kernel::mpol_weighted_interleave),
                 PREFERRED = MPOL_PREFERRED,
-                PREFERRED_MANY = MPOL_PREFERRED_MANY,
+                PREFERRED_MANY = static_cast<int>(kernel::mpol_preferred_many),
                 LOCAL = MPOL_LOCAL,
             };
 
             mode_t mode;
-            std::optional<std::vector<int>> nodes;
+            std::optional<std::vector<unsigned int>> nodes;
 
             enum class flag_t : uint16_t {
-                NUMA_BALANCING = MPOL_F_NUMA_BALANCING,
-                RELATIVE_NODES = MPOL_F_RELATIVE_NODES,
-                STATIC_NODES = MPOL_F_STATIC_NODES,
+                NUMA_BALANCING = static_cast<uint16_t>(kernel::mpol_f_numa_balancing),
+                RELATIVE_NODES = static_cast<uint16_t>(MPOL_F_RELATIVE_NODES),
+                STATIC_NODES = static_cast<uint16_t>(MPOL_F_STATIC_NODES),
             };
             std::optional<flag_t> flags;
         };
@@ -388,41 +443,56 @@ struct config
 #ifdef LINYAPS_BOX_ENABLE_SECCOMP
         struct seccomp_t
         {
-            std::string default_action;
+            enum class action_t : std::uint32_t {
+                ALLOW = SCMP_ACT_ALLOW,
+                ERRNO = SCMP_ACT_ERRNO(0),
+                KILL = SCMP_ACT_KILL,
+                KILL_PROCESS = static_cast<std::uint32_t>(kernel::scmp_act_kill_process),
+                KILL_THREAD = static_cast<std::uint32_t>(kernel::scmp_act_kill_thread),
+                LOG = static_cast<std::uint32_t>(kernel::scmp_act_log),
+                NOTIFY = static_cast<std::uint32_t>(kernel::scmp_act_notify),
+                TRACE = SCMP_ACT_TRACE(0),
+                TRAP = SCMP_ACT_TRAP
+            };
+
+            action_t default_action;
             std::optional<uint> default_errno_ret;
 
-            enum class arch_t : uint32_t {
-                X86 = SCMP_ARCH_X86,
-                X86_64 = SCMP_ARCH_X86_64,
-                X32 = SCMP_ARCH_X32,
-                ARM = SCMP_ARCH_ARM,
-                AARCH64 = SCMP_ARCH_AARCH64,
-                MIPS = SCMP_ARCH_MIPS,
-                MIPS64 = SCMP_ARCH_MIPS64,
-                MIPS64N32 = SCMP_ARCH_MIPS64N32,
-                MIPSEL = SCMP_ARCH_MIPSEL,
-                MIPSEL64 = SCMP_ARCH_MIPSEL64,
-                MIPSEL64N32 = SCMP_ARCH_MIPSEL64N32,
-                PPC = SCMP_ARCH_PPC,
-                PPC64 = SCMP_ARCH_PPC64,
-                PPC64LE = SCMP_ARCH_PPC64LE,
-                S390 = SCMP_ARCH_S390,
-                S390X = SCMP_ARCH_S390X,
-                PARISC = SCMP_ARCH_PARISC,
-                PARISC64 = SCMP_ARCH_PARISC64,
-                RISCV64 = SCMP_ARCH_RISCV64,
-                LOONGARCH64 = SCMP_ARCH_LOONGARCH64,
-                M68K = SCMP_ARCH_M68K,
-                SH = SCMP_ARCH_SH,
-                SHEB = SCMP_ARCH_SHEB
+            // TODO: currently we only parsing seccomp flags
+            // using it when we supports seccomp fully
+            enum class arch_t : uint8_t {
+                X86,
+                X86_64,
+                X32,
+                ARM,
+                AARCH64,
+                MIPS,
+                MIPS64,
+                MIPS64N32,
+                MIPSEL,
+                MIPSEL64,
+                MIPSEL64N32,
+                PPC,
+                PPC64,
+                PPC64LE,
+                S390,
+                S390X,
+                PARISC,
+                PARISC64,
+                RISCV64,
+                LOONGARCH64,
+                M68K,
+                SH,
+                SHEB,
             };
             std::optional<std::vector<arch_t>> architectures;
 
             enum class flag_t : std::uint8_t {
                 TSYNC = SECCOMP_FILTER_FLAG_TSYNC,
-                LOG = SECCOMP_FILTER_FLAG_LOG,
-                SPEC_ALLOW = SECCOMP_FILTER_FLAG_SPEC_ALLOW,
-                WAIT_KILLABLE_RECV = SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV,
+                LOG = static_cast<std::uint8_t>(kernel::seccomp_filter_flag_log),
+                SPEC_ALLOW = static_cast<std::uint8_t>(kernel::seccomp_filter_flag_spec_allow),
+                WAIT_KILLABLE_RECV =
+                  static_cast<std::uint8_t>(kernel::seccomp_filter_flag_wait_killable_recv),
             };
             std::optional<flag_t> flags;
 
@@ -431,15 +501,15 @@ struct config
 
             struct syscall_t
             {
-                std::vector<std::string> name;
-                std::string action;
+                std::vector<std::string> names;
+                action_t action;
                 std::optional<uint> errno_ret;
 
                 struct arg_t
                 {
                     uint index;
                     uint64_t value;
-                    uint64_t value_two;
+                    std::optional<uint64_t> value_two;
 
                     enum class op_t : uint8_t {
                         EQ = SCMP_CMP_EQ,
@@ -448,7 +518,7 @@ struct config
                         LE = SCMP_CMP_LE,
                         GT = SCMP_CMP_GT,
                         GE = SCMP_CMP_GE,
-                        MASKED_EQ = SCMP_CMP_MASKED_EQ
+                        MASKED_EQ = SCMP_CMP_MASKED_EQ,
                     };
                     op_t op;
                 };
@@ -461,13 +531,8 @@ struct config
 
         std::optional<seccomp_t> seccomp;
 #endif
-        enum class rootfs_propagation_t : uint {
-            PRIVATE = MS_PRIVATE,
-            SHARED = MS_SHARED,
-            SLAVE = MS_SLAVE,
-            UNBINDABLE = MS_UNBINDABLE
-        };
-        std::optional<rootfs_propagation_t> rootfs_propagation;
+
+        unsigned long rootfs_propagation{ 0 };
 
         std::optional<std::vector<std::filesystem::path>> masked_paths;
         std::optional<std::vector<std::filesystem::path>> readonly_paths;
@@ -493,7 +558,7 @@ struct config
         {
             std::filesystem::path path;
             std::optional<std::vector<std::string>> args;
-            std::optional<std::unordered_map<std::string, std::string>> env;
+            std::optional<std::vector<std::string>> env;
             std::optional<int> timeout;
         };
 
@@ -507,107 +572,58 @@ struct config
 
     std::optional<hooks_t> hooks;
 
-    struct mount_t
-    {
-        enum class extension : std::uint8_t { NONE = 0, COPY_SYMLINK };
-
-        std::optional<std::string> source;
-        std::filesystem::path destination;
-        std::optional<std::string> type;
-        std::string data;
-
-        // for id mapped mount
-        std::optional<std::vector<linux_t::id_mapping_t>> uid_mappings;
-        std::optional<std::vector<linux_t::id_mapping_t>> gid_mappings;
-        unsigned long flags{ 0 };
-        unsigned long propagation_flags{ 0 };
-        extension extension_flags{ 0 };
-    };
-
-    std::vector<mount_t> mounts;
-
     struct root_t
     {
         std::filesystem::path path;
         bool readonly{ false };
     };
 
-    root_t root;
+    std::optional<root_t> root;
 
     std::optional<std::unordered_map<std::string, std::string>> annotations;
 };
 
-auto to_string_view(linyaps_box::config::linux_t::namespace_t::type type) noexcept
-  -> std::string_view;
-auto to_string_view(linyaps_box::config::process_t::rlimit_t::type_t type) noexcept
-  -> std::string_view;
+auto to_string_view(Config::linux_t::namespace_t::type type) noexcept -> std::string_view;
 
-void validate_namespace_path(const linyaps_box::config::linux_t::namespace_t &ns);
+auto to_string_view(Config::process_t::rlimit_t::type_t type) noexcept -> std::string_view;
+
+void validate_namespace_path(const Config::linux_t::namespace_t &ns);
+
+void from_json(const nlohmann::json &j, Config &v);
+
+template <>
+struct utils::is_bitmask_enum<Config::linux_t::namespace_t::type> : std::true_type
+{
+};
+
+template <>
+struct utils::is_bitmask_enum<Config::mount_t::extension> : std::true_type
+{
+};
+
+template <>
+struct utils::is_bitmask_enum<Config::process_t::scheduler_t::flag_t> : std::true_type
+{
+};
+
+template <>
+struct utils::is_bitmask_enum<Config::linux_t::memory_policy_t::flag_t> : std::true_type
+{
+};
+
+#ifdef LINYAPS_BOX_ENABLE_SECCOMP
+template <>
+struct utils::is_bitmask_enum<Config::linux_t::seccomp_t::flag_t> : std::true_type
+{
+};
+#endif
+
+using utils::operator|;
+using utils::operator&;
+using utils::operator^;
+using utils::operator~;
+using utils::operator|=;
+using utils::operator&=;
+using utils::operator^=;
 
 } // namespace linyaps_box
-
-constexpr linyaps_box::config::mount_t::extension
-operator|(linyaps_box::config::mount_t::extension lhs, linyaps_box::config::mount_t::extension rhs)
-{
-    return static_cast<linyaps_box::config::mount_t::extension>(
-      static_cast<std::underlying_type_t<linyaps_box::config::mount_t::extension>>(lhs)
-      | static_cast<std::underlying_type_t<linyaps_box::config::mount_t::extension>>(rhs));
-}
-
-constexpr linyaps_box::config::mount_t::extension
-operator&(linyaps_box::config::mount_t::extension lhs, linyaps_box::config::mount_t::extension rhs)
-{
-    return static_cast<linyaps_box::config::mount_t::extension>(
-      static_cast<std::underlying_type_t<linyaps_box::config::mount_t::extension>>(lhs)
-      & static_cast<std::underlying_type_t<linyaps_box::config::mount_t::extension>>(rhs));
-}
-
-constexpr linyaps_box::config::mount_t::extension &
-operator|=(linyaps_box::config::mount_t::extension &lhs,
-           linyaps_box::config::mount_t::extension rhs) noexcept
-{
-    lhs = lhs | rhs;
-    return lhs;
-}
-
-constexpr linyaps_box::config::mount_t::extension &
-operator&=(linyaps_box::config::mount_t::extension &lhs,
-           linyaps_box::config::mount_t::extension rhs) noexcept
-{
-    lhs = lhs & rhs;
-    return lhs;
-}
-
-constexpr linyaps_box::config::linux_t::namespace_t::type
-operator|(linyaps_box::config::linux_t::namespace_t::type lhs,
-          linyaps_box::config::linux_t::namespace_t::type rhs) noexcept
-{
-    return static_cast<linyaps_box::config::linux_t::namespace_t::type>(
-      static_cast<std::underlying_type_t<linyaps_box::config::linux_t::namespace_t::type>>(lhs)
-      | static_cast<std::underlying_type_t<linyaps_box::config::linux_t::namespace_t::type>>(rhs));
-}
-
-constexpr linyaps_box::config::linux_t::namespace_t::type
-operator&(linyaps_box::config::linux_t::namespace_t::type lhs,
-          linyaps_box::config::linux_t::namespace_t::type rhs) noexcept
-{
-    return static_cast<linyaps_box::config::linux_t::namespace_t::type>(
-      static_cast<std::underlying_type_t<linyaps_box::config::linux_t::namespace_t::type>>(lhs)
-      & static_cast<std::underlying_type_t<linyaps_box::config::linux_t::namespace_t::type>>(rhs));
-}
-
-constexpr linyaps_box::config::linux_t::namespace_t::type &
-operator|=(linyaps_box::config::linux_t::namespace_t::type &lhs,
-           linyaps_box::config::linux_t::namespace_t::type rhs) noexcept
-{
-    lhs = lhs | rhs;
-    return lhs;
-}
-
-constexpr linyaps_box::config::linux_t::namespace_t::type &
-operator&=(linyaps_box::config::linux_t::namespace_t::type &lhs,
-           linyaps_box::config::linux_t::namespace_t::type rhs) noexcept
-{
-    lhs = lhs & rhs;
-    return lhs;
-}

--- a/src/linyaps_box/config/kernel_fallbacks.h
+++ b/src/linyaps_box/config/kernel_fallbacks.h
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+// ATTENTION: This file must be the last one of including sequence
+
+#pragma once
+
+#include <cstdint>
+
+namespace linyaps_box::kernel {
+
+// CLONE_NEWTIME since Linux 5.6
+#ifdef CLONE_NEWTIME
+inline constexpr unsigned int clone_newtime = CLONE_NEWTIME;
+#else
+inline constexpr unsigned int clone_newtime = 0x00000080;
+#endif
+
+// scheduler flags — CLAMP_MIN/CLAMP_MAX since Linux 5.3
+#ifdef SCHED_FLAG_UTIL_CLAMP_MIN
+inline constexpr unsigned int sched_flag_util_clamp_min = SCHED_FLAG_UTIL_CLAMP_MIN;
+#else
+inline constexpr unsigned int sched_flag_util_clamp_min = 0x20;
+#endif
+
+#ifdef SCHED_FLAG_UTIL_CLAMP_MAX
+inline constexpr unsigned int sched_flag_util_clamp_max = SCHED_FLAG_UTIL_CLAMP_MAX;
+#else
+inline constexpr unsigned int sched_flag_util_clamp_max = 0x40;
+#endif
+
+// SCHED_ISO is not standard — use value 4
+#ifdef SCHED_ISO
+inline constexpr int sched_iso = SCHED_ISO;
+#else
+inline constexpr int sched_iso = 4;
+#endif
+
+// memory policy modes — PREFERRED_MANY since 5.15, WEIGHTED_INTERLEAVE since 6.9
+#ifdef MPOL_PREFERRED_MANY
+inline constexpr int mpol_preferred_many = MPOL_PREFERRED_MANY;
+#else
+inline constexpr int mpol_preferred_many = 5;
+#endif
+
+#ifdef MPOL_WEIGHTED_INTERLEAVE
+inline constexpr int mpol_weighted_interleave = MPOL_WEIGHTED_INTERLEAVE;
+#else
+inline constexpr int mpol_weighted_interleave = 6;
+#endif
+
+// memory policy flags — NUMA_BALANCING since 5.12
+#ifdef MPOL_F_NUMA_BALANCING
+inline constexpr unsigned int mpol_f_numa_balancing = MPOL_F_NUMA_BALANCING;
+#else
+inline constexpr unsigned int mpol_f_numa_balancing = (1U << 13);
+#endif
+
+// seccomp filter flags — LOG/SPEC_ALLOW since 4.8, WAIT_KILLABLE_RECV since 5.6
+#ifdef SECCOMP_FILTER_FLAG_LOG
+inline constexpr unsigned long seccomp_filter_flag_log = SECCOMP_FILTER_FLAG_LOG;
+#else
+inline constexpr unsigned long seccomp_filter_flag_log = (1UL << 1);
+#endif
+
+#ifdef SECCOMP_FILTER_FLAG_SPEC_ALLOW
+inline constexpr unsigned long seccomp_filter_flag_spec_allow = SECCOMP_FILTER_FLAG_SPEC_ALLOW;
+#else
+inline constexpr unsigned long seccomp_filter_flag_spec_allow = (1UL << 2);
+#endif
+
+#ifdef SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
+inline constexpr unsigned long seccomp_filter_flag_wait_killable_recv =
+  SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV;
+#else
+inline constexpr unsigned long seccomp_filter_flag_wait_killable_recv = (1UL << 5);
+#endif
+
+// seccomp actions — KILL_PROCESS/KILL_THREAD since 4.14, LOG since 4.14, NOTIFY since 5.0
+#ifdef SCMP_ACT_KILL_PROCESS
+inline constexpr unsigned int scmp_act_kill_process = SCMP_ACT_KILL_PROCESS;
+#else
+inline constexpr unsigned int scmp_act_kill_process = 0x80000000U;
+#endif
+
+#ifdef SCMP_ACT_KILL_THREAD
+inline constexpr unsigned int scmp_act_kill_thread = SCMP_ACT_KILL_THREAD;
+#else
+inline constexpr unsigned int scmp_act_kill_thread = 0x00000000U;
+#endif
+
+#ifdef SCMP_ACT_LOG
+inline constexpr unsigned int scmp_act_log = SCMP_ACT_LOG;
+#else
+inline constexpr unsigned int scmp_act_log = 0x7ffc0000U;
+#endif
+
+#ifdef SCMP_ACT_NOTIFY
+inline constexpr unsigned int scmp_act_notify = SCMP_ACT_NOTIFY;
+#else
+inline constexpr unsigned int scmp_act_notify = 0x7fc00000U;
+#endif
+
+// MS_NOSYMFOLLOW since Linux 5.10
+#ifdef MS_NOSYMFOLLOW
+inline constexpr unsigned int ms_nosymfollow = MS_NOSYMFOLLOW;
+#else
+inline constexpr unsigned int ms_nosymfollow = 256U;
+#endif
+
+// MOUNT_ATTR_* for mount_setattr(2) since kernel 5.12
+#ifdef MOUNT_ATTR_RDONLY
+inline constexpr uint64_t mount_attr_rdonly = MOUNT_ATTR_RDONLY;
+#else
+inline constexpr uint64_t mount_attr_rdonly = 0x00000001ULL;
+#endif
+
+#ifdef MOUNT_ATTR_NOSUID
+inline constexpr uint64_t mount_attr_nosuid = MOUNT_ATTR_NOSUID;
+#else
+inline constexpr uint64_t mount_attr_nosuid = 0x00000002ULL;
+#endif
+
+#ifdef MOUNT_ATTR_NODEV
+inline constexpr uint64_t mount_attr_nodev = MOUNT_ATTR_NODEV;
+#else
+inline constexpr uint64_t mount_attr_nodev = 0x00000004ULL;
+#endif
+
+#ifdef MOUNT_ATTR_NOEXEC
+inline constexpr uint64_t mount_attr_noexec = MOUNT_ATTR_NOEXEC;
+#else
+inline constexpr uint64_t mount_attr_noexec = 0x00000008ULL;
+#endif
+
+#ifdef MOUNT_ATTR_NOATIME
+inline constexpr uint64_t mount_attr_noatime = MOUNT_ATTR_NOATIME;
+#else
+inline constexpr uint64_t mount_attr_noatime = 0x00000010ULL;
+#endif
+
+#ifdef MOUNT_ATTR_STRICTATIME
+inline constexpr uint64_t mount_attr_strictatime = MOUNT_ATTR_STRICTATIME;
+#else
+inline constexpr uint64_t mount_attr_strictatime = 0x00000020ULL;
+#endif
+
+#ifdef MOUNT_ATTR_NODIRATIME
+inline constexpr uint64_t mount_attr_nodiratime = MOUNT_ATTR_NODIRATIME;
+#else
+inline constexpr uint64_t mount_attr_nodiratime = 0x00000080ULL;
+#endif
+
+#ifdef MOUNT_ATTR_NOSYMFOLLOW
+inline constexpr uint64_t mount_attr_nosymfollow = MOUNT_ATTR_NOSYMFOLLOW;
+#else
+inline constexpr uint64_t mount_attr_nosymfollow = 0x00200000ULL;
+#endif
+
+} // namespace linyaps_box::kernel

--- a/src/linyaps_box/config/mount_options.h
+++ b/src/linyaps_box/config/mount_options.h
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <sys/mount.h>
+
+#include <array>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+// clang-format off
+#include "linyaps_box/config/kernel_fallbacks.h"
+// clang-format on
+
+namespace linyaps_box::config::mount_options {
+
+struct flag_entry
+{
+    unsigned long value;
+    std::string_view name;
+};
+
+// VFS mount(2) flags — passed directly to mount()'s 4th argument.
+constexpr std::array<flag_entry, 20> vfs{ {
+  { MS_BIND, "bind" },
+  { MS_DIRSYNC, "dirsync" },
+  { 0, "defaults" },
+  { MS_I_VERSION, "iversion" },
+  { MS_LAZYTIME, "lazytime" },
+  { MS_MANDLOCK, "mand" },
+  { MS_NOATIME, "noatime" },
+  { MS_NODEV, "nodev" },
+  { MS_NODIRATIME, "nodiratime" },
+  { MS_NOEXEC, "noexec" },
+  { MS_NOSUID, "nosuid" },
+  { kernel::ms_nosymfollow, "nosymfollow" },
+  { MS_BIND | MS_REC, "rbind" },
+  { MS_RELATIME, "relatime" },
+  { MS_REMOUNT, "remount" },
+  { MS_RDONLY, "ro" },
+  { MS_SILENT, "silent" },
+  { MS_STRICTATIME, "strictatime" },
+  { MS_SYNCHRONOUS, "sync" },
+} };
+
+// Negation options — clear the corresponding bit from VFS flags.
+constexpr std::array<flag_entry, 14> unset{ {
+  { MS_SYNCHRONOUS, "async" },
+  { MS_NOATIME, "atime" },
+  { MS_NODEV, "dev" },
+  { MS_NODIRATIME, "diratime" },
+  { MS_NOEXEC, "exec" },
+  { MS_SILENT, "loud" },
+  { MS_I_VERSION, "noiversion" },
+  { MS_LAZYTIME, "nolazytime" },
+  { MS_MANDLOCK, "nomand" },
+  { MS_RELATIME, "norelatime" },
+  { MS_STRICTATIME, "nostrictatime" },
+  { MS_RDONLY, "rw" },
+  { MS_NOSUID, "suid" },
+  { kernel::ms_nosymfollow, "symfollow" },
+} };
+
+// Propagation flags — applied as separate mount(2) calls after the main mount.
+constexpr std::array<flag_entry, 8> propagation{ {
+  { MS_PRIVATE, "private" },
+  { MS_PRIVATE | MS_REC, "rprivate" },
+  { MS_SLAVE, "slave" },
+  { MS_SLAVE | MS_REC, "rslave" },
+  { MS_SHARED, "shared" },
+  { MS_SHARED | MS_REC, "rshared" },
+  { MS_UNBINDABLE, "unbindable" },
+  { MS_UNBINDABLE | MS_REC, "runbindable" },
+} };
+
+// Recursive mount_setattr attributes — applied via mount_setattr(AT_RECURSIVE).
+// Values use MOUNT_ATTR_* (kernel 5.12+).  These are consumed from mount options
+// and NOT passed to mount(2).
+//
+// TODO: implement mount_setattr.  ATIME field handling: when any ATIME bit is
+//       set/cleared, MOUNT_ATTR__ATIME must appear in attr_clr to reset the
+//       field before applying the new mode.
+constexpr std::array<flag_entry, 9> recursive_attr_set{ {
+  { static_cast<unsigned long>(kernel::mount_attr_rdonly), "rro" },
+  { static_cast<unsigned long>(kernel::mount_attr_nosuid), "rnosuid" },
+  { static_cast<unsigned long>(kernel::mount_attr_nodev), "rnodev" },
+  { static_cast<unsigned long>(kernel::mount_attr_noexec), "rnoexec" },
+  { static_cast<unsigned long>(kernel::mount_attr_nodiratime), "rnodiratime" },
+  { static_cast<unsigned long>(kernel::mount_attr_noatime), "rnoatime" },
+  { static_cast<unsigned long>(kernel::mount_attr_strictatime), "rstrictatime" },
+  { static_cast<unsigned long>(kernel::mount_attr_nosymfollow), "rnosymfollow" },
+  { 0, "rrelatime" },
+} };
+
+constexpr std::array<flag_entry, 9> recursive_attr_clr{ {
+  { static_cast<unsigned long>(kernel::mount_attr_rdonly), "rrw" },
+  { static_cast<unsigned long>(kernel::mount_attr_nosuid), "rsuid" },
+  { static_cast<unsigned long>(kernel::mount_attr_nodev), "rdev" },
+  { static_cast<unsigned long>(kernel::mount_attr_noexec), "rexec" },
+  { static_cast<unsigned long>(kernel::mount_attr_nodiratime), "rdiratime" },
+  { static_cast<unsigned long>(kernel::mount_attr_noatime), "ratime" },
+  { static_cast<unsigned long>(kernel::mount_attr_strictatime), "rnostrictatime" },
+  { static_cast<unsigned long>(kernel::mount_attr_nosymfollow), "rsymfollow" },
+  { 0, "rnorelatime" },
+} };
+
+template <size_t N>
+constexpr const flag_entry *find(const std::array<flag_entry, N> &table,
+                                 std::string_view key) noexcept
+{
+    for (const auto &entry : table) {
+        if (entry.name == key) {
+            return &entry;
+        }
+    }
+    return nullptr;
+}
+
+// Dump VFS + propagation flags and any leftover unknown bits.
+// Names are looked up from the vfs and propagation tables; unknown bits
+// are printed as hex.
+inline std::string dump(unsigned long vfs_flags, unsigned long prop_flags = 0) noexcept
+{
+    std::stringstream ss;
+    ss << "[ ";
+
+    // VFS flags
+    for (const auto &[val, name] : vfs) {
+        if (val != 0 && (vfs_flags & val) == val) {
+            ss << name << " ";
+            vfs_flags &= ~val;
+        }
+    }
+    if (vfs_flags != 0) {
+        ss << "0x" << std::hex << vfs_flags << std::dec << " ";
+    }
+
+    // Propagation flags
+    if (prop_flags != 0) {
+        ss << "prop:";
+        for (const auto &[val, name] : propagation) {
+            if ((prop_flags & val) == val) {
+                ss << name << " ";
+                prop_flags &= ~val;
+            }
+        }
+        if (prop_flags != 0) {
+            ss << "0x" << std::hex << prop_flags << std::dec << " ";
+        }
+    }
+
+    ss << "]";
+    return ss.str();
+}
+
+} // namespace linyaps_box::config::mount_options

--- a/src/linyaps_box/container.cpp
+++ b/src/linyaps_box/container.cpp
@@ -4,6 +4,7 @@
 
 #include "linyaps_box/container.h"
 
+#include "linyaps_box/config/mount_options.h"
 #include "linyaps_box/container_monitor.h"
 #include "linyaps_box/impl/disabled_cgroup_manager.h"
 #include "linyaps_box/socket.h"
@@ -17,7 +18,6 @@
 #include "linyaps_box/utils/log.h"
 #include "linyaps_box/utils/mkdir.h"
 #include "linyaps_box/utils/mknod.h"
-#include "linyaps_box/utils/platform.h"
 #include "linyaps_box/utils/process.h"
 #include "linyaps_box/utils/session.h"
 #include "linyaps_box/utils/signal.h"
@@ -37,11 +37,8 @@
 #include <fstream>
 #include <iostream>
 #include <limits>
-#include <set>
-#include <stdexcept>
 #include <string>
 
-#include <dirent.h>
 #include <grp.h>
 #include <pwd.h>
 #include <sys/mman.h>
@@ -53,10 +50,11 @@
 #  include <sys/capability.h>
 #endif
 
-constexpr auto propagations_flag = (MS_SHARED | MS_PRIVATE | MS_SLAVE | MS_UNBINDABLE);
 constexpr auto max_symlink_depth{ 32 };
 
 namespace {
+
+using linyaps_box::config::mount_options::dump;
 
 enum class sync_message : std::uint8_t {
     REQUEST_CONFIGURE_NAMESPACE,
@@ -113,58 +111,6 @@ std::ostream &operator<<(std::ostream &os, const sync_message message)
     return os;
 }
 
-struct MountFlag
-{
-    unsigned int flag;
-    std::string_view name;
-};
-
-constexpr std::array<MountFlag, 27> mount_flags{
-    MountFlag{ MS_RDONLY, "MS_RDONLY" },
-    { MS_NOSUID, "MS_NOSUID" },
-    { MS_NODEV, "MS_NODEV" },
-    { MS_NOEXEC, "MS_NOEXEC" },
-    { MS_SYNCHRONOUS, "MS_SYNCHRONOUS" },
-    { MS_REMOUNT, "MS_REMOUNT" },
-    { MS_MANDLOCK, "MS_MANDLOCK" },
-    { MS_DIRSYNC, "MS_DIRSYNC" },
-    { MS_NOSYMFOLLOW, "MS_NOSYMFOLLOW" },
-    { MS_NOATIME, "MS_NOATIME" },
-    { MS_NODIRATIME, "MS_NODIRATIME" },
-    { MS_BIND, "MS_BIND" },
-    { MS_MOVE, "MS_MOVE" },
-    { MS_REC, "MS_REC" },
-    { MS_SILENT, "MS_SILENT" },
-    { MS_POSIXACL, "MS_POSIXACL" },
-    { MS_UNBINDABLE, "MS_UNBINDABLE" },
-    { MS_PRIVATE, "MS_PRIVATE" },
-    { MS_SLAVE, "MS_SLAVE" },
-    { MS_SHARED, "MS_SHARED" },
-    { MS_RELATIME, "MS_RELATIME" },
-    { MS_KERNMOUNT, "MS_KERNMOUNT" },
-    { MS_I_VERSION, "MS_I_VERSION" },
-    { MS_STRICTATIME, "MS_STRICTATIME" },
-    { MS_LAZYTIME, "MS_LAZYTIME" },
-    { MS_ACTIVE, "MS_ACTIVE" },
-    // MS_NOUSER will be overflowed before 2.42.9000
-    // refer:
-    // https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=3263675250cbcbbcc76ede4f7c660418bd345a11;hp=cd335350021fd0b7ac533c83717ee38832fd9887
-    { static_cast<unsigned int>(MS_NOUSER), "MS_NOUSER" }
-};
-
-[[maybe_unused]] auto dump_mount_flags(unsigned long flags) noexcept -> std::string
-{
-    std::stringstream ss;
-    ss << "[ ";
-    for (const auto &[flag, name] : mount_flags) {
-        if ((flags & flag) != 0) {
-            ss << name << " ";
-        }
-    }
-    ss << "]";
-    return ss.str();
-}
-
 class unexpected_sync_message : public std::logic_error
 {
 public:
@@ -198,7 +144,7 @@ auto read_sync_message(linyaps_box::unix_socket &socket) -> sync_message
     return message;
 }
 
-void execute_hook(const linyaps_box::config::hooks_t::hook_t &hook,
+void execute_hook(const linyaps_box::Config::hooks_t::hook_t &hook,
                   const linyaps_box::container_status_t &state)
 {
     auto [parent, child] = linyaps_box::unix_socket::pair();
@@ -224,16 +170,9 @@ void execute_hook(const linyaps_box::config::hooks_t::hook_t &hook,
         }
         c_args.push_back(nullptr);
 
-        std::vector<std::string> env_storage;
         std::vector<const char *> c_env;
         if (hook.env) {
-            env_storage.reserve(hook.env.value().size());
-            for (const auto &[key, value] : hook.env.value()) {
-                env_storage.push_back(key + "=" + value);
-            }
-
-            c_env.reserve(env_storage.size() + 1);
-            for (const auto &env : env_storage) {
+            for (const auto &env : hook.env.value()) {
                 c_env.push_back(env.c_str());
             }
         }
@@ -352,7 +291,7 @@ struct clone_fn_args
 // NOTE: All function in this namespace are running in the container namespace.
 namespace container_ns {
 
-void initialize_container(const linyaps_box::config &config, linyaps_box::unix_socket &socket)
+void initialize_container(const linyaps_box::Config &config, linyaps_box::unix_socket &socket)
 {
     LINYAPS_BOX_DEBUG() << "Request OCI runtime in runtime namespace to configure namespace";
 
@@ -366,8 +305,8 @@ void initialize_container(const linyaps_box::config &config, linyaps_box::unix_s
 
     LINYAPS_BOX_DEBUG() << "Container namespaces configured from runtime namespace";
 
-    if (config.process.oom_score_adj) {
-        auto score = std::to_string(config.process.oom_score_adj.value());
+    if (config.process->oom_score_adj) {
+        auto score = std::to_string(config.process->oom_score_adj.value());
         LINYAPS_BOX_DEBUG() << "Set oom score to " << score;
 
         std::ofstream ofs("/proc/self/oom_score_adj");
@@ -419,8 +358,7 @@ void syscall_mount(const char *_special_file,
         }
         return _fstype;
     }()
-      << "\n\t_rwflag = " << dump_mount_flags(_rwflag)
-      << "\n\t_data = " << [_data]() -> std::string {
+      << "\n\t_rwflag = " << dump(_rwflag) << "\n\t_data = " << [_data]() -> std::string {
         if (_data == nullptr) {
             return "nullptr";
         }
@@ -440,12 +378,13 @@ struct remount_t
     std::string data;
 };
 
-void do_remount(const remount_t &mount)
+auto do_remount(const remount_t &mount) -> void
 {
-    if (mount.destination_fd.get() == -1) {
+    if (UNLIKELY(mount.destination_fd.get() == -1)) {
         throw std::invalid_argument("remount: invalid destination file descriptor");
     }
-    if ((mount.flags & (MS_BIND | MS_REMOUNT | MS_RDONLY)) == 0) {
+
+    if (UNLIKELY((mount.flags & (MS_BIND | MS_REMOUNT | MS_RDONLY)) == 0)) {
         throw std::invalid_argument("remount: flags must include BIND|REMOUNT|RDONLY");
     }
 
@@ -457,15 +396,14 @@ void do_remount(const remount_t &mount)
         data_ptr = nullptr;
     }
 
-    LINYAPS_BOX_DEBUG() << "Remount " << destination << " with flags "
-                        << dump_mount_flags(mount.flags);
+    LINYAPS_BOX_DEBUG() << "Remount " << destination << " with flags " << dump(mount.flags);
     try {
         syscall_mount(nullptr, destination.c_str(), nullptr, mount.flags, data_ptr);
         return;
     } catch (const std::system_error &e) {
         LINYAPS_BOX_DEBUG() << "Failed to remount "
                             << linyaps_box::utils::inspect_path(mount.destination_fd.get())
-                            << "with flags " << dump_mount_flags(mount.flags) << ": " << e.what()
+                            << "with flags " << dump(mount.flags) << ": " << e.what()
                             << ", retrying";
     }
 
@@ -484,8 +422,8 @@ void do_remount(const remount_t &mount)
         } catch (const std::system_error &e) {
             LINYAPS_BOX_DEBUG() << "Failed to remount "
                                 << linyaps_box::utils::inspect_path(mount.destination_fd.get())
-                                << "with flags " << dump_mount_flags(remount_flags | mount.flags)
-                                << ": " << e.what() << ", retrying";
+                                << "with flags " << dump(remount_flags | mount.flags) << ": "
+                                << e.what() << ", retrying";
         }
 
         if ((dest_flag & MS_RDONLY) != 0) {
@@ -583,7 +521,7 @@ create_destination_symlink(const linyaps_box::utils::file_descriptor &root,
 [[nodiscard]] linyaps_box::utils::file_descriptor
 ensure_mount_destination(bool isDir,
                          const linyaps_box::utils::file_descriptor &root,
-                         const linyaps_box::config::mount_t &mount)
+                         const linyaps_box::Config::mount_t &mount)
 try {
     auto open_flag = O_PATH | O_CLOEXEC;
     LINYAPS_BOX_DEBUG() << "Opening " << (isDir ? "directory " : "file ") << mount.destination
@@ -609,8 +547,8 @@ try {
     return create_destination_file(root, path, max_symlink_depth);
 }
 
-void do_propagation_mount(const linyaps_box::utils::file_descriptor &destination,
-                          unsigned long flags)
+auto do_propagation_mount(const linyaps_box::utils::file_descriptor &destination,
+                          unsigned long flags) -> void
 {
     LINYAPS_BOX_DEBUG() << "mount propagation flags";
 
@@ -626,7 +564,7 @@ void do_propagation_mount(const linyaps_box::utils::file_descriptor &destination
 }
 
 [[nodiscard]] linyaps_box::utils::file_descriptor do_bind_mount(
-  const linyaps_box::utils::file_descriptor &root, const linyaps_box::config::mount_t &mount)
+  const linyaps_box::utils::file_descriptor &root, const linyaps_box::Config::mount_t &mount)
 {
     if (UNLIKELY(!mount.source)) {
         throw std::invalid_argument("bind mount requires source");
@@ -646,8 +584,9 @@ void do_propagation_mount(const linyaps_box::utils::file_descriptor &destination
                                     + (S_ISDIR(dest_stat.st_mode) ? "dir" : "file") + ")");
     }
 
-    auto bind_flags = mount.flags & ~(propagations_flag | MS_RDONLY);
-
+    // remove MS_RDONLY for creating destination
+    // we will remount it on later
+    auto bind_flags = mount.vfs_flags & ~MS_RDONLY;
     try {
         // bind mount will ignore fstype and data
         syscall_mount(source_fd.proc_path().c_str(),
@@ -665,7 +604,7 @@ void do_propagation_mount(const linyaps_box::utils::file_descriptor &destination
 }
 
 [[noreturn]] void do_cgroup_mount([[maybe_unused]] const linyaps_box::utils::file_descriptor &root,
-                                  [[maybe_unused]] const linyaps_box::config::mount_t &mount,
+                                  [[maybe_unused]] const linyaps_box::Config::mount_t &mount,
                                   [[maybe_unused]] std::string_view unified_cgroup_path)
 {
     // TODO: implement
@@ -674,7 +613,7 @@ void do_propagation_mount(const linyaps_box::utils::file_descriptor &destination
 
 [[nodiscard]] std::optional<remount_t> do_mount(linyaps_box::container &container,
                                                 linyaps_box::utils::file_descriptor &root,
-                                                const linyaps_box::config::mount_t &mount)
+                                                const linyaps_box::Config::mount_t &mount)
 {
     // FIXME: this is a workaround, it should be fixed in the future
     static auto is_sys_rbind{ false };
@@ -697,8 +636,8 @@ void do_propagation_mount(const linyaps_box::utils::file_descriptor &destination
             auto unshared_cgroup_ns = std::find_if(
               namespaces->cbegin(),
               namespaces->cend(),
-              [](const linyaps_box::config::linux_t::namespace_t &ns) -> bool {
-                  return ns.type_ == linyaps_box::config::linux_t::namespace_t::type::CGROUP;
+              [](const linyaps_box::Config::linux_t::namespace_t &ns) -> bool {
+                  return ns.type_ == linyaps_box::Config::linux_t::namespace_t::type::CGROUP;
               });
             if (mount.destination == "/sys/fs/cgroup" && is_sys_rbind) {
                 if (unshared_cgroup_ns != namespaces->cend()) {
@@ -715,9 +654,9 @@ void do_propagation_mount(const linyaps_box::utils::file_descriptor &destination
 
     // TODO: fstype == sysfs and it's fallback
     linyaps_box::utils::file_descriptor destination_fd;
-    if ((mount.flags & MS_BIND) != 0) {
+    if ((mount.vfs_flags & MS_BIND) != 0) {
         destination_fd = do_bind_mount(root, mount);
-        if (!is_sys_rbind && mount.destination == "/sys" && (mount.flags & MS_REC) != 0) {
+        if (!is_sys_rbind && mount.destination == "/sys" && (mount.vfs_flags & MS_REC) != 0) {
             is_sys_rbind = true;
         }
 
@@ -730,11 +669,13 @@ void do_propagation_mount(const linyaps_box::utils::file_descriptor &destination
         syscall_mount(mount.source ? mount.source.value().c_str() : nullptr,
                       destination_fd.proc_path().c_str(),
                       mount.type ? mount.type.value().c_str() : nullptr,
-                      mount.flags,
+                      mount.vfs_flags,
                       mount.data.empty() ? nullptr : mount.data.c_str());
     }
 
-    do_propagation_mount(destination_fd, mount.propagation_flags);
+    if (auto prop_flags = mount.propagation_flags; prop_flags != 0) {
+        do_propagation_mount(destination_fd, prop_flags);
+    }
 
     // if the mount destination is root, we need to reopen it after mount
     // to refresh the file descriptor, otherwise it may cause some unexpected behavior
@@ -743,7 +684,7 @@ void do_propagation_mount(const linyaps_box::utils::file_descriptor &destination
     }
 
     bool need_remount{ false };
-    if ((mount.flags & (MS_RDONLY | MS_BIND)) != 0) {
+    if ((mount.vfs_flags & (MS_RDONLY | MS_BIND)) != 0) {
         need_remount = true;
     }
 
@@ -760,8 +701,12 @@ void do_propagation_mount(const linyaps_box::utils::file_descriptor &destination
         return std::nullopt;
     }
 
-    auto remount_flags = mount.flags | MS_REMOUNT;
+    auto remount_flags = mount.vfs_flags | MS_REMOUNT;
     if (mount.type != "proc") {
+        // Linux kernel requires MS_REMOUNT | MS_BIND to safely change mount options
+        // (e.g., ro/rw) of an existing bind mount without altering the underlying
+        // filesystem's superblock. For single-instance filesystems like 'proc',
+        // we skip MS_BIND to reconfigure the instance directly.
         remount_flags |= MS_BIND;
     }
 
@@ -810,39 +755,35 @@ public:
         : container(container)
         , root(std::move(rootfd))
     {
+        remounts.reserve(this->container.get().get_config().mounts.size());
     }
 
     void configure_rootfs()
     {
         const auto &config = container.get().get_config();
 
-        if (!config.linux || !config.linux->namespaces) {
-            return;
-        }
-
-        auto unshared_mount_ns = std::find_if(
-          std::cbegin(*(config.linux->namespaces)),
-          std::cend(*(config.linux->namespaces)),
-          [](const linyaps_box::config::linux_t::namespace_t &ns) -> bool {
-              return ns.type_ == linyaps_box::config::linux_t::namespace_t::type::MOUNT;
-          });
-        if (unshared_mount_ns == std::cend(*(config.linux->namespaces))) {
+        auto has_mount_ns = config.linux && config.linux->namespaces
+          && std::any_of(config.linux->namespaces->begin(),
+                         config.linux->namespaces->end(),
+                         [](const auto &ns) {
+                             return ns.type_
+                               == linyaps_box::Config::linux_t::namespace_t::type::MOUNT;
+                         });
+        if (!has_mount_ns) {
             LINYAPS_BOX_DEBUG() << "no unshared mount namespace";
             return;
         }
 
         // we will pivot root later
         LINYAPS_BOX_DEBUG() << "configure rootfs";
-        auto flags = static_cast<unsigned long>(config.linux->rootfs_propagation.value_or(
-          linyaps_box::config::linux_t::rootfs_propagation_t::PRIVATE));
-        if (!config.linux->rootfs_propagation) {
-            flags |= MS_REC;
+        auto prop = config.linux->rootfs_propagation;
+        if (prop == 0) {
+            prop = MS_REC | MS_PRIVATE;
         }
 
         // change the propagation type of rootfs mountpoint to configured type
         // otherwise bind mount will inherit the propagation type of rootfs mountpoint
-        do_propagation_mount(linyaps_box::utils::open("/", O_PATH | O_CLOEXEC | O_DIRECTORY),
-                             flags);
+        do_propagation_mount(linyaps_box::utils::open("/", O_PATH | O_CLOEXEC | O_DIRECTORY), prop);
 
         // make sure the parent mountpoint of new root is private
         // pivot root will fail if it has shared propagation type
@@ -851,14 +792,14 @@ public:
         // pivot root will reset the propagation type of rootfs mountpoint
         // we need to save the propagation type to make sure the parent mountpoint of new root is
         // what we want
-        container.get().set_rootfs_propagation(flags);
+        container.get().set_rootfs_propagation(prop);
 
         LINYAPS_BOX_DEBUG() << "rebind container rootfs";
 
-        linyaps_box::config::mount_t mount;
+        linyaps_box::Config::mount_t mount;
         mount.source = root.current_path();
         mount.destination = ".";
-        mount.flags = MS_BIND | MS_REC;
+        mount.vfs_flags = MS_BIND | MS_REC;
         mount.propagation_flags = MS_PRIVATE | MS_REC;
         auto ret = do_mount(container, root, mount);
         if (ret) {
@@ -868,7 +809,7 @@ public:
         // reopen rootfs after mount
         root = linyaps_box::utils::open(root.current_path(), O_PATH | O_CLOEXEC | O_DIRECTORY);
 
-        if (config.root.readonly) {
+        if (config.root->readonly) {
             LINYAPS_BOX_DEBUG() << "remount bind rootfs to readonly";
             remount_t mount;
             mount.destination_fd = root.duplicate();
@@ -884,10 +825,10 @@ public:
         }
     }
 
-    void mount(const linyaps_box::config::mount_t &mount)
+    void mount(const linyaps_box::Config::mount_t &mount)
     {
-        if ((mount.extension_flags & linyaps_box::config::mount_t::extension::COPY_SYMLINK)
-            != linyaps_box::config::mount_t::extension::NONE) {
+        if ((mount.extension_flags & linyaps_box::Config::mount_t::extension::COPY_SYMLINK)
+            == linyaps_box::Config::mount_t::extension::COPY_SYMLINK) {
             auto ret = create_destination_symlink(root, mount.source.value(), mount.destination);
             return;
         }
@@ -922,25 +863,27 @@ public:
                 throw;
             }
 
-            auto mount_flag = MS_BIND | MS_PRIVATE | MS_RDONLY | MS_REC;
+            auto vfs_flag = MS_BIND | MS_RDONLY | MS_REC;
+            auto prop_flag = MS_PRIVATE | MS_REC;
 
             // readonly path is an absolute path within the container,
             // the path is already exists in the container when making it readonly
             // so we should inherit the mount flags to keep it as same as the original
             auto ret = linyaps_box::utils::statfs(dst);
-            mount_flag |= ret.f_flags;
+            vfs_flag |= ret.f_flags;
 
             // parent mount flags may contain MS_REMOUNT, we should remove it due to the
             // readonly path is not mounted yet
-            mount_flag &= ~MS_REMOUNT;
+            vfs_flag &= ~MS_REMOUNT;
 
-            linyaps_box::config::mount_t mount{ };
+            linyaps_box::Config::mount_t mount{ };
             mount.destination = path;
             mount.source = dst.proc_path();
-            mount.flags = mount_flag;
+            mount.vfs_flags = vfs_flag;
+            mount.propagation_flags = prop_flag;
 
             LINYAPS_BOX_DEBUG() << "make readonly path " << path << " with "
-                                << dump_mount_flags(mount.flags);
+                                << dump(mount.vfs_flags, mount.propagation_flags);
             auto delay_mount = do_mount(container, root, mount);
             if (!delay_mount) {
                 throw std::runtime_error("mount " + path.string()
@@ -975,10 +918,10 @@ public:
             }
 
             auto ret = linyaps_box::utils::fstatat(dst, "");
-            auto mount = linyaps_box::config::mount_t{ };
+            auto mount = linyaps_box::Config::mount_t{ };
 
             mount.destination = path;
-            mount.flags = MS_RDONLY;
+            mount.vfs_flags = MS_RDONLY;
 
             if (S_ISDIR(ret.st_mode)) {
                 mount.source = "tmpfs";
@@ -996,7 +939,7 @@ public:
             }
 
             mount.source = "/dev/null";
-            mount.flags |= MS_BIND;
+            mount.vfs_flags |= MS_BIND;
 
             LINYAPS_BOX_DEBUG() << "mask file " << path;
             auto delay_mount = do_mount(container, root, mount);
@@ -1039,7 +982,7 @@ private:
 
             struct statfs buf{ };
 
-            int ret = ::statfs(proc.proc_path().c_str(), &buf);
+            const auto ret = ::statfs(proc.proc_path().c_str(), &buf);
             if (ret != 0) {
                 throw std::system_error(errno, std::system_category(), "statfs");
             }
@@ -1048,7 +991,7 @@ private:
                 break;
             }
 
-            linyaps_box::config::mount_t mount;
+            linyaps_box::Config::mount_t mount;
             mount.source = "proc";
             mount.type = "proc";
             mount.destination = "/proc";
@@ -1068,11 +1011,11 @@ private:
                 break;
             }
 
-            linyaps_box::config::mount_t mount;
+            linyaps_box::Config::mount_t mount;
             mount.source = "sysfs";
             mount.type = "sysfs";
             mount.destination = "/sys";
-            mount.flags = MS_NOSUID | MS_NOEXEC | MS_NODEV;
+            mount.vfs_flags = MS_NOSUID | MS_NOEXEC | MS_NODEV;
             try {
                 this->mount(mount);
             } catch (const std::system_error &e) {
@@ -1084,7 +1027,7 @@ private:
                 mount.source = "/sys";
                 mount.type = "bind";
                 mount.destination = "/sys";
-                mount.flags = MS_BIND | MS_REC | MS_NOSUID | MS_NOEXEC | MS_NODEV;
+                mount.vfs_flags = MS_BIND | MS_REC | MS_NOSUID | MS_NOEXEC | MS_NODEV;
                 this->mount(mount);
             }
         } while (false);
@@ -1107,11 +1050,11 @@ private:
                 break;
             }
 
-            linyaps_box::config::mount_t mount;
+            linyaps_box::Config::mount_t mount;
             mount.source = "tmpfs";
             mount.destination = "/dev";
             mount.type = "tmpfs";
-            mount.flags = MS_NOSUID | MS_STRICTATIME;
+            mount.vfs_flags = MS_NOSUID | MS_STRICTATIME;
             mount.data = "mode=755,size=65536k";
             this->mount(mount);
         } while (false);
@@ -1126,11 +1069,11 @@ private:
                 }
             }
 
-            linyaps_box::config::mount_t mount;
+            linyaps_box::Config::mount_t mount;
             mount.source = "devpts";
             mount.destination = "/dev/pts";
             mount.type = "devpts";
-            mount.flags = MS_NOSUID | MS_NOEXEC;
+            mount.vfs_flags = MS_NOSUID | MS_NOEXEC;
             mount.data = "newinstance,ptmxmode=0666,mode=0620";
             this->mount(mount);
         } while (false);
@@ -1145,11 +1088,11 @@ private:
                 }
             }
 
-            linyaps_box::config::mount_t mount;
+            linyaps_box::Config::mount_t mount;
             mount.source = "shm";
             mount.destination = "/dev/shm";
             mount.type = "tmpfs";
-            mount.flags = MS_NOSUID | MS_NOEXEC | MS_NODEV;
+            mount.vfs_flags = MS_NOSUID | MS_NOEXEC | MS_NODEV;
             mount.data = "mode=1777,size=65536k";
             this->mount(mount);
         } while (false);
@@ -1195,11 +1138,12 @@ private:
             // not available. Fallback to bind mount the host device.
             if (ec == std::errc::operation_not_permitted) {
                 LINYAPS_BOX_DEBUG() << "fallback to bind mount device";
-                linyaps_box::config::mount_t mount;
+                linyaps_box::Config::mount_t mount;
                 mount.source = destination;
                 mount.destination = destination;
                 mount.type = "bind";
-                mount.flags = MS_BIND | MS_PRIVATE | MS_NOEXEC | MS_NOSUID;
+                mount.vfs_flags = MS_BIND | MS_NOEXEC | MS_NOSUID;
+                mount.propagation_flags = MS_PRIVATE;
                 this->mount(mount);
                 return;
             }
@@ -1250,11 +1194,12 @@ private:
 
             if (S_ISREG(ptmx_stat.st_mode)) {
                 // /dev/ptmx is a regular file: bind mount /dev/pts/ptmx over it
-                linyaps_box::config::mount_t mount;
+                linyaps_box::Config::mount_t mount;
                 mount.source = root.current_path() / "dev/pts/ptmx";
                 mount.destination = "/dev/ptmx";
                 mount.type = "bind";
-                mount.flags = MS_BIND | MS_PRIVATE | MS_NOEXEC | MS_NOSUID;
+                mount.vfs_flags = MS_BIND | MS_NOEXEC | MS_NOSUID;
+                mount.propagation_flags = MS_PRIVATE;
                 this->mount(mount);
             } else if (S_ISLNK(ptmx_stat.st_mode)) {
                 // /dev/ptmx is a symlink: check if it points to pts/ptmx
@@ -1331,9 +1276,9 @@ void configure_mounts(linyaps_box::container &container, const std::filesystem::
     LINYAPS_BOX_DEBUG() << "Mounts configured";
 }
 
-[[noreturn]] void execute_process(const linyaps_box::config &config)
+[[noreturn]] void execute_process(const linyaps_box::Config &config)
 {
-    const auto &process = config.process;
+    const auto &process = *config.process;
     std::vector<const char *> c_args;
     c_args.reserve(process.args.size());
     for (const auto &arg : process.args) {
@@ -1391,7 +1336,7 @@ void configure_mounts(linyaps_box::container &container, const std::filesystem::
     throw std::system_error(errno, std::system_category(), "execvpe");
 }
 
-void wait_prestart_hooks_result(const linyaps_box::config &config, linyaps_box::unix_socket &socket)
+void wait_prestart_hooks_result(const linyaps_box::Config &config, linyaps_box::unix_socket &socket)
 {
     if (!config.hooks || !config.hooks->prestart) {
         return;
@@ -1416,7 +1361,7 @@ void wait_prestart_hooks_result(const linyaps_box::config &config, linyaps_box::
     throw unexpected_sync_message(sync_message::PRESTART_HOOKS_EXECUTED, message);
 }
 
-void wait_create_runtime_result(const linyaps_box::config &config, linyaps_box::unix_socket &socket)
+void wait_create_runtime_result(const linyaps_box::Config &config, linyaps_box::unix_socket &socket)
 {
     if (!config.hooks || !config.hooks->create_runtime) {
         return;
@@ -1471,10 +1416,10 @@ void do_pivot_root(const linyaps_box::container &container, const std::filesyste
     auto new_root = linyaps_box::utils::open(rootfs.c_str(), O_DIRECTORY | O_RDONLY | O_CLOEXEC);
 
     auto old_root_stat = linyaps_box::utils::statfs(old_root);
-    LINYAPS_BOX_DEBUG() << "Pivot root old root: " << dump_mount_flags(old_root_stat.f_flags);
+    LINYAPS_BOX_DEBUG() << "Pivot root old root: " << dump(old_root_stat.f_flags);
 
     auto new_root_stat = linyaps_box::utils::statfs(new_root);
-    LINYAPS_BOX_DEBUG() << "Pivot root new root: " << dump_mount_flags(new_root_stat.f_flags);
+    LINYAPS_BOX_DEBUG() << "Pivot root new root: " << dump(new_root_stat.f_flags);
 
     auto ret = fchdir(new_root.get());
     if (ret < 0) {
@@ -1535,14 +1480,18 @@ void set_umask(const std::optional<mode_t> &mask)
 
 unsigned long get_last_cap()
 {
-    const auto *file = "/proc/sys/kernel/cap_last_cap";
-    std::ifstream ifs(file);
-    if (!ifs) {
-        throw std::runtime_error("Can't open " + std::string(file));
-    }
+    static const auto last_cap = []() -> unsigned long {
+        const auto *file = "/proc/sys/kernel/cap_last_cap";
+        std::ifstream ifs(file);
+        if (!ifs) {
+            throw std::runtime_error("Can't open " + std::string(file));
+        }
 
-    unsigned long last_cap{ 0 };
-    ifs >> last_cap;
+        unsigned long val{ 0 };
+        ifs >> val;
+        return val;
+    }();
+
     return last_cap;
 }
 
@@ -1558,36 +1507,41 @@ security_status get_runtime_security_status()
     return status;
 }
 
-void set_capabilities(const linyaps_box::config &config, int last_cap)
+void set_capabilities(const linyaps_box::Config &config, int last_cap)
 {
 #ifdef LINYAPS_BOX_ENABLE_CAP
     LINYAPS_BOX_DEBUG() << "Set capabilities";
-    const auto &capabilities = config.process.capabilities;
+    const auto &capabilities = config.process->capabilities;
     if (!capabilities) {
         return;
     }
 
-    if (last_cap <= 0) {
+    if (UNLIKELY(last_cap <= 0)) {
         throw std::runtime_error("kernel does not support capabilities");
     }
 
     const auto &bounding_set = capabilities->bounding;
     if (bounding_set) {
-        for (int cap = 0; cap < last_cap; ++cap) {
-            if (std::find_if(bounding_set->cbegin(),
-                             bounding_set->cend(),
-                             [cap](int c) {
-                                 return c == cap;
-                             })
-                == bounding_set->cend()) {
-                if (cap_drop_bound(cap) < 0) {
+        std::vector<bool> keep_mask(last_cap + 1, false);
+        for (auto cap : *bounding_set) {
+            keep_mask[cap] = true;
+        }
+
+        for (int cap = 0; cap <= last_cap; ++cap) {
+            if (!keep_mask[cap]) {
+                if (UNLIKELY(cap_drop_bound(cap) < 0)) {
                     throw std::system_error(errno, std::system_category(), "cap_drop_bound");
                 }
             }
         }
     }
 
-    std::unique_ptr<_cap_struct, decltype(&cap_free)> caps(cap_init(), cap_free);
+    auto *cap = cap_init();
+    if (UNLIKELY(cap == nullptr)) {
+        throw std::system_error(errno, std::system_category(), "failed to init cap");
+    }
+    const std::unique_ptr<_cap_struct, decltype(&cap_free)> caps(cap, cap_free);
+
     int ret{ -1 };
     const auto &effective_set = capabilities->effective;
     if (effective_set && !effective_set->empty()) {
@@ -1596,7 +1550,7 @@ void set_capabilities(const linyaps_box::config &config, int last_cap)
                            effective_set->size(),
                            effective_set->data(),
                            CAP_SET);
-        if (ret < 0) {
+        if (UNLIKELY(ret < 0)) {
             throw std::system_error(errno,
                                     std::system_category(),
                                     "failed to set effective capabilities");
@@ -1610,7 +1564,7 @@ void set_capabilities(const linyaps_box::config &config, int last_cap)
                            permitted_set->size(),
                            permitted_set->data(),
                            CAP_SET);
-        if (ret < 0) {
+        if (UNLIKELY(ret < 0)) {
             throw std::system_error(errno,
                                     std::system_category(),
                                     "failed to set permitted capabilities");
@@ -1624,7 +1578,7 @@ void set_capabilities(const linyaps_box::config &config, int last_cap)
                            inheritable_set->size(),
                            inheritable_set->data(),
                            CAP_SET);
-        if (ret < 0) {
+        if (UNLIKELY(ret < 0)) {
             throw std::system_error(errno,
                                     std::system_category(),
                                     "failed to set inheritable capabilities");
@@ -1632,21 +1586,21 @@ void set_capabilities(const linyaps_box::config &config, int last_cap)
     }
 
     // keep current capabilities, we need these caps on later
-    std::ignore = linyaps_box::utils::prctl(PR_SET_KEEPCAPS, 1);
+    std::ignore = linyaps_box::utils::prctl(PR_SET_KEEPCAPS, 1L, 0L, 0L, 0L);
 
-    const auto &process = config.process;
+    const auto &process = *config.process;
     ret = setresuid(process.user.uid, process.user.uid, process.user.uid);
-    if (ret < 0) {
+    if (UNLIKELY(ret < 0)) {
         throw std::system_error(errno, std::system_category(), "setresuid");
     }
 
     ret = setresgid(process.user.gid, process.user.gid, process.user.gid);
-    if (ret < 0) {
+    if (UNLIKELY(ret < 0)) {
         throw std::system_error(errno, std::system_category(), "setresgid");
     }
 
     ret = cap_set_proc(caps.get());
-    if (ret < 0) {
+    if (UNLIKELY(ret < 0)) {
         throw std::system_error(errno, std::system_category(), "cap_set_proc");
     }
 
@@ -1656,17 +1610,20 @@ void set_capabilities(const linyaps_box::config &config, int last_cap)
     const auto &ambient_set = capabilities->ambient;
     if (ambient_set) {
         std::for_each(ambient_set->cbegin(), ambient_set->cend(), [](cap_value_t cap) {
-            std::ignore =
-              linyaps_box::utils::prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, cap, 0L, 0L);
+            std::ignore = linyaps_box::utils::prctl(PR_CAP_AMBIENT,
+                                                    PR_CAP_AMBIENT_RAISE,
+                                                    static_cast<long>(cap),
+                                                    0L,
+                                                    0L);
         });
     }
 #  endif
 
 #endif
 
-    if (config.process.no_new_privileges) {
+    if (config.process->no_new_privileges) {
         LINYAPS_BOX_DEBUG() << "Set no new privileges";
-        std::ignore = linyaps_box::utils::prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+        std::ignore = linyaps_box::utils::prctl(PR_SET_NO_NEW_PRIVS, 1L, 0L, 0L, 0L);
     }
 }
 
@@ -1692,7 +1649,7 @@ void start_container_hooks(const linyaps_box::container &container,
     LINYAPS_BOX_DEBUG() << "Sync message sent";
 }
 
-void close_other_fds(std::set<uint> except_fds)
+void close_other_fds(linyaps_box::utils::span<const int> except_fds)
 {
     LINYAPS_BOX_DEBUG() << "Close all fds excepts " << [&]() -> std::string {
         std::stringstream ss;
@@ -1702,10 +1659,12 @@ void close_other_fds(std::set<uint> except_fds)
         return ss.str();
     }();
 
-    except_fds.insert(0);
-    except_fds.insert(std::numeric_limits<uint>::max());
-
-    for (auto fd = except_fds.begin(); std::next(fd) != except_fds.end(); ++fd) {
+    std::vector<int> sorted;
+    sorted.reserve(except_fds.size() + 1);
+    sorted.assign(except_fds.begin(), except_fds.end());
+    std::sort(sorted.begin(), sorted.end());
+    sorted.push_back(std::numeric_limits<int>::max());
+    for (auto fd = sorted.begin(); std::next(fd) != sorted.end(); ++fd) {
         auto low = *fd + 1;
         auto high = *std::next(fd) - 1;
         if (low >= high) {
@@ -1716,7 +1675,7 @@ void close_other_fds(std::set<uint> except_fds)
     }
 }
 
-void processing_extensions(const linyaps_box::config &config)
+void processing_extensions(const linyaps_box::Config &config)
 {
     if (!config.annotations) {
         return;
@@ -1780,7 +1739,7 @@ void configure_terminal(const linyaps_box::container &container,
                         const linyaps_box::unix_socket &socket)
 {
     LINYAPS_BOX_DEBUG() << "Configure terminal";
-    const auto &process = container.get_config().process;
+    const auto &process = *container.get_config().process;
 
     auto [master, slave] = linyaps_box::create_pty_pair();
 
@@ -1797,10 +1756,10 @@ void configure_terminal(const linyaps_box::container &container,
 
     auto root = linyaps_box::utils::open("/", O_PATH | O_CLOEXEC | O_DIRECTORY);
 
-    linyaps_box::config::mount_t mount{ };
+    linyaps_box::Config::mount_t mount{ };
     mount.source = slave.file_describer().current_path();
     mount.destination = "/dev/console";
-    mount.flags = MS_BIND;
+    mount.vfs_flags = MS_BIND;
 
     auto dest_fd = do_bind_mount(root, mount);
     socket.send_fd(std::move(master).take());
@@ -1835,25 +1794,27 @@ try {
 
     auto &args = *static_cast<clone_fn_args *>(data);
 
-    if (args.socket.fd().get() < 0) {
+    if (UNLIKELY(args.socket.fd().get() < 0)) {
         throw std::runtime_error("clone_fn: invalid socket fd");
     }
-    std::set<uint> except_fds{
+
+    std::vector<int> except_fds{
         STDIN_FILENO,
         STDOUT_FILENO,
         STDERR_FILENO,
     };
+
     for (auto fd = 0; fd < args.preserve_fds; ++fd) {
-        except_fds.insert(fd + 3);
+        except_fds.push_back(fd + 3);
     }
-    except_fds.insert(static_cast<unsigned int>(args.socket.fd().get()));
-    close_other_fds(std::move(except_fds));
+    except_fds.push_back(static_cast<unsigned int>(args.socket.fd().get()));
+    close_other_fds(linyaps_box::utils::span<const int>(except_fds.data(), except_fds.size()));
 
     auto &container = *args.container;
     const auto &config = container.get_config();
     auto &socket = args.socket;
 
-    auto rootfs = container.get_config().root.path;
+    auto rootfs = container.get_config().root->path;
     if (rootfs.is_relative()) {
         LINYAPS_BOX_DEBUG() << "rootfs is relative based on bundle path:" << container.get_bundle();
         rootfs = std::filesystem::canonical(container.get_bundle() / rootfs);
@@ -1875,7 +1836,7 @@ try {
         configure_terminal(container, args.console_socket.value());
     }
 
-    set_umask(container.get_config().process.user.umask);
+    set_umask(container.get_config().process->user.umask);
     // processing all extensions before drop capabilities
     processing_extensions(config);
     set_capabilities(config, runtime_cap);
@@ -1888,17 +1849,6 @@ try {
 
     start_container_hooks(container, status, socket);
     execute_process(config);
-} catch (const std::system_error &e) {
-    LINYAPS_BOX_ERR() << "clone failed: " << e.what();
-
-    try {
-        auto &args = *static_cast<clone_fn_args *>(data);
-        args.socket << std::byte(sync_message::ERROR);
-    } catch (const std::exception &e) {
-        LINYAPS_BOX_ERR() << "failed to write data to socket: " << e.what();
-    }
-
-    return -1;
 } catch (const std::exception &e) {
     LINYAPS_BOX_ERR() << "clone failed: " << e.what();
 
@@ -1929,7 +1879,7 @@ try {
 namespace runtime_ns {
 
 [[nodiscard]] unsigned generate_clone_flag(
-  const std::optional<std::vector<linyaps_box::config::linux_t::namespace_t>> &namespaces)
+  const std::optional<std::vector<linyaps_box::Config::linux_t::namespace_t>> &namespaces)
 {
     LINYAPS_BOX_DEBUG() << "Generate clone flags";
 
@@ -1940,7 +1890,7 @@ namespace runtime_ns {
     }
 
     for (const auto &ns : *namespaces) {
-        flag |= static_cast<unsigned>(ns.type_);
+        flag = flag | static_cast<unsigned int>(ns.type_);
         LINYAPS_BOX_DEBUG() << "Add " << to_string_view(ns.type_) << " , flag=0x" << std::hex
                             << flag;
     }
@@ -1992,11 +1942,11 @@ private:
     void *stack_low;
 };
 
-void set_rlimits(const std::vector<linyaps_box::config::process_t::rlimit_t> &rlimits)
+void set_rlimits(const std::vector<linyaps_box::Config::process_t::rlimit_t> &rlimits)
 {
     std::for_each(rlimits.begin(),
                   rlimits.end(),
-                  [](const linyaps_box::config::process_t::rlimit_t &rlimit) {
+                  [](const linyaps_box::Config::process_t::rlimit_t &rlimit) {
                       const struct rlimit rl{ rlimit.soft, rlimit.hard };
                       auto resource = static_cast<int>(rlimit.type);
                       LINYAPS_BOX_DEBUG()
@@ -2021,11 +1971,11 @@ std::tuple<int, linyaps_box::unix_socket> start_container_process(
                         << linyaps_box::utils::inspect_fds();
 
     // config rlimits before we enter new user namespace
-    if (const auto &rlimits = config.process.rlimits; rlimits) {
+    if (const auto &rlimits = config.process->rlimits; rlimits) {
         set_rlimits(rlimits.value());
     }
 
-    std::optional<std::vector<linyaps_box::config::linux_t::namespace_t>> namespaces;
+    std::optional<std::vector<linyaps_box::Config::linux_t::namespace_t>> namespaces;
     if (config.linux && config.linux->namespaces) {
         namespaces = config.linux->namespaces;
     }
@@ -2334,9 +2284,9 @@ void configure_container_namespaces(linyaps_box::container &container,
 
             if (std::find_if(namespaces->cbegin(),
                              namespaces->cend(),
-                             [](const linyaps_box::config::linux_t::namespace_t &ns) -> bool {
+                             [](const linyaps_box::Config::linux_t::namespace_t &ns) -> bool {
                                  return ns.type_
-                                   == linyaps_box::config::linux_t::namespace_t::type::USER;
+                                   == linyaps_box::Config::linux_t::namespace_t::type::USER;
                              })
                 != namespaces->end()) {
                 auto pid = container.status().PID;
@@ -2500,17 +2450,15 @@ linyaps_box::container::container(status_directory status_dir,
     }
 
     LINYAPS_BOX_DEBUG() << "load config from " << config;
-    const auto config_str = linyaps_box::utils::read_all(config);
-
-    this->config = linyaps_box::config::parse(config_str);
+    this->config = linyaps_box::Config::parse(config);
     auto &mount = this->config.mounts;
-    std::for_each(mount.begin(), mount.end(), [this](config::mount_t &mount) {
+    std::for_each(mount.begin(), mount.end(), [this](Config::mount_t &mount) {
         if (mount.destination.is_relative()) {
             throw std::runtime_error("destination of mount point is relative");
         }
         mount.destination = std::filesystem::weakly_canonical(mount.destination);
 
-        if ((mount.flags & MS_BIND) == 0) {
+        if ((mount.vfs_flags & MS_BIND) == 0) {
             return;
         }
 
@@ -2538,7 +2486,7 @@ linyaps_box::container::container(status_directory status_dir,
 #endif
     {
         container_status_t status;
-        status.oci_version = linyaps_box::config::oci_version;
+        status.oci_version = linyaps_box::Config::oci_version;
         status.ID = options.ID;
         status.PID = getpid();
         status.status = container_status_t::runtime_status::CREATING;
@@ -2552,7 +2500,7 @@ linyaps_box::container::container(status_directory status_dir,
         this->status_dir().write(status);
     }
 
-    this->status_dir().write_config(config_str);
+    this->status_dir().save_config(config);
 
     switch (options.manager) {
     case cgroup_manager_t::disabled: {
@@ -2564,7 +2512,7 @@ linyaps_box::container::container(status_directory status_dir,
     }
 }
 
-const linyaps_box::config &linyaps_box::container::get_config() const
+const linyaps_box::Config &linyaps_box::container::get_config() const
 {
     return this->config;
 }
@@ -2579,7 +2527,7 @@ int linyaps_box::container::run(run_container_options_t options)
 {
     int container_process_exit_code{ -1 };
 
-    std::ignore = utils::prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0);
+    std::ignore = utils::prctl(PR_SET_CHILD_SUBREAPER, 1L, 0L, 0L, 0L);
 
     try {
         // TODO: there are some thing that should be done before starting the container process
@@ -2587,7 +2535,7 @@ int linyaps_box::container::run(run_container_options_t options)
         // setup, etc.
 
         std::optional<unix_socket> recv_socketpair;
-        if (config.process.terminal && !options.console_socket) {
+        if (config.process->terminal && !options.console_socket) {
             auto [socket1, socket2] = linyaps_box::unix_socket::pair();
             options.console_socket = unix_socket{ std::move(socket1) };
             recv_socketpair = unix_socket{ std::move(socket2) };

--- a/src/linyaps_box/container.h
+++ b/src/linyaps_box/container.h
@@ -5,14 +5,13 @@
 #pragma once
 
 #include "linyaps_box/cgroup_manager.h"
+#include "linyaps_box/config.h"
 #include "linyaps_box/container_ref.h"
 #include "linyaps_box/status_directory.h"
 #include "linyaps_box/unix_socket.h"
 #include "linyaps_box/utils/file_describer.h"
 
 namespace linyaps_box {
-
-struct container_data;
 
 struct create_container_options_t
 {
@@ -38,7 +37,7 @@ public:
     container(container &&) = delete;
     auto operator=(container &&) -> container & = delete;
 
-    [[nodiscard]] auto get_config() const -> const linyaps_box::config &;
+    [[nodiscard]] auto get_config() const -> const linyaps_box::Config &;
     [[nodiscard]] auto get_bundle() const -> const std::filesystem::path &;
     [[nodiscard]] auto run(run_container_options_t options) -> int;
 
@@ -56,7 +55,7 @@ public:
 
     [[nodiscard]] auto rootfs_propagation() const noexcept { return rootfs_propagation_; }
 
-    auto set_rootfs_propagation(unsigned int propagation) noexcept
+    auto set_rootfs_propagation(unsigned long propagation) noexcept
     {
         rootfs_propagation_ = propagation;
     }
@@ -67,10 +66,10 @@ public:
 
 private:
     void cgroup_preenter(const cgroup_options &options, utils::file_descriptor &dirfd);
-    linyaps_box::config config;
+    linyaps_box::Config config;
     std::filesystem::path bundle;
     std::unique_ptr<cgroup_manager> manager;
-    unsigned int rootfs_propagation_{ 0 };
+    unsigned long rootfs_propagation_{ 0 };
     gid_t host_gid_;
     uid_t host_uid_;
     bool deny_setgroups_{ false };

--- a/src/linyaps_box/container_ref.cpp
+++ b/src/linyaps_box/container_ref.cpp
@@ -11,7 +11,6 @@
 #include "linyaps_box/utils/log.h"
 #include "linyaps_box/utils/process.h"
 #include "linyaps_box/utils/session.h"
-#include "nlohmann/json.hpp"
 
 #include <csignal> // IWYU pragma: keep
 #include <utility>
@@ -49,7 +48,7 @@ auto linyaps_box::container_ref::exec(exec_container_option option) -> int
 {
     auto target = std::to_string(this->status().PID);
 
-    std::ignore = utils::prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0);
+    std::ignore = utils::prctl(PR_SET_CHILD_SUBREAPER, 1L, 0L, 0L, 0L);
 
     std::optional<unix_socket> recv_socketpair;
     if (option.proc.terminal && !option.console_socket) {
@@ -77,31 +76,41 @@ auto linyaps_box::container_ref::exec(exec_container_option option) -> int
 
         std::vector<const char *> argv{ "nsenter", "--target", target.c_str() };
 
-        auto config_str = status_dir_.read_config();
-        auto config = nlohmann::json::parse(config_str);
-        const auto &linux = config.at("linux");
-        if (linux.is_null()) {
+        auto path = status_dir_.config();
+        auto config = Config::parse(path);
+        const auto &linux = config.linux;
+        if (!linux) {
             throw std::runtime_error("container config missing linux section");
         }
 
         // FIXME: we assume that container always unshare some namespaces for now
         // support exec commands without setns in the future
-        for (const auto &ns : linux.at("namespaces")) {
-            const auto &type = ns.at("type");
-            if (type == "pid") {
-                argv.push_back("--pid");
-            } else if (type == "mount") {
-                argv.push_back("--mount");
-            } else if (type == "uts") {
-                argv.push_back("--uts");
-            } else if (type == "ipc") {
+        for (const auto &ns : linux->namespaces.value()) {
+            switch (ns.type_) {
+            case Config::linux_t::namespace_t::type::IPC: {
                 argv.push_back("--ipc");
-            } else if (type == "network") {
+            } break;
+            case Config::linux_t::namespace_t::type::UTS: {
+                argv.push_back("--uts");
+            } break;
+            case Config::linux_t::namespace_t::type::MOUNT: {
+                argv.push_back("--mount");
+            } break;
+            case Config::linux_t::namespace_t::type::PID: {
+                argv.push_back("--pid");
+            } break;
+            case Config::linux_t::namespace_t::type::NET: {
                 argv.push_back("--net");
-            } else if (type == "user") {
+            } break;
+            case Config::linux_t::namespace_t::type::USER: {
                 argv.push_back("--user");
-            } else if (type == "cgroup") {
+            } break;
+            case Config::linux_t::namespace_t::type::CGROUP: {
                 argv.push_back("--cgroup");
+            } break;
+            case Config::linux_t::namespace_t::type::TIME: {
+                argv.push_back("--time");
+            } break;
             }
         }
         argv.push_back("--preserve-credentials");

--- a/src/linyaps_box/container_ref.h
+++ b/src/linyaps_box/container_ref.h
@@ -16,7 +16,7 @@ namespace linyaps_box {
 struct exec_container_option
 {
     int preserve_fds;
-    config::process_t proc;
+    Config::process_t proc;
     std::optional<unix_socket> console_socket;
 };
 

--- a/src/linyaps_box/io/forwarder.cpp
+++ b/src/linyaps_box/io/forwarder.cpp
@@ -11,7 +11,7 @@
 
 namespace linyaps_box::io {
 
-static constexpr std::size_t default_bytes_quota{ static_cast<const std::size_t>(16 * 1024) };
+static constexpr std::size_t default_bytes_quota{ static_cast<std::size_t>(16 * 1024) };
 
 Forwarder::Forwarder(Epoll &poller, std::size_t buffer_size)
     : rb(utils::ring_buffer::create(buffer_size))

--- a/src/linyaps_box/status_directory.cpp
+++ b/src/linyaps_box/status_directory.cpp
@@ -97,20 +97,17 @@ void linyaps_box::status_directory::remove() const
     std::filesystem::remove_all(path_);
 }
 
-void linyaps_box::status_directory::write_config(std::string_view config) const
+auto linyaps_box::status_directory::write_config(std::string_view config) const -> void
 {
     utils::atomic_write(path_ / "config.json", config);
 }
 
-auto linyaps_box::status_directory::read_config() const -> std::string
+auto linyaps_box::status_directory::save_config(const std::filesystem::path &src) const -> void
 {
-    auto config_path = path_ / "config.json";
-    std::ifstream istrm(config_path);
-    if (istrm.fail()) {
-        throw std::system_error(errno,
-                                std::system_category(),
-                                "failed to open config file: " + config_path.string());
-    }
+    std::filesystem::copy(src, path_ / "config.json");
+}
 
-    return { std::istreambuf_iterator<char>(istrm), std::istreambuf_iterator<char>() };
+auto linyaps_box::status_directory::config() const -> std::filesystem::path
+{
+    return path_ / "config.json";
 }

--- a/src/linyaps_box/status_directory.h
+++ b/src/linyaps_box/status_directory.h
@@ -7,7 +7,6 @@
 #include "linyaps_box/container_status.h"
 
 #include <filesystem>
-#include <string>
 #include <string_view>
 
 namespace linyaps_box {
@@ -17,12 +16,13 @@ class status_directory
 public:
     explicit status_directory(std::filesystem::path path);
 
-    void write(const container_status_t &status) const;
+    auto write(const container_status_t &status) const -> void;
     [[nodiscard]] auto read() const -> container_status_t;
-    void remove() const;
+    auto remove() const -> void;
 
-    void write_config(std::string_view config) const;
-    [[nodiscard]] auto read_config() const -> std::string;
+    auto write_config(std::string_view config) const -> void;
+    auto save_config(const std::filesystem::path &src) const -> void;
+    [[nodiscard]] auto config() const -> std::filesystem::path;
 
 private:
     std::filesystem::path path_;

--- a/src/linyaps_box/utils/enum_traits.h
+++ b/src/linyaps_box/utils/enum_traits.h
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string_view>
+#include <type_traits>
+
+namespace linyaps_box::utils {
+
+template <typename E>
+using enum_underlying_t = std::underlying_type_t<E>;
+
+template <typename E>
+struct enum_entry
+{
+    E value;
+    std::string_view name;
+};
+
+template <typename E, std::size_t N>
+struct enum_table
+{
+    std::array<enum_entry<E>, N> entries;
+
+    [[nodiscard]] constexpr auto to_name(const E &value) const noexcept
+      -> std::optional<std::string_view>
+    {
+        for (const auto &entry : entries) {
+            if (entry.value == value) {
+                return entry.name;
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    [[nodiscard]] constexpr auto from_name(std::string_view name) const noexcept -> std::optional<E>
+    {
+        for (const auto &entry : entries) {
+            if (entry.name == name) {
+                return entry.value;
+            }
+        }
+
+        return std::nullopt;
+    }
+};
+
+template <typename E>
+constexpr auto bitmask_popcount(E value) noexcept -> int
+{
+    using U = std::make_unsigned_t<std::underlying_type_t<E>>;
+    return __builtin_popcountll(static_cast<unsigned long long>(static_cast<U>(value)));
+}
+
+template <typename E, std::size_t N, typename F>
+constexpr void for_each_bit(E value, const enum_table<E, N> &table, const F &callback)
+{
+    static_assert(std::is_invocable_v<F, const enum_entry<E> &>);
+    auto u = static_cast<enum_underlying_t<E>>(value);
+    for (const auto &entry : table.entries) {
+        auto eu = static_cast<enum_underlying_t<E>>(entry.value);
+        if (eu != 0 && (u & eu) != 0) {
+            callback(entry);
+        }
+    }
+}
+
+template <typename E, std::size_t N>
+constexpr auto verify_enum_table(const enum_table<E, N> &table) noexcept -> bool
+{
+    for (std::size_t i = 0; i < N; ++i) {
+        for (std::size_t j = i + 1; j < N; ++j) {
+            if (table.entries[i].name == table.entries[j].name
+                || table.entries[i].value == table.entries[j].value) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+template <typename E, std::size_t N, typename Pred>
+constexpr auto verify_enum_table(const enum_table<E, N> &table, Pred is_valid) -> bool
+{
+    for (std::size_t i = 0; i < N; ++i) {
+        for (std::size_t j = i + 1; j < N; ++j) {
+            if (!is_valid(table.entries[i], table.entries[j])) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+template <typename T>
+struct is_bitmask_enum : std::false_type
+{
+};
+
+template <typename T>
+inline constexpr bool is_bitmask_enum_v = is_bitmask_enum<T>::value;
+
+template <typename E>
+constexpr std::enable_if_t<is_bitmask_enum_v<E>, E> operator|(E lhs, E rhs) noexcept
+{
+    using U = std::underlying_type_t<E>;
+    return static_cast<E>(static_cast<U>(lhs) | static_cast<U>(rhs));
+}
+
+template <typename E>
+constexpr std::enable_if_t<is_bitmask_enum_v<E>, E> operator&(E lhs, E rhs) noexcept
+{
+    using U = std::underlying_type_t<E>;
+    return static_cast<E>(static_cast<U>(lhs) & static_cast<U>(rhs));
+}
+
+template <typename E>
+constexpr std::enable_if_t<is_bitmask_enum_v<E>, E> operator^(E lhs, E rhs) noexcept
+{
+    using U = std::underlying_type_t<E>;
+    return static_cast<E>(static_cast<U>(lhs) ^ static_cast<U>(rhs));
+}
+
+template <typename E>
+constexpr std::enable_if_t<is_bitmask_enum_v<E>, E> operator~(E rhs) noexcept
+{
+    using U = std::underlying_type_t<E>;
+    return static_cast<E>(~static_cast<U>(rhs));
+}
+
+template <typename E>
+constexpr std::enable_if_t<is_bitmask_enum_v<E>, E &> operator|=(E &lhs, E rhs) noexcept
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+template <typename E>
+constexpr std::enable_if_t<is_bitmask_enum_v<E>, E &> operator&=(E &lhs, E rhs) noexcept
+{
+    lhs = lhs & rhs;
+    return lhs;
+}
+
+template <typename E>
+constexpr std::enable_if_t<is_bitmask_enum_v<E>, E &> operator^=(E &lhs, E rhs) noexcept
+{
+    lhs = lhs ^ rhs;
+    return lhs;
+}
+
+} // namespace linyaps_box::utils


### PR DESCRIPTION
- Rename `config` → `Config`, move to PascalCase per C++ conventions
- Split `mount_t::flags` into `vfs_flags`, `propagation_flags`, `rec_attr`
- Move `id_mapping_t` to `Config` scope for reuse across mount and linux
- Extract `resources_t` under `linux_t` matching OCI spec hierarchy
- Make `root`, `process`, `user` optional per spec (user defaults to 0/0)
- Fix `netDevices` type from `vector` to `unordered_map` per spec
- Fix hooks.env from `unordered_map` to `vector<string>` with KEY=VALUE validation per POSIX environ semantics

Extract:
- `config/kernel_fallbacks.h` — kernel constant compat for older headers
- `config/mount_options.h` — mount flag lookup tables and dump()
- `utils/enum_traits.h` — generic enum_table + SFINAE bitmask operators

Seccomp:
- Replace string fields with typed action_t/arch_t/flag_t enums
- Validate errnoRet only valid with ERRNO/TRACE actions
- Validate NOTIFY requires listenerPath
- Decouple arch_t values from libseccomp constants for 2.3.3 compat

Performance:
- close_other_fds uses close_range() syscall instead of per-fd loop
- set_capabilities bounding set uses vector<bool> mask for O(n) drop
- get_last_cap uses static local for one-time /proc read

Safety:
- Remove __builtin_unreachable() from to_string_view (UB on unknown)
- Add null check for cap_init() before unique_ptr construction
- Explicit long args for prctl() to avoid sign-extension issues
- Add overflow validation in parse_range_list
- UNLIKELY annotations on all validation/error branches

Removed:
- All to_json functions (one-way parse only)
- Old per-enum bitwise operator overloads (replaced by enum_traits)
- Unused includes: <set>, <dirent.h>, platform.h