### PR TITLE
fix: return 0 for --help/--version instead of crashing

### DIFF
--- a/src/linyaps_box/app.cpp
+++ b/src/linyaps_box/app.cpp
@@ -59,7 +59,7 @@ try {
                                            return command::run(options);
                                        },
                                        [](const std::monostate &) -> int {
-                                           __builtin_unreachable();
+                                           return 0;
                                        } },
                       opts.subcommand_opt);
 } catch (const std::exception &e) {


### PR DESCRIPTION
std::monostate is triggered when only flags like --help or --version
are passed (no subcommand). __builtin_unreachable() caused a coredump
because this path was actually reachable.

Signed-off-by: Yuming He <ComixHe1895@outlook.com>
