### PR TITLE
refactor: drop nsenter dependency, refactor command dispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,8 @@ set(linyaps-box_LIBRARY_SOURCE
     src/linyaps_box/utils/semver.h
     src/linyaps_box/utils/session.cpp
     src/linyaps_box/utils/session.h
+    src/linyaps_box/utils/setns.cpp
+    src/linyaps_box/utils/setns.h
     src/linyaps_box/utils/signal.cpp
     src/linyaps_box/utils/signal.h
     src/linyaps_box/utils/span.h

--- a/src/linyaps_box/app.cpp
+++ b/src/linyaps_box/app.cpp
@@ -21,11 +21,11 @@ namespace linyaps_box {
 // Extended commands and options should be compatible with crun.
 auto main(int argc, char **argv) noexcept -> int
 try {
-    LINYAPS_BOX_DEBUG() << "linyaps box called with" << [=]() -> std::string {
+    LINYAPS_BOX_DEBUG() << "linyaps box called with" << [argc, argv]() -> std::string {
         std::stringstream result;
         for (int i = 0; i < argc; ++i) {
             result << " \"";
-            for (const auto ch : std::string_view(argv[i])) { // NOLINT
+            for (const auto ch : std::string_view(argv[i])) {
                 if (ch == '\\') {
                     result << "\\\\";
                 } else if (ch == '"') {
@@ -39,24 +39,23 @@ try {
         return result.str();
     }();
 
-    auto opts = command::parse(argc, argv);
-    if (opts.global.return_code != 0) {
-        return opts.global.return_code;
+    auto result = command::parse(argc, argv);
+    if (!result) {
+        return EXIT_FAILURE;
     }
 
-    return std::visit(utils::Overload{ [](const command::list_options &options) -> int {
-                                          command::list(options);
-                                          return 0;
+    auto &opts = *result;
+    return std::visit(utils::Overload{ [&opts](const command::list_options &list) -> int {
+                                          return command::list(list, opts.global);
                                       },
-                                       [](const command::exec_options &options) -> int {
-                                           return command::exec(options);
+                                       [&opts](command::exec_options &exec) -> int {
+                                           return command::exec(std::move(exec), opts.global);
                                        },
-                                       [](const command::kill_options &options) -> int {
-                                           command::kill(options);
-                                           return 0;
+                                       [&opts](const command::kill_options &kill) -> int {
+                                           return command::kill(kill, opts.global);
                                        },
-                                       [](const command::run_options &options) -> int {
-                                           return command::run(options);
+                                       [&opts](const command::run_options &run) -> int {
+                                           return command::run(run, opts.global);
                                        },
                                        [](const std::monostate &) -> int {
                                            return 0;

--- a/src/linyaps_box/command/exec.cpp
+++ b/src/linyaps_box/command/exec.cpp
@@ -6,58 +6,64 @@
 
 #include "linyaps_box/runtime.h"
 #include "linyaps_box/status_directory_manager.h"
+#include "linyaps_box/utils/utils.h"
 
-#ifdef LINYAPS_BOX_ENABLE_CAP
-#  include <sys/capability.h>
-#endif
+#include <nlohmann/json.hpp>
 
-auto linyaps_box::command::exec(const struct exec_options &options) -> int
-{
-    status_directory_manager mgr(options.global_.get().root);
+#include <fstream>
+
+auto linyaps_box::command::exec(exec_options options, const global_options &global) noexcept -> int
+try {
+    status_directory_manager mgr(global.root);
     runtime_t runtime(std::move(mgr));
 
-    auto container_refs = runtime.containers();
+    const auto &container_refs = runtime.containers();
     auto container = container_refs.find(options.ID);
-    if (container == container_refs.end()) {
+    if (UNLIKELY(container == container_refs.cend())) {
         throw std::runtime_error("container not found");
     }
 
     exec_container_option option;
-    option.proc.cwd = options.cwd.value_or("/");
-    option.proc.args = options.command;
-    option.proc.terminal = options.tty;
-    option.proc.no_new_privileges = options.no_new_privs;
-    option.proc.env = options.envs;
     option.preserve_fds = options.preserve_fds;
 
-    if (option.proc.terminal && options.console_socket) {
-        option.console_socket = unix_socket::connect(options.console_socket.value());
+    if (options.process_file) {
+        std::ifstream file(*options.process_file);
+        if (UNLIKELY(!file)) {
+            throw std::runtime_error("cannot open process file: " + options.process_file->string());
+        }
+
+        nlohmann::json j;
+        file >> j;
+        option.proc = j.get<oci_config::process_t>();
+    }
+
+    option.cwd = std::move(options.cwd);
+    if (options.tty) {
+        option.tty = true;
+    }
+
+    if (options.no_new_privs) {
+        option.no_new_privs = true;
+    }
+
+    option.extra_envs = std::move(options.envs);
+    if (options.user) {
+        option.uid = options.user->uid;
+        option.gid = options.user->gid;
+    }
+    option.command = std::move(options.command);
+
+    auto needs_terminal = option.tty.value_or(false) || (option.proc && option.proc->terminal);
+    if (needs_terminal && options.console_socket) {
+        option.console_socket = unix_socket::connect(*options.console_socket);
     }
 
 #ifdef LINYAPS_BOX_ENABLE_CAP
-    if (options.caps) {
-        const auto &caps = options.caps.value();
-        if (!option.proc.capabilities) {
-            option.proc.capabilities.emplace();
-        }
-
-        std::vector<cap_value_t> parsed;
-        parsed.reserve(caps.size());
-        for (const auto &name : caps) {
-            cap_value_t val{ };
-            if (cap_from_name(name.c_str(), &val) < 0) {
-                throw std::system_error(errno, std::system_category(), "cap_from_name");
-            }
-
-            parsed.push_back(val);
-        }
-
-        option.proc.capabilities->effective = parsed;
-        option.proc.capabilities->ambient = parsed;
-        option.proc.capabilities->bounding = parsed;
-        option.proc.capabilities->permitted = parsed;
-    }
+    option.caps = std::move(options.caps);
 #endif
 
     return container->second.exec(std::move(option));
+} catch (const std::exception &e) {
+    LINYAPS_BOX_ERR() << "failed to exec: " << e.what();
+    return -1;
 }

--- a/src/linyaps_box/command/exec.h
+++ b/src/linyaps_box/command/exec.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -8,6 +8,6 @@
 
 namespace linyaps_box::command {
 
-[[nodiscard]] auto exec(const exec_options &options) -> int;
+[[nodiscard]] auto exec(exec_options options, const global_options &global) noexcept -> int;
 
 } // namespace linyaps_box::command

--- a/src/linyaps_box/command/kill.cpp
+++ b/src/linyaps_box/command/kill.cpp
@@ -6,29 +6,10 @@
 
 #include "linyaps_box/runtime.h"
 #include "linyaps_box/status_directory_manager.h"
-#include "linyaps_box/utils/platform.h"
 
-#include <algorithm>
-
-void linyaps_box::command::kill(const struct kill_options &options)
+auto linyaps_box::command::kill(const kill_options &options, const global_options &global) -> int
 {
-    auto signal{ options.signal };
-    int sig{ -1 };
-    while (true) {
-        if (std::all_of(signal.cbegin(), signal.cend(), ::isdigit)) {
-            sig = std::stoi(signal);
-            break;
-        }
-
-        if (signal.rfind("SIG", 0) == std::string::npos) {
-            signal.insert(0, "SIG");
-        }
-
-        sig = utils::str_to_signal(signal);
-        break;
-    }
-
-    status_directory_manager mgr(options.global_.get().root);
+    status_directory_manager mgr(global.root);
     runtime_t runtime(std::move(mgr));
     const auto &containers = runtime.containers();
     for (const auto &[id, ref] : containers) {
@@ -36,8 +17,8 @@ void linyaps_box::command::kill(const struct kill_options &options)
             continue;
         }
 
-        ref.kill(sig);
-        return;
+        ref.kill(options.signal);
+        return 0;
     }
 
     throw std::runtime_error("container not found");

--- a/src/linyaps_box/command/kill.h
+++ b/src/linyaps_box/command/kill.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -8,6 +8,6 @@
 
 namespace linyaps_box::command {
 
-void kill(const kill_options &options);
+[[nodiscard]] auto kill(const kill_options &options, const global_options &global) -> int;
 
 } // namespace linyaps_box::command

--- a/src/linyaps_box/command/list.cpp
+++ b/src/linyaps_box/command/list.cpp
@@ -9,9 +9,9 @@
 #include "linyaps_box/runtime.h"
 #include "linyaps_box/status_directory_manager.h"
 
-void linyaps_box::command::list(const struct list_options &options)
+auto linyaps_box::command::list(const list_options &options, const global_options &global) -> int
 {
-    status_directory_manager mgr(options.global_.get().root);
+    status_directory_manager mgr(global.root);
     runtime_t runtime(std::move(mgr));
 
     std::unique_ptr<printer> printer;
@@ -21,7 +21,7 @@ void linyaps_box::command::list(const struct list_options &options)
         printer = std::make_unique<impl::table_printer>();
     }
 
-    auto containers = runtime.containers();
+    const auto &containers = runtime.containers();
     std::vector<container_status_t> statuses;
     statuses.reserve(containers.size());
     for (const auto &[_, container] : containers) {
@@ -29,4 +29,6 @@ void linyaps_box::command::list(const struct list_options &options)
     }
 
     printer->print_statuses(statuses);
+
+    return 0;
 }

--- a/src/linyaps_box/command/list.h
+++ b/src/linyaps_box/command/list.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -8,6 +8,6 @@
 
 namespace linyaps_box::command {
 
-void list(const list_options &options);
+[[nodiscard]] auto list(const list_options &options, const global_options &global) -> int;
 
 } // namespace linyaps_box::command

--- a/src/linyaps_box/command/options.cpp
+++ b/src/linyaps_box/command/options.cpp
@@ -6,163 +6,291 @@
 
 #include "linyaps_box/config.h"
 #include "linyaps_box/utils/file.h"
+#include "linyaps_box/utils/platform.h"
 #include "linyaps_box/version.h"
 
 #include <CLI/CLI.hpp>
 
+#include <array>
+#include <charconv>
+#include <csignal>
+
 #include <unistd.h>
 
-linyaps_box::command::options linyaps_box::command::parse(int argc, char *argv[]) // NOLINT
+namespace {
+
+auto socket_check(const std::string &str) noexcept -> std::string
 {
-    CLI::App app{ "A simple OCI runtime implementation focused on desktop applications.",
-                  "ll-box" };
-    app.set_version_flag("-v,--version", [] {
-        std::stringstream ss;
-        ss << "ll-box version " << LINYAPS_BOX_VERSION << "\n";
-        ss << "spec " << linyaps_box::Config::oci_version;
-        return ss.str();
-    });
-    app.require_subcommand();
-
-    linyaps_box::command::options options;
-
-    std::filesystem::path default_root;
-    if (auto *env = getenv("XDG_RUNTIME_DIR"); env != nullptr) {
-        default_root = std::filesystem::path{ env } / "linglong" / "box";
-    } else {
-        default_root = std::filesystem::current_path().root_path() / "run" / "user"
-          / std::to_string(geteuid()) / "linglong" / "box";
+    try {
+        auto ret = linyaps_box::utils::lstat(str);
+        if (!linyaps_box::utils::is_type(ret.st_mode, std::filesystem::file_type::socket)) {
+            return "console-socket must be an existing socket file";
+        }
+    } catch (const std::system_error &e) {
+        return e.what();
     }
 
-    app.add_option("--root", options.global.root, "Root directory for storage of container state")
-      ->default_val(default_root);
-    app.add_option("--cgroup-manager", options.global.manager, "Cgroup manager to use")
-      ->type_name("MANAGER")
-      ->transform(CLI::CheckedTransformer(std::unordered_map<std::string_view, cgroup_manager_t>{
-        { "cgroupfs", cgroup_manager_t::cgroupfs },
-        { "systemd", cgroup_manager_t::systemd },
-        { "disabled", cgroup_manager_t::disabled },
-      }))
-      ->default_val(cgroup_manager_t::disabled);
+    return "";
+};
 
-    list_options list_opt{ options.global };
-    auto *cmd_list = app.add_subcommand("list", "List know containers");
-    cmd_list->add_option("-f,--format", list_opt.output_format, "Specify the output format")
-      ->type_name("FORMAT")
-      ->transform(
-        CLI::CheckedTransformer(std::unordered_map<std::string_view, list_options::output_format_t>{
-          { "json", list_options::output_format_t::json },
-          { "table", list_options::output_format_t::table },
-        }))
-      ->default_val(list_options::output_format_t::table);
+auto default_root_path() -> std::filesystem::path
+{
+    static const auto default_root = [] {
+        if (auto *env = ::getenv("XDG_RUNTIME_DIR"); env != nullptr) {
+            return std::filesystem::path{ env } / "linglong" / "box";
+        }
+        return std::filesystem::path("/run/user") / std::to_string(geteuid()) / "linglong" / "box";
+    }();
+    return default_root;
+}
 
-    run_options run_opt{ options.global };
-    auto *cmd_run = app.add_subcommand("run", "Create and immediately start a container");
-    cmd_run->add_option("CONTAINER", run_opt.ID, "The container ID")->required();
-    cmd_run->add_option("-b,--bundle", run_opt.bundle, "Path to the OCI bundle")->default_val(".");
-    cmd_run->add_option("-f,--config", run_opt.config, "Override the configuration file to use")
-      ->default_val("config.json");
-    cmd_run
-      ->add_option("--preserve-fds",
-                   run_opt.preserve_fds,
-                   "Pass N additional file descriptors to the container")
+template <typename T>
+auto add_console_socket(CLI::App *cmd, T &opt) -> CLI::Option *
+{
+    return cmd
+      ->add_option("--console-socket",
+                   opt,
+                   "Path to an unix socket that will receive the master end of the console's "
+                   "pseudoterminal")
+      ->type_name("SOCKET")
+      ->check(socket_check, "must be an existing socket file");
+}
+
+template <typename T>
+auto add_preserve_fds(CLI::App *cmd, T &opt) -> CLI::Option *
+{
+    return cmd
+      ->add_option("--preserve-fds", opt, "Pass N additional file descriptors to the container")
+      ->type_name("N")
+      ->check(CLI::NonNegativeNumber)
       ->default_val(0);
+}
 
-    auto socket_check = [](const std::string &str) {
-        try {
-            auto ret = utils::lstat(str);
-            if (!utils::is_type(ret.st_mode, std::filesystem::file_type::socket)) {
-                return "console-socket must be a socket";
+auto register_global(CLI::App &app, linyaps_box::command::global_options &opts) -> void
+{
+    app.add_option("--root", opts.root, "Root directory for storage of container state")
+      ->default_val(default_root_path());
+    static constexpr std::array cgroup_managers{
+        std::pair{ "cgroupfs", linyaps_box::cgroup_manager_t::cgroupfs },
+        std::pair{ "systemd", linyaps_box::cgroup_manager_t::systemd },
+        std::pair{ "disabled", linyaps_box::cgroup_manager_t::disabled },
+    };
+    app.add_option("--cgroup-manager", opts.manager, "Cgroup manager to use")
+      ->type_name("MANAGER")
+      ->transform(CLI::CheckedTransformer(cgroup_managers))
+      ->default_val(linyaps_box::cgroup_manager_t::disabled);
+}
+
+auto register_list(CLI::App &app, linyaps_box::command::list_options &opts) -> CLI::App *
+{
+    auto *cmd = app.add_subcommand("list", "List known containers");
+    static constexpr std::array format_map{
+        std::pair{ "json", linyaps_box::command::list_options::output_format_t::json },
+        std::pair{ "table", linyaps_box::command::list_options::output_format_t::table },
+    };
+    cmd->add_option("-f,--format", opts.output_format, "Specify the output format")
+      ->type_name("FORMAT")
+      ->transform(CLI::CheckedTransformer(format_map))
+      ->default_val(linyaps_box::command::list_options::output_format_t::table);
+    return cmd;
+}
+
+auto register_run(CLI::App &app, linyaps_box::command::run_options &opts) -> CLI::App *
+{
+    auto *cmd = app.add_subcommand("run", "Create and immediately start a container");
+    cmd->add_option("CONTAINER", opts.ID, "The container ID")->required();
+    cmd->add_option("-b,--bundle", opts.bundle, "Path to the OCI bundle")
+      ->default_val(".")
+      ->check(CLI::ExistingDirectory);
+    cmd->add_option("-f,--config", opts.config, "Override the configuration file to use")
+      ->type_name("FILE")
+      ->default_val("config.json");
+    add_preserve_fds(cmd, opts.preserve_fds);
+    add_console_socket(cmd, opts.console_socket);
+    return cmd;
+}
+
+auto register_exec(CLI::App &app, linyaps_box::command::exec_options &opts) -> CLI::App *
+{
+    auto *cmd =
+      app.add_subcommand("exec", "Exec a command in a running container")->positionals_at_end();
+    cmd
+      ->add_option_function<std::string>(
+        "-u,--user",
+        [&opts](const std::string &value) {
+            linyaps_box::command::user_spec spec{ };
+            auto colon = value.find(':');
+            auto uid_len = colon == std::string::npos ? value.size() : colon;
+
+            auto [uid_ptr, uid_ec] =
+              std::from_chars(value.data(), value.data() + uid_len, spec.uid);
+            if (uid_ec != std::errc{ } || uid_ptr != value.data() + uid_len) {
+                throw CLI::ValidationError("--user",
+                                           "invalid UID:" + std::make_error_code(uid_ec).message());
             }
-        } catch (const std::system_error &e) {
-            return e.what();
+
+            if (colon != std::string::npos) {
+                auto [gid_ptr, gid_ec] =
+                  std::from_chars(value.data() + colon + 1, value.data() + value.size(), spec.gid);
+                if (gid_ec != std::errc{ } || gid_ptr != value.data() + value.size()) {
+                    throw CLI::ValidationError("--user",
+                                               "invalid GID: "
+                                                 + std::make_error_code(gid_ec).message());
+                }
+            } else {
+                spec.gid = spec.uid;
+            }
+
+            opts.user = spec;
+        },
+        "Specify the user, "
+        "for example `1000` for UID=1000 "
+        "or `1000:1000` for UID=1000 and GID=1000")
+      ->type_name("UID[:GID]");
+    cmd->add_option("--cwd", opts.cwd, "Current working directory.")->type_name("PATH");
+    cmd
+      ->add_option("-e,--env",
+                   opts.envs,
+                   "Environment variables to set, use -e KEY=VALUE -e KEY2=VALUE2 for multiple")
+      ->type_name("ENV")
+      ->check(
+        [](const std::string &str) noexcept -> std::string {
+            return linyaps_box::utils::is_invalid_env(str) ? "invalid env: " + str : "";
+        },
+        "check environment variables is valid or not");
+    add_console_socket(cmd, opts.console_socket);
+    cmd->add_flag("-t,--tty", opts.tty, "Allocate a pseudo-TTY");
+    add_preserve_fds(cmd, opts.preserve_fds);
+
+#ifdef LINYAPS_BOX_ENABLE_CAP
+    cmd->add_option("-c,--cap", opts.caps, "Set capabilities")
+      ->type_name("CAP")
+      ->transform([](const std::string &str) -> std::string {
+          cap_value_t val{ };
+          if (cap_from_name(str.c_str(), &val) < 0) {
+              throw CLI::ValidationError("--cap", "invalid capability: " + str);
+          }
+          return std::to_string(val);
+      });
+#endif
+    cmd->add_flag("--no-new-privs",
+                  opts.no_new_privs,
+                  "Set the no new privileges value for the process");
+    cmd->add_option("-p,--process", opts.process_file, "Path to the process.json file to use")
+      ->type_name("FILE")
+      ->check(CLI::ExistingFile);
+    cmd->add_option("CONTAINER", opts.ID, "Container ID")->required();
+    cmd->add_option("COMMAND", opts.command, "Command to execute");
+    cmd->callback([&opts]() {
+        if (opts.command.empty() && !opts.process_file) {
+            throw CLI::ValidationError("At least one of COMMAND or --process must be provided");
+        }
+    });
+    return cmd;
+}
+
+auto register_kill(CLI::App &app, linyaps_box::command::kill_options &opts) -> CLI::App *
+{
+    auto *cmd =
+      app.add_subcommand("kill", "Send the specified signal to the container init process");
+    cmd->add_option("CONTAINER", opts.container, "The container ID")->required();
+    cmd->add_option("SIGNAL", opts.signal, "Signal to send")
+      ->transform([](const std::string &str) -> std::string {
+          int sig{ };
+          auto [ptr, ec] = std::from_chars(str.data(), str.data() + str.size(), sig);
+          if (ec == std::errc{ } && ptr == str.data() + str.size()) {
+              if (sig < 0 || sig >= NSIG) {
+                  throw CLI::ValidationError("SIGNAL", "signal number out of range: " + str);
+              }
+
+              return str;
+          }
+
+          try {
+              return std::to_string(linyaps_box::utils::str_to_signal(str));
+          } catch (const std::invalid_argument &) {
+              throw CLI::ValidationError("SIGNAL", "invalid signal: " + str);
+          }
+      })
+      ->default_val(SIGTERM);
+    return cmd;
+}
+
+} // namespace
+
+namespace {
+
+struct cli_app_data
+{
+    cli_app_data()
+        : app("A simple OCI runtime implementation focused on desktop applications.", "ll-box")
+    {
+    }
+
+    CLI::App app;
+    linyaps_box::command::global_options global;
+    linyaps_box::command::list_options list_opts;
+    linyaps_box::command::run_options run_opts;
+    linyaps_box::command::exec_options exec_opts;
+    linyaps_box::command::kill_options kill_opts;
+    CLI::App *cmd_list{ nullptr };
+    CLI::App *cmd_run{ nullptr };
+    CLI::App *cmd_exec{ nullptr };
+    CLI::App *cmd_kill{ nullptr };
+};
+
+void build_cli_app(cli_app_data &data)
+{
+    data.app.set_version_flag("-v,--version", [] {
+        return std::string("ll-box version ") + LINYAPS_BOX_VERSION + "\nspec "
+          + linyaps_box::oci_config::version + "\n";
+    });
+    data.app.require_subcommand(1);
+
+    register_global(data.app, data.global);
+    data.cmd_list = register_list(data.app, data.list_opts);
+    data.cmd_run = register_run(data.app, data.run_opts);
+    data.cmd_exec = register_exec(data.app, data.exec_opts);
+    data.cmd_kill = register_kill(data.app, data.kill_opts);
+}
+
+void run_parse(CLI::App &app, int argc, char **argv)
+{
+    argv = app.ensure_utf8(argv);
+    app.parse(argc, argv);
+}
+
+auto convert_result(cli_app_data &data) -> linyaps_box::command::options
+{
+    linyaps_box::command::options opts{ std::move(data.global), std::monostate{ } };
+    if (data.cmd_list->parsed()) {
+        opts.subcommand_opt = data.list_opts;
+    } else if (data.cmd_run->parsed()) {
+        opts.subcommand_opt = std::move(data.run_opts);
+    } else if (data.cmd_exec->parsed()) {
+        opts.subcommand_opt = std::move(data.exec_opts);
+    } else if (data.cmd_kill->parsed()) {
+        opts.subcommand_opt = std::move(data.kill_opts);
+    }
+    return opts;
+}
+
+} // namespace
+
+auto linyaps_box::command::parse(int argc, char **argv) -> std::optional<options>
+{
+    cli_app_data data;
+    build_cli_app(data);
+    try {
+        run_parse(data.app, argc, argv);
+    } catch (const CLI::ParseError &e) {
+        auto code = data.app.exit(e);
+        if (code != 0) {
+            return std::nullopt;
         }
 
-        return "";
-    };
-
-    cmd_run
-      ->add_option("--console-socket",
-                   run_opt.console_socket,
-                   "Path to an unix socket that will receive the master end of the console's "
-                   "pseudoterminal")
-      ->type_name("SOCKET")
-      ->check(socket_check);
-
-    exec_options exec_opt{ options.global };
-    auto *cmd_exec =
-      app.add_subcommand("exec", "Exec a command in a running container")->positionals_at_end();
-    cmd_exec
-      ->add_option("-u,--user",
-                   exec_opt.user,
-                   "Specify the user, "
-                   "for example `1000` for UID=1000 "
-                   "or `1000:1000` for UID=1000 and GID=1000")
-      ->type_name("UID[:GID]");
-    cmd_exec->add_option("--cwd", exec_opt.cwd, "Current working directory.")->type_name("PATH");
-    cmd_exec->add_option("--env", exec_opt.envs, "Environment variables to set")
-      ->type_name("ENV")
-      ->take_all()
-      ->check([](const std::string &str) {
-          if (str.find('=') == std::string::npos) {
-              return "invalid argument, env must be in the format of KEY=VALUE";
-          }
-          return "";
-      });
-    cmd_exec
-      ->add_option("--console-socket",
-                   exec_opt.console_socket,
-                   "Path to an unix socket that will receive the master end of the console's "
-                   "pseudoterminal")
-      ->type_name("SOCKET")
-      ->check(socket_check);
-    cmd_exec->add_flag("-t,--tty", exec_opt.tty, "Allocate a pseudo-TTY")->take_last();
-    cmd_exec
-      ->add_option("--preserve-fds",
-                   exec_opt.preserve_fds,
-                   "Pass N additional file descriptors to the container")
-      ->type_name("N");
-    // TODO: enable capabilities and no_new_privs support after rewrite exec,
-    //      cmd_exec->add_option("-c,--cap", options.exec.caps, "Set capabilities")
-    //              ->check(
-    //                      [](const std::string &val) -> std::string {
-    //                          if (val.rfind("CAP_", 0) != std::string::npos) {
-    //                              return "";
-    //                          }
-
-    //                         return "invalid argument, capability must start with CAP_";
-    //                     },
-    //                     "cap_check");
-    //     cmd_exec->add_flag("--no-new-privs",
-    //                        options.exec.no_new_privs,
-    //                        "Set the no new privileges value for the process")
-    //             ->default_val(false);
-    cmd_exec->add_option("CONTAINER", exec_opt.ID, "Container ID")->required();
-    cmd_exec->add_option("COMMAND", exec_opt.command, "Command to execute")->required();
-
-    kill_options kill_opt{ options.global };
-    auto *cmd_kill =
-      app.add_subcommand("kill", "Send the specified signal to the container init process");
-    cmd_kill->add_option("CONTAINER", kill_opt.container, "The container ID")->required();
-    cmd_kill->add_option("SIGNAL", kill_opt.signal, "Signal to send")->default_val("SIGTERM");
-
-    argv = app.ensure_utf8(argv);
-    try {
-        app.parse(argc, argv);
-    } catch (const CLI::ParseError &e) {
-        options.global.return_code = app.exit(e);
-        return options;
+        std::exit(EXIT_SUCCESS);
     }
 
-    if (cmd_list->parsed()) {
-        options.subcommand_opt = list_opt;
-    } else if (cmd_run->parsed()) {
-        options.subcommand_opt = std::move(run_opt);
-    } else if (cmd_exec->parsed()) {
-        options.subcommand_opt = std::move(exec_opt);
-    } else if (cmd_kill->parsed()) {
-        options.subcommand_opt = std::move(kill_opt);
-    }
-
-    return options;
+    return convert_result(data);
 }

--- a/src/linyaps_box/command/options.h
+++ b/src/linyaps_box/command/options.h
@@ -6,10 +6,17 @@
 
 #include <linyaps_box/cgroup_manager.h>
 
+#include <cstdint>
 #include <filesystem>
 #include <optional>
 #include <variant>
 #include <vector>
+
+#include <sys/types.h>
+
+#ifdef LINYAPS_BOX_ENABLE_CAP
+#  include <sys/capability.h>
+#endif
 
 namespace linyaps_box::command {
 
@@ -17,76 +24,55 @@ struct global_options
 {
     cgroup_manager_t manager{ cgroup_manager_t::disabled };
     std::filesystem::path root;
-    int return_code{ 0 };
 };
 
 struct list_options
 {
     enum class output_format_t : std::uint8_t { table, json };
 
-    explicit list_options(global_options &global)
-        : global_(global)
-    {
-    }
-
     output_format_t output_format{ output_format_t::table };
-    std::reference_wrapper<global_options> global_;
+};
+
+struct user_spec
+{
+    uid_t uid{ };
+    gid_t gid{ };
 };
 
 struct exec_options
 {
-    explicit exec_options(global_options &global)
-        : global_(global)
-    {
-    }
-
     bool no_new_privs{ false };
     bool tty{ false };
     int preserve_fds{ 0 };
-    std::reference_wrapper<global_options> global_;
     std::vector<std::string> command;
-    std::string user;
-    std::optional<std::vector<std::string>> caps;
+    std::optional<user_spec> user;
+#ifdef LINYAPS_BOX_ENABLE_CAP
+    std::optional<std::vector<cap_value_t>> caps;
+#endif
     std::string ID;
-    std::optional<std::string> cwd;
-    std::optional<std::vector<std::string>> envs;
-    std::optional<std::string> console_socket;
+    std::optional<std::filesystem::path> cwd;
+    std::vector<std::string> envs;
+    std::optional<std::filesystem::path> console_socket;
+    std::optional<std::filesystem::path> process_file;
 };
 
 struct run_options
 {
-    explicit run_options(global_options &global)
-        : global_(global)
-    {
-    }
-
-    std::reference_wrapper<global_options> global_;
     std::string ID;
-    std::string bundle;
-    std::string config;
-    std::optional<std::string> console_socket;
+    std::filesystem::path bundle;
+    std::filesystem::path config;
+    std::optional<std::filesystem::path> console_socket;
     int preserve_fds{ 0 };
 };
 
 struct kill_options
 {
-    explicit kill_options(global_options &global)
-        : global_(global)
-    {
-    }
-
-    std::reference_wrapper<global_options> global_;
     std::string container;
-    std::string signal;
+    int signal{ };
 };
 
 struct options
 {
-    options()
-        : global()
-    {
-    }
-
     using subcommand_opt_t =
       std::variant<std::monostate, list_options, exec_options, run_options, kill_options>;
 
@@ -94,8 +80,6 @@ struct options
     subcommand_opt_t subcommand_opt;
 };
 
-// This function parses the command line arguments.
-// It might print help or usage to stdout or stderr.
-options parse(int argc, char *argv[]); // NOLINT
+auto parse(int argc, char *argv[]) -> std::optional<options>;
 
 } // namespace linyaps_box::command

--- a/src/linyaps_box/command/run.cpp
+++ b/src/linyaps_box/command/run.cpp
@@ -8,11 +8,12 @@
 #include "linyaps_box/status_directory_manager.h"
 #include "linyaps_box/utils/utils.h"
 
-auto linyaps_box::command::run(const struct run_options &options) -> int
+auto linyaps_box::command::run(const struct run_options &options, const global_options &global)
+  -> int
 {
-    status_directory_manager mgr(options.global_.get().root);
+    status_directory_manager mgr(global.root);
     runtime_t runtime(std::move(mgr));
-    const create_container_options_t create_container_options{ options.global_.get().manager,
+    const create_container_options_t create_container_options{ global.manager,
                                                                options.ID,
                                                                options.bundle,
                                                                options.config };
@@ -27,7 +28,7 @@ auto linyaps_box::command::run(const struct run_options &options) -> int
     }
 
     if (container.get_config().process->terminal && options.console_socket) {
-        run_options.console_socket = unix_socket::connect(options.console_socket.value());
+        run_options.console_socket = unix_socket::connect(*options.console_socket);
     }
 
     return container.run(std::move(run_options));

--- a/src/linyaps_box/command/run.h
+++ b/src/linyaps_box/command/run.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -8,6 +8,6 @@
 
 namespace linyaps_box::command {
 
-[[nodiscard]] auto run(const run_options &options) -> int;
+[[nodiscard]] auto run(const run_options &options, const global_options &global) -> int;
 
 } // namespace linyaps_box::command

--- a/src/linyaps_box/config.cpp
+++ b/src/linyaps_box/config.cpp
@@ -6,9 +6,11 @@
 
 #include "linyaps_box/config/mount_options.h"
 #include "linyaps_box/utils/enum_traits.h"
+#include "linyaps_box/utils/platform.h"
 #include "linyaps_box/utils/semver.h"
 #include "linyaps_box/utils/utils.h"
-#include "nlohmann/json.hpp"
+
+#include <nlohmann/json.hpp>
 
 #include <bitset>
 #include <fstream>
@@ -35,130 +37,137 @@ namespace {
 namespace mo = linyaps_box::config::mount_options;
 
 constexpr auto rlimit_type_table =
-  linyaps_box::utils::enum_table<linyaps_box::Config::process_t::rlimit_t::type_t, 16>{
-      { { { linyaps_box::Config::process_t::rlimit_t::type_t::AS, "RLIMIT_AS" },
-          { linyaps_box::Config::process_t::rlimit_t::type_t::CORE, "RLIMIT_CORE" },
-          { linyaps_box::Config::process_t::rlimit_t::type_t::CPU, "RLIMIT_CPU" },
-          { linyaps_box::Config::process_t::rlimit_t::type_t::DATA, "RLIMIT_DATA" },
-          { linyaps_box::Config::process_t::rlimit_t::type_t::FSIZE, "RLIMIT_FSIZE" },
-          { linyaps_box::Config::process_t::rlimit_t::type_t::LOCKS, "RLIMIT_LOCKS" },
-          { linyaps_box::Config::process_t::rlimit_t::type_t::MEMLOCK, "RLIMIT_MEMLOCK" },
-          { linyaps_box::Config::process_t::rlimit_t::type_t::MSGQUEUE, "RLIMIT_MSGQUEUE" },
-          { linyaps_box::Config::process_t::rlimit_t::type_t::NICE, "RLIMIT_NICE" },
-          { linyaps_box::Config::process_t::rlimit_t::type_t::NOFILE, "RLIMIT_NOFILE" },
-          { linyaps_box::Config::process_t::rlimit_t::type_t::NPROC, "RLIMIT_NPROC" },
-          { linyaps_box::Config::process_t::rlimit_t::type_t::RSS, "RLIMIT_RSS" },
-          { linyaps_box::Config::process_t::rlimit_t::type_t::RTPRIO, "RLIMIT_RTPRIO" },
-          { linyaps_box::Config::process_t::rlimit_t::type_t::RTTIME, "RLIMIT_RTTIME" },
-          { linyaps_box::Config::process_t::rlimit_t::type_t::SIGPENDING, "RLIMIT_SIGPENDING" },
-          { linyaps_box::Config::process_t::rlimit_t::type_t::STACK, "RLIMIT_STACK" } } }
+  linyaps_box::utils::enum_table<linyaps_box::oci_config::process_t::rlimit_t::type_t, 16>{
+      { { { linyaps_box::oci_config::process_t::rlimit_t::type_t::AS, "RLIMIT_AS" },
+          { linyaps_box::oci_config::process_t::rlimit_t::type_t::CORE, "RLIMIT_CORE" },
+          { linyaps_box::oci_config::process_t::rlimit_t::type_t::CPU, "RLIMIT_CPU" },
+          { linyaps_box::oci_config::process_t::rlimit_t::type_t::DATA, "RLIMIT_DATA" },
+          { linyaps_box::oci_config::process_t::rlimit_t::type_t::FSIZE, "RLIMIT_FSIZE" },
+          { linyaps_box::oci_config::process_t::rlimit_t::type_t::LOCKS, "RLIMIT_LOCKS" },
+          { linyaps_box::oci_config::process_t::rlimit_t::type_t::MEMLOCK, "RLIMIT_MEMLOCK" },
+          { linyaps_box::oci_config::process_t::rlimit_t::type_t::MSGQUEUE, "RLIMIT_MSGQUEUE" },
+          { linyaps_box::oci_config::process_t::rlimit_t::type_t::NICE, "RLIMIT_NICE" },
+          { linyaps_box::oci_config::process_t::rlimit_t::type_t::NOFILE, "RLIMIT_NOFILE" },
+          { linyaps_box::oci_config::process_t::rlimit_t::type_t::NPROC, "RLIMIT_NPROC" },
+          { linyaps_box::oci_config::process_t::rlimit_t::type_t::RSS, "RLIMIT_RSS" },
+          { linyaps_box::oci_config::process_t::rlimit_t::type_t::RTPRIO, "RLIMIT_RTPRIO" },
+          { linyaps_box::oci_config::process_t::rlimit_t::type_t::RTTIME, "RLIMIT_RTTIME" },
+          { linyaps_box::oci_config::process_t::rlimit_t::type_t::SIGPENDING, "RLIMIT_SIGPENDING" },
+          { linyaps_box::oci_config::process_t::rlimit_t::type_t::STACK, "RLIMIT_STACK" } } }
   };
 
 static_assert(linyaps_box::utils::verify_enum_table(rlimit_type_table));
 
 constexpr auto scheduler_policy_table =
-  linyaps_box::utils::enum_table<linyaps_box::Config::process_t::scheduler_t::policy_t, 7>{
-      { { { linyaps_box::Config::process_t::scheduler_t::policy_t::OTHER, "SCHED_OTHER" },
-          { linyaps_box::Config::process_t::scheduler_t::policy_t::FIFO, "SCHED_FIFO" },
-          { linyaps_box::Config::process_t::scheduler_t::policy_t::RR, "SCHED_RR" },
-          { linyaps_box::Config::process_t::scheduler_t::policy_t::BATCH, "SCHED_BATCH" },
-          { linyaps_box::Config::process_t::scheduler_t::policy_t::ISO, "SCHED_ISO" },
-          { linyaps_box::Config::process_t::scheduler_t::policy_t::IDLE, "SCHED_IDLE" },
-          { linyaps_box::Config::process_t::scheduler_t::policy_t::DEADLINE, "SCHED_DEADLINE" } } }
+  linyaps_box::utils::enum_table<linyaps_box::oci_config::process_t::scheduler_t::policy_t, 7>{
+      { { { linyaps_box::oci_config::process_t::scheduler_t::policy_t::OTHER, "SCHED_OTHER" },
+          { linyaps_box::oci_config::process_t::scheduler_t::policy_t::FIFO, "SCHED_FIFO" },
+          { linyaps_box::oci_config::process_t::scheduler_t::policy_t::RR, "SCHED_RR" },
+          { linyaps_box::oci_config::process_t::scheduler_t::policy_t::BATCH, "SCHED_BATCH" },
+          { linyaps_box::oci_config::process_t::scheduler_t::policy_t::ISO, "SCHED_ISO" },
+          { linyaps_box::oci_config::process_t::scheduler_t::policy_t::IDLE, "SCHED_IDLE" },
+          { linyaps_box::oci_config::process_t::scheduler_t::policy_t::DEADLINE,
+            "SCHED_DEADLINE" } } }
   };
 
 static_assert(linyaps_box::utils::verify_enum_table(scheduler_policy_table));
 
 constexpr auto scheduler_flag_table =
-  linyaps_box::utils::enum_table<linyaps_box::Config::process_t::scheduler_t::flag_t, 7>{ { {
-    { linyaps_box::Config::process_t::scheduler_t::flag_t::RESET_ON_FORK,
+  linyaps_box::utils::enum_table<linyaps_box::oci_config::process_t::scheduler_t::flag_t, 7>{ { {
+    { linyaps_box::oci_config::process_t::scheduler_t::flag_t::RESET_ON_FORK,
       "SCHED_FLAG_RESET_ON_FORK" },
-    { linyaps_box::Config::process_t::scheduler_t::flag_t::RECLAIM, "SCHED_FLAG_RECLAIM" },
-    { linyaps_box::Config::process_t::scheduler_t::flag_t::DL_OVERRUN, "SCHED_FLAG_DL_OVERRUN" },
-    { linyaps_box::Config::process_t::scheduler_t::flag_t::KEEP_POLICY, "SCHED_FLAG_KEEP_POLICY" },
-    { linyaps_box::Config::process_t::scheduler_t::flag_t::KEEP_PARAMS, "SCHED_FLAG_KEEP_PARAMS" },
-    { linyaps_box::Config::process_t::scheduler_t::flag_t::UTIL_CLAMP_MIN,
+    { linyaps_box::oci_config::process_t::scheduler_t::flag_t::RECLAIM, "SCHED_FLAG_RECLAIM" },
+    { linyaps_box::oci_config::process_t::scheduler_t::flag_t::DL_OVERRUN,
+      "SCHED_FLAG_DL_OVERRUN" },
+    { linyaps_box::oci_config::process_t::scheduler_t::flag_t::KEEP_POLICY,
+      "SCHED_FLAG_KEEP_POLICY" },
+    { linyaps_box::oci_config::process_t::scheduler_t::flag_t::KEEP_PARAMS,
+      "SCHED_FLAG_KEEP_PARAMS" },
+    { linyaps_box::oci_config::process_t::scheduler_t::flag_t::UTIL_CLAMP_MIN,
       "SCHED_FLAG_UTIL_CLAMP_MIN" },
-    { linyaps_box::Config::process_t::scheduler_t::flag_t::UTIL_CLAMP_MAX,
+    { linyaps_box::oci_config::process_t::scheduler_t::flag_t::UTIL_CLAMP_MAX,
       "SCHED_FLAG_UTIL_CLAMP_MAX" },
   } } };
 
 static_assert(linyaps_box::utils::verify_enum_table(scheduler_flag_table));
 
 constexpr auto io_priority_class_table =
-  linyaps_box::utils::enum_table<linyaps_box::Config::process_t::io_priority_t::class_t, 3>{
-      { { { linyaps_box::Config::process_t::io_priority_t::class_t::RT, "IOPRIO_CLASS_RT" },
-          { linyaps_box::Config::process_t::io_priority_t::class_t::BEST_EFFORT,
+  linyaps_box::utils::enum_table<linyaps_box::oci_config::process_t::io_priority_t::class_t, 3>{
+      { { { linyaps_box::oci_config::process_t::io_priority_t::class_t::RT, "IOPRIO_CLASS_RT" },
+          { linyaps_box::oci_config::process_t::io_priority_t::class_t::BEST_EFFORT,
             "IOPRIO_CLASS_BE" },
-          { linyaps_box::Config::process_t::io_priority_t::class_t::IDLE, "IOPRIO_CLASS_IDLE" } } }
+          { linyaps_box::oci_config::process_t::io_priority_t::class_t::IDLE,
+            "IOPRIO_CLASS_IDLE" } } }
   };
 
 static_assert(linyaps_box::utils::verify_enum_table(io_priority_class_table));
 
 constexpr auto personality_domain_table =
-  linyaps_box::utils::enum_table<linyaps_box::Config::linux_t::personality_t::domain_t, 2>{
-      { { { linyaps_box::Config::linux_t::personality_t::domain_t::LINUX, "LINUX" },
-          { linyaps_box::Config::linux_t::personality_t::domain_t::LINUX32, "LINUX32" } } }
+  linyaps_box::utils::enum_table<linyaps_box::oci_config::linux_t::personality_t::domain_t, 2>{
+      { { { linyaps_box::oci_config::linux_t::personality_t::domain_t::LINUX, "LINUX" },
+          { linyaps_box::oci_config::linux_t::personality_t::domain_t::LINUX32, "LINUX32" } } }
   };
 
 static_assert(linyaps_box::utils::verify_enum_table(personality_domain_table));
 
 constexpr auto memory_policy_mode_table =
-  linyaps_box::utils::enum_table<linyaps_box::Config::linux_t::memory_policy_t::mode_t, 7>{
-      { { { linyaps_box::Config::linux_t::memory_policy_t::mode_t::DEFAULT, "MPOL_DEFAULT" },
-          { linyaps_box::Config::linux_t::memory_policy_t::mode_t::BIND, "MPOL_BIND" },
-          { linyaps_box::Config::linux_t::memory_policy_t::mode_t::INTERLEAVE, "MPOL_INTERLEAVE" },
-          { linyaps_box::Config::linux_t::memory_policy_t::mode_t::WEIGHTED_INTERLEAVE,
+  linyaps_box::utils::enum_table<linyaps_box::oci_config::linux_t::memory_policy_t::mode_t, 7>{
+      { { { linyaps_box::oci_config::linux_t::memory_policy_t::mode_t::DEFAULT, "MPOL_DEFAULT" },
+          { linyaps_box::oci_config::linux_t::memory_policy_t::mode_t::BIND, "MPOL_BIND" },
+          { linyaps_box::oci_config::linux_t::memory_policy_t::mode_t::INTERLEAVE,
+            "MPOL_INTERLEAVE" },
+          { linyaps_box::oci_config::linux_t::memory_policy_t::mode_t::WEIGHTED_INTERLEAVE,
             "MPOL_WEIGHTED_INTERLEAVE" },
-          { linyaps_box::Config::linux_t::memory_policy_t::mode_t::PREFERRED, "MPOL_PREFERRED" },
-          { linyaps_box::Config::linux_t::memory_policy_t::mode_t::PREFERRED_MANY,
+          { linyaps_box::oci_config::linux_t::memory_policy_t::mode_t::PREFERRED,
+            "MPOL_PREFERRED" },
+          { linyaps_box::oci_config::linux_t::memory_policy_t::mode_t::PREFERRED_MANY,
             "MPOL_PREFERRED_MANY" },
-          { linyaps_box::Config::linux_t::memory_policy_t::mode_t::LOCAL, "MPOL_LOCAL" } } }
+          { linyaps_box::oci_config::linux_t::memory_policy_t::mode_t::LOCAL, "MPOL_LOCAL" } } }
   };
 
 static_assert(linyaps_box::utils::verify_enum_table(memory_policy_mode_table));
 
 constexpr auto memory_policy_flag_table =
-  linyaps_box::utils::enum_table<linyaps_box::Config::linux_t::memory_policy_t::flag_t, 3>{
-      { { { linyaps_box::Config::linux_t::memory_policy_t::flag_t::NUMA_BALANCING,
+  linyaps_box::utils::enum_table<linyaps_box::oci_config::linux_t::memory_policy_t::flag_t, 3>{
+      { { { linyaps_box::oci_config::linux_t::memory_policy_t::flag_t::NUMA_BALANCING,
             "MPOL_F_NUMA_BALANCING" },
-          { linyaps_box::Config::linux_t::memory_policy_t::flag_t::RELATIVE_NODES,
+          { linyaps_box::oci_config::linux_t::memory_policy_t::flag_t::RELATIVE_NODES,
             "MPOL_F_RELATIVE_NODES" },
-          { linyaps_box::Config::linux_t::memory_policy_t::flag_t::STATIC_NODES,
+          { linyaps_box::oci_config::linux_t::memory_policy_t::flag_t::STATIC_NODES,
             "MPOL_F_STATIC_NODES" } } }
   };
 
 static_assert(linyaps_box::utils::verify_enum_table(memory_policy_flag_table));
 
 #ifdef LINYAPS_BOX_ENABLE_SECCOMP
-constexpr auto seccomp_op_table =
-  linyaps_box::utils::enum_table<linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t,
-                                 7>{
-      { { { linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t::EQ, "SCMP_CMP_EQ" },
-          { linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t::NE, "SCMP_CMP_NE" },
-          { linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t::LT, "SCMP_CMP_LT" },
-          { linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t::LE, "SCMP_CMP_LE" },
-          { linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t::GT, "SCMP_CMP_GT" },
-          { linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t::GE, "SCMP_CMP_GE" },
-          { linyaps_box::Config::linux_t::seccomp_t::syscall_t::arg_t::op_t::MASKED_EQ,
-            "SCMP_CMP_MASKED_EQ" } } }
-  };
+constexpr auto seccomp_op_table = linyaps_box::utils::enum_table<
+  linyaps_box::oci_config::linux_t::seccomp_t::syscall_t::arg_t::op_t,
+  7>{
+    { { { linyaps_box::oci_config::linux_t::seccomp_t::syscall_t::arg_t::op_t::EQ, "SCMP_CMP_EQ" },
+        { linyaps_box::oci_config::linux_t::seccomp_t::syscall_t::arg_t::op_t::NE, "SCMP_CMP_NE" },
+        { linyaps_box::oci_config::linux_t::seccomp_t::syscall_t::arg_t::op_t::LT, "SCMP_CMP_LT" },
+        { linyaps_box::oci_config::linux_t::seccomp_t::syscall_t::arg_t::op_t::LE, "SCMP_CMP_LE" },
+        { linyaps_box::oci_config::linux_t::seccomp_t::syscall_t::arg_t::op_t::GT, "SCMP_CMP_GT" },
+        { linyaps_box::oci_config::linux_t::seccomp_t::syscall_t::arg_t::op_t::GE, "SCMP_CMP_GE" },
+        { linyaps_box::oci_config::linux_t::seccomp_t::syscall_t::arg_t::op_t::MASKED_EQ,
+          "SCMP_CMP_MASKED_EQ" } } }
+};
 
 static_assert(linyaps_box::utils::verify_enum_table(seccomp_op_table));
 
 constexpr auto seccomp_action_table =
-  linyaps_box::utils::enum_table<linyaps_box::Config::linux_t::seccomp_t::action_t, 9>{
-      { { { linyaps_box::Config::linux_t::seccomp_t::action_t::ALLOW, "SCMP_ACT_ALLOW" },
-          { linyaps_box::Config::linux_t::seccomp_t::action_t::ERRNO, "SCMP_ACT_ERRNO" },
-          { linyaps_box::Config::linux_t::seccomp_t::action_t::KILL, "SCMP_ACT_KILL" },
-          { linyaps_box::Config::linux_t::seccomp_t::action_t::KILL_PROCESS,
+  linyaps_box::utils::enum_table<linyaps_box::oci_config::linux_t::seccomp_t::action_t, 9>{
+      { { { linyaps_box::oci_config::linux_t::seccomp_t::action_t::ALLOW, "SCMP_ACT_ALLOW" },
+          { linyaps_box::oci_config::linux_t::seccomp_t::action_t::ERRNO, "SCMP_ACT_ERRNO" },
+          { linyaps_box::oci_config::linux_t::seccomp_t::action_t::KILL, "SCMP_ACT_KILL" },
+          { linyaps_box::oci_config::linux_t::seccomp_t::action_t::KILL_PROCESS,
             "SCMP_ACT_KILL_PROCESS" },
-          { linyaps_box::Config::linux_t::seccomp_t::action_t::KILL_THREAD,
+          { linyaps_box::oci_config::linux_t::seccomp_t::action_t::KILL_THREAD,
             "SCMP_ACT_KILL_THREAD" },
-          { linyaps_box::Config::linux_t::seccomp_t::action_t::LOG, "SCMP_ACT_LOG" },
-          { linyaps_box::Config::linux_t::seccomp_t::action_t::NOTIFY, "SCMP_ACT_NOTIFY" },
-          { linyaps_box::Config::linux_t::seccomp_t::action_t::TRACE, "SCMP_ACT_TRACE" },
-          { linyaps_box::Config::linux_t::seccomp_t::action_t::TRAP, "SCMP_ACT_TRAP" } } }
+          { linyaps_box::oci_config::linux_t::seccomp_t::action_t::LOG, "SCMP_ACT_LOG" },
+          { linyaps_box::oci_config::linux_t::seccomp_t::action_t::NOTIFY, "SCMP_ACT_NOTIFY" },
+          { linyaps_box::oci_config::linux_t::seccomp_t::action_t::TRACE, "SCMP_ACT_TRACE" },
+          { linyaps_box::oci_config::linux_t::seccomp_t::action_t::TRAP, "SCMP_ACT_TRAP" } } }
   };
 
 // SCMP_ACT_KILL is aliased to KILL_THREAD or KILL_PROCESS depending on the
@@ -181,12 +190,13 @@ static_assert(linyaps_box::utils::verify_enum_table(
   }));
 
 constexpr auto seccomp_flag_table =
-  linyaps_box::utils::enum_table<linyaps_box::Config::linux_t::seccomp_t::flag_t, 4>{
-      { { { linyaps_box::Config::linux_t::seccomp_t::flag_t::TSYNC, "SECCOMP_FILTER_FLAG_TSYNC" },
-          { linyaps_box::Config::linux_t::seccomp_t::flag_t::LOG, "SECCOMP_FILTER_FLAG_LOG" },
-          { linyaps_box::Config::linux_t::seccomp_t::flag_t::SPEC_ALLOW,
+  linyaps_box::utils::enum_table<linyaps_box::oci_config::linux_t::seccomp_t::flag_t, 4>{
+      { { { linyaps_box::oci_config::linux_t::seccomp_t::flag_t::TSYNC,
+            "SECCOMP_FILTER_FLAG_TSYNC" },
+          { linyaps_box::oci_config::linux_t::seccomp_t::flag_t::LOG, "SECCOMP_FILTER_FLAG_LOG" },
+          { linyaps_box::oci_config::linux_t::seccomp_t::flag_t::SPEC_ALLOW,
             "SECCOMP_FILTER_FLAG_SPEC_ALLOW" },
-          { linyaps_box::Config::linux_t::seccomp_t::flag_t::WAIT_KILLABLE_RECV,
+          { linyaps_box::oci_config::linux_t::seccomp_t::flag_t::WAIT_KILLABLE_RECV,
             "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV" } } }
   };
 
@@ -194,17 +204,17 @@ static_assert(linyaps_box::utils::verify_enum_table(seccomp_flag_table));
 #endif
 
 constexpr auto extra_flags_table =
-  linyaps_box::utils::enum_table<linyaps_box::Config::mount_t::extension, 2>{
-      { { { linyaps_box::Config::mount_t::extension::COPY_SYMLINK, "copy-symlink" },
-          { linyaps_box::Config::mount_t::extension::TMPCOPYUP, "tmpcopyup" } } }
+  linyaps_box::utils::enum_table<linyaps_box::oci_config::mount_t::extension, 2>{
+      { { { linyaps_box::oci_config::mount_t::extension::COPY_SYMLINK, "copy-symlink" },
+          { linyaps_box::oci_config::mount_t::extension::TMPCOPYUP, "tmpcopyup" } } }
   };
 
 static_assert(linyaps_box::utils::verify_enum_table(extra_flags_table));
 
 constexpr auto idmap_options_table =
-  linyaps_box::utils::enum_table<linyaps_box::Config::mount_t::idmap_type, 2>{
-      { { { linyaps_box::Config::mount_t::idmap_type::IDMAP, "idmap" },
-          { linyaps_box::Config::mount_t::idmap_type::RIDMAP, "ridmap" } } }
+  linyaps_box::utils::enum_table<linyaps_box::oci_config::mount_t::idmap_type, 2>{
+      { { { linyaps_box::oci_config::mount_t::idmap_type::IDMAP, "idmap" },
+          { linyaps_box::oci_config::mount_t::idmap_type::RIDMAP, "ridmap" } } }
   };
 
 static_assert(linyaps_box::utils::verify_enum_table(idmap_options_table));
@@ -212,18 +222,18 @@ static_assert(linyaps_box::utils::verify_enum_table(idmap_options_table));
 auto parse_mount_options(const std::vector<std::string> &options)
   -> std::tuple<unsigned long,
                 unsigned long,
-                std::optional<linyaps_box::Config::mount_t::recursive_attr>,
-                linyaps_box::Config::mount_t::extension,
-                std::optional<linyaps_box::Config::mount_t::idmap_type>,
+                std::optional<linyaps_box::oci_config::mount_t::recursive_attr>,
+                linyaps_box::oci_config::mount_t::extension,
+                std::optional<linyaps_box::oci_config::mount_t::idmap_type>,
                 std::string>
 {
-    using extension = linyaps_box::Config::mount_t::extension;
+    using extension = linyaps_box::oci_config::mount_t::extension;
 
     auto vfs_flags{ 0UL };
     auto propagation_flags{ 0UL };
-    std::optional<linyaps_box::Config::mount_t::recursive_attr> rec_attr;
+    std::optional<linyaps_box::oci_config::mount_t::recursive_attr> rec_attr;
     auto extension_flags{ extension::NONE };
-    std::optional<linyaps_box::Config::mount_t::idmap_type> idmap;
+    std::optional<linyaps_box::oci_config::mount_t::idmap_type> idmap;
 
     std::string data;
 
@@ -285,21 +295,21 @@ auto parse_mount_options(const std::vector<std::string> &options)
 }
 
 constexpr auto namespace_type_table =
-  linyaps_box::utils::enum_table<linyaps_box::Config::linux_t::namespace_t::type, 8>{
-      { { { linyaps_box::Config::linux_t::namespace_t::type::CGROUP, "cgroup" },
-          { linyaps_box::Config::linux_t::namespace_t::type::IPC, "ipc" },
-          { linyaps_box::Config::linux_t::namespace_t::type::MOUNT, "mount" },
-          { linyaps_box::Config::linux_t::namespace_t::type::NET, "network" },
-          { linyaps_box::Config::linux_t::namespace_t::type::PID, "pid" },
-          { linyaps_box::Config::linux_t::namespace_t::type::TIME, "time" },
-          { linyaps_box::Config::linux_t::namespace_t::type::USER, "user" },
-          { linyaps_box::Config::linux_t::namespace_t::type::UTS, "uts" } } }
+  linyaps_box::utils::enum_table<linyaps_box::oci_config::linux_t::namespace_t::type, 8>{
+      { { { linyaps_box::oci_config::linux_t::namespace_t::type::CGROUP, "cgroup" },
+          { linyaps_box::oci_config::linux_t::namespace_t::type::IPC, "ipc" },
+          { linyaps_box::oci_config::linux_t::namespace_t::type::MOUNT, "mount" },
+          { linyaps_box::oci_config::linux_t::namespace_t::type::NET, "network" },
+          { linyaps_box::oci_config::linux_t::namespace_t::type::PID, "pid" },
+          { linyaps_box::oci_config::linux_t::namespace_t::type::TIME, "time" },
+          { linyaps_box::oci_config::linux_t::namespace_t::type::USER, "user" },
+          { linyaps_box::oci_config::linux_t::namespace_t::type::UTS, "uts" } } }
   };
 
 static_assert(linyaps_box::utils::verify_enum_table(namespace_type_table));
 
 #ifdef LINYAPS_BOX_ENABLE_SECCOMP
-using arch_t = linyaps_box::Config::linux_t::seccomp_t::arch_t;
+using arch_t = linyaps_box::oci_config::linux_t::seccomp_t::arch_t;
 constexpr auto seccomp_arch_table =
   linyaps_box::utils::enum_table<arch_t, 23>{ { { { arch_t::X86, "SCMP_ARCH_X86" },
                                                   { arch_t::X86_64, "SCMP_ARCH_X86_64" },
@@ -425,36 +435,17 @@ auto parse_range_list(std::string_view s) -> std::vector<unsigned int>
     return result;
 }
 
-// see: https://pubs.opengroup.org/onlinepubs/9799919799/
-auto is_invalid_env(std::string_view env) noexcept -> bool
-{
-    auto pos = env.find('=');
-    if (pos == std::string_view::npos) {
-        return true;
-    }
-
-    if (pos == 0) {
-        return true;
-    }
-
-    if (env.find('\0') != std::string_view::npos) {
-        return true;
-    }
-
-    return false;
-}
-
 } // namespace
 
 namespace linyaps_box {
 
-void from_json(const nlohmann::json &j, linyaps_box::Config::process_t::console_size_t &v)
+void from_json(const nlohmann::json &j, linyaps_box::oci_config::process_t::console_size_t &v)
 {
     j.at("height").get_to(v.height);
     j.at("width").get_to(v.width);
 }
 
-void from_json(const nlohmann::json &j, linyaps_box::Config::process_t::rlimit_t &v)
+void from_json(const nlohmann::json &j, linyaps_box::oci_config::process_t::rlimit_t &v)
 {
     auto name = j.at("type").get<std::string_view>();
     auto opt = rlimit_type_table.from_name(name);
@@ -466,7 +457,7 @@ void from_json(const nlohmann::json &j, linyaps_box::Config::process_t::rlimit_t
     j.at("hard").get_to(v.hard);
 }
 
-void from_json(const nlohmann::json &j, Config::process_t::user_t &v)
+void from_json(const nlohmann::json &j, oci_config::process_t::user_t &v)
 {
     j.at("uid").get_to(v.uid);
     j.at("gid").get_to(v.gid);
@@ -481,7 +472,7 @@ void from_json(const nlohmann::json &j, Config::process_t::user_t &v)
 }
 
 #ifdef LINYAPS_BOX_ENABLE_CAP
-void from_json(const nlohmann::json &j, Config::process_t::capabilities_t &v)
+void from_json(const nlohmann::json &j, oci_config::process_t::capabilities_t &v)
 {
     auto parse_set = [](const nlohmann::json &j, std::vector<cap_value_t> &set) {
         set.reserve(j.size());
@@ -519,7 +510,7 @@ void from_json(const nlohmann::json &j, Config::process_t::capabilities_t &v)
 
 #endif // LINYAPS_BOX_ENABLE_CAP
 
-void from_json(const nlohmann::json &j, Config::process_t::io_priority_t &v)
+void from_json(const nlohmann::json &j, oci_config::process_t::io_priority_t &v)
 {
     auto name = j.at("class").get<std::string_view>();
     auto opt = io_priority_class_table.from_name(name);
@@ -536,7 +527,7 @@ void from_json(const nlohmann::json &j, Config::process_t::io_priority_t &v)
     }
 }
 
-void from_json(const nlohmann::json &j, Config::process_t::scheduler_t &v)
+void from_json(const nlohmann::json &j, oci_config::process_t::scheduler_t &v)
 {
     auto policy_name = j.at("policy").get<std::string_view>();
     auto policy_opt = scheduler_policy_table.from_name(policy_name);
@@ -554,7 +545,7 @@ void from_json(const nlohmann::json &j, Config::process_t::scheduler_t &v)
     }
 
     if (auto flags_it = j.find("flags"); flags_it != j.end() && !flags_it->is_null()) {
-        Config::process_t::scheduler_t::flag_t flags{ };
+        oci_config::process_t::scheduler_t::flag_t flags{ };
         for (const auto &f : *flags_it) {
             const auto &flag_str = f.get_ref<const std::string &>();
             auto flag_opt = scheduler_flag_table.from_name(flag_str);
@@ -586,22 +577,22 @@ void from_json(const nlohmann::json &j, Config::process_t::scheduler_t &v)
     }
 
     if (v.priority && *v.priority != 0) {
-        if (v.policy != Config::process_t::scheduler_t::policy_t::FIFO
-            && v.policy != Config::process_t::scheduler_t::policy_t::RR) {
+        if (v.policy != oci_config::process_t::scheduler_t::policy_t::FIFO
+            && v.policy != oci_config::process_t::scheduler_t::policy_t::RR) {
             throw std::runtime_error(
               "scheduler.priority can only be specified for SCHED_FIFO or SCHED_RR");
         }
     }
 
     if (v.runtime || v.deadline || v.period) {
-        if (v.policy != Config::process_t::scheduler_t::policy_t::DEADLINE) {
+        if (v.policy != oci_config::process_t::scheduler_t::policy_t::DEADLINE) {
             throw std::runtime_error(
               "scheduler runtime/deadline/period can only be specified for SCHED_DEADLINE");
         }
     }
 }
 
-void from_json(const nlohmann::json &j, Config::process_t::exec_cpu_affinity_t &v)
+void from_json(const nlohmann::json &j, oci_config::process_t::exec_cpu_affinity_t &v)
 {
     if (auto it = j.find("initial"); it != j.end() && !it->is_null()) {
         it->get_to(v.initial.emplace());
@@ -612,7 +603,7 @@ void from_json(const nlohmann::json &j, Config::process_t::exec_cpu_affinity_t &
     }
 }
 
-void from_json(const nlohmann::json &j, Config::process_t &v)
+void from_json(const nlohmann::json &j, oci_config::process_t &v)
 {
     if (auto it = j.find("terminal"); it != j.end() && !it->is_null()) {
         it->get_to(v.terminal.emplace());
@@ -631,7 +622,7 @@ void from_json(const nlohmann::json &j, Config::process_t &v)
 
     if (auto it = j.find("env"); it != j.end() && !it->is_null()) {
         it->get_to(v.env.emplace());
-        auto invalid = std::find_if(v.env->cbegin(), v.env->cend(), is_invalid_env);
+        auto invalid = std::find_if(v.env->cbegin(), v.env->cend(), utils::is_invalid_env);
         if (UNLIKELY(invalid != v.env->cend())) {
             throw std::runtime_error("process.env contains a invalid env: " + *invalid);
         }
@@ -702,14 +693,14 @@ void from_json(const nlohmann::json &j, Config::process_t &v)
     }
 }
 
-void from_json(const nlohmann::json &j, Config::id_mapping_t &v)
+void from_json(const nlohmann::json &j, oci_config::id_mapping_t &v)
 {
     j.at("hostID").get_to(v.host_id);
     j.at("containerID").get_to(v.container_id);
     j.at("size").get_to(v.size);
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::namespace_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::namespace_t &v)
 {
     auto type_str = j.at("type").get<std::string_view>();
     auto opt = namespace_type_table.from_name(type_str);
@@ -733,13 +724,13 @@ void from_json(const nlohmann::json &j, Config::linux_t::namespace_t &v)
     }
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::time_offset_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::time_offset_t &v)
 {
     j.at("secs").get_to(v.secs);
     j.at("nanosecs").get_to(v.nanosecs);
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::device_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::device_t &v)
 {
     j.at("type").get_to(v.type);
     j.at("path").get_to(v.path);
@@ -765,7 +756,7 @@ void from_json(const nlohmann::json &j, Config::linux_t::device_t &v)
     }
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::network_device_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::network_device_t &v)
 {
     if (auto it = j.find("name"); it != j.end() && !it->is_null()) {
         it->get_to(v.name.emplace());
@@ -774,7 +765,7 @@ void from_json(const nlohmann::json &j, Config::linux_t::network_device_t &v)
 
 // --- allowed_device_t ---
 
-void from_json(const nlohmann::json &j, Config::linux_t::resources_t::device_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::resources_t::device_t &v)
 {
     j.at("allow").get_to(v.allow);
     if (auto it = j.find("type"); it != j.end() && !it->is_null()) {
@@ -794,7 +785,7 @@ void from_json(const nlohmann::json &j, Config::linux_t::resources_t::device_t &
     }
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::resources_t::memory_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::resources_t::memory_t &v)
 {
     if (auto it = j.find("limit"); it != j.end() && !it->is_null()) {
         it->get_to(v.limit.emplace());
@@ -832,7 +823,7 @@ void from_json(const nlohmann::json &j, Config::linux_t::resources_t::memory_t &
     }
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::resources_t::cpu_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::resources_t::cpu_t &v)
 {
     if (auto it = j.find("shares"); it != j.end() && !it->is_null()) {
         it->get_to(v.shares.emplace());
@@ -868,13 +859,13 @@ void from_json(const nlohmann::json &j, Config::linux_t::resources_t::cpu_t &v)
     if (auto it = j.find("idle"); it != j.end() && !it->is_null()) {
         // TODO: move this logic to converter?
         auto val = it->get<int64_t>();
-        v.idle.emplace((val == 1) ? Config::linux_t::resources_t::cpu_t::idle_t::IDLE
-                                  : Config::linux_t::resources_t::cpu_t::idle_t::NONE);
+        v.idle.emplace((val == 1) ? oci_config::linux_t::resources_t::cpu_t::idle_t::IDLE
+                                  : oci_config::linux_t::resources_t::cpu_t::idle_t::NONE);
     }
 }
 
 void from_json(const nlohmann::json &j,
-               Config::linux_t::resources_t::block_io_t::weight_device_t &v)
+               oci_config::linux_t::resources_t::block_io_t::weight_device_t &v)
 {
     j.at("major").get_to(v.major);
     j.at("minor").get_to(v.minor);
@@ -889,14 +880,14 @@ void from_json(const nlohmann::json &j,
 }
 
 void from_json(const nlohmann::json &j,
-               Config::linux_t::resources_t::block_io_t::throttle_device_t &v)
+               oci_config::linux_t::resources_t::block_io_t::throttle_device_t &v)
 {
     j.at("major").get_to(v.major);
     j.at("minor").get_to(v.minor);
     j.at("rate").get_to(v.rate);
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::resources_t::block_io_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::resources_t::block_io_t &v)
 {
     if (auto it = j.find("weight"); it != j.end() && !it->is_null()) {
         it->get_to(v.weight.emplace());
@@ -927,19 +918,19 @@ void from_json(const nlohmann::json &j, Config::linux_t::resources_t::block_io_t
     }
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::resources_t::hugepage_limit_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::resources_t::hugepage_limit_t &v)
 {
     j.at("pageSize").get_to(v.page_size);
     j.at("limit").get_to(v.limit);
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::resources_t::network_t::priority_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::resources_t::network_t::priority_t &v)
 {
     j.at("name").get_to(v.name);
     j.at("priority").get_to(v.priority);
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::resources_t::network_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::resources_t::network_t &v)
 {
     if (auto it = j.find("classID"); it != j.end() && !it->is_null()) {
         it->get_to(v.class_id.emplace());
@@ -950,14 +941,14 @@ void from_json(const nlohmann::json &j, Config::linux_t::resources_t::network_t 
     }
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::resources_t::pids_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::resources_t::pids_t &v)
 {
     if (auto it = j.find("limit"); it != j.end() && !it->is_null()) {
         it->get_to(v.limit.emplace());
     }
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::resources_t::rdma_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::resources_t::rdma_t &v)
 {
     if (auto it = j.find("hcaHandles"); it != j.end() && !it->is_null()) {
         it->get_to(v.hca_handles.emplace());
@@ -968,7 +959,7 @@ void from_json(const nlohmann::json &j, Config::linux_t::resources_t::rdma_t &v)
     }
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::intel_rdt_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::intel_rdt_t &v)
 {
     if (auto it = j.find("closID"); it != j.end() && !it->is_null()) {
         it->get_to(v.clos_id.emplace());
@@ -991,7 +982,7 @@ void from_json(const nlohmann::json &j, Config::linux_t::intel_rdt_t &v)
     }
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::resources_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::resources_t &v)
 {
     if (auto it = j.find("unified"); it != j.end() && !it->is_null()) {
         it->get_to(v.unified.emplace());
@@ -1030,7 +1021,7 @@ void from_json(const nlohmann::json &j, Config::linux_t::resources_t &v)
     }
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::memory_policy_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::memory_policy_t &v)
 {
     auto mode_name = j.at("mode").get<std::string_view>();
     auto mode_opt = memory_policy_mode_table.from_name(mode_name);
@@ -1044,7 +1035,7 @@ void from_json(const nlohmann::json &j, Config::linux_t::memory_policy_t &v)
     }
 
     if (auto flags_it = j.find("flags"); flags_it != j.end() && !flags_it->is_null()) {
-        Config::linux_t::memory_policy_t::flag_t flags{ };
+        oci_config::linux_t::memory_policy_t::flag_t flags{ };
         for (const auto &f : *flags_it) {
             const auto &flag_str = f.get_ref<const std::string &>();
             auto flag_opt = memory_policy_flag_table.from_name(flag_str);
@@ -1058,7 +1049,7 @@ void from_json(const nlohmann::json &j, Config::linux_t::memory_policy_t &v)
     }
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::personality_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::personality_t &v)
 {
     auto domain_name = j.at("domain").get<std::string_view>();
     auto domain_opt = personality_domain_table.from_name(domain_name);
@@ -1073,7 +1064,7 @@ void from_json(const nlohmann::json &j, Config::linux_t::personality_t &v)
 }
 
 #ifdef LINYAPS_BOX_ENABLE_SECCOMP
-void from_json(const nlohmann::json &j, Config::linux_t::seccomp_t::syscall_t::arg_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::seccomp_t::syscall_t::arg_t &v)
 {
     j.at("index").get_to(v.index);
     j.at("value").get_to(v.value);
@@ -1091,14 +1082,14 @@ void from_json(const nlohmann::json &j, Config::linux_t::seccomp_t::syscall_t::a
     v.op = *op_opt;
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::seccomp_t::syscall_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::seccomp_t::syscall_t &v)
 {
     j.at("names").get_to(v.names);
     if (UNLIKELY(v.names.empty())) {
         throw std::runtime_error("seccomp syscall names must not be empty");
     }
 
-    using action_t = Config::linux_t::seccomp_t::action_t;
+    using action_t = oci_config::linux_t::seccomp_t::action_t;
     {
         auto action_name = j.at("action").get<std::string_view>();
         auto action_opt = seccomp_action_table.from_name(action_name);
@@ -1121,9 +1112,9 @@ void from_json(const nlohmann::json &j, Config::linux_t::seccomp_t::syscall_t &v
     }
 }
 
-void from_json(const nlohmann::json &j, Config::linux_t::seccomp_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t::seccomp_t &v)
 {
-    using action_t = Config::linux_t::seccomp_t::action_t;
+    using action_t = oci_config::linux_t::seccomp_t::action_t;
     {
         auto action_name = j.at("defaultAction").get<std::string_view>();
         auto action_opt = seccomp_action_table.from_name(action_name);
@@ -1144,7 +1135,7 @@ void from_json(const nlohmann::json &j, Config::linux_t::seccomp_t &v)
     }
 
     if (auto it = j.find("architectures"); it != j.end() && !it->is_null()) {
-        std::vector<Config::linux_t::seccomp_t::arch_t> archs;
+        std::vector<oci_config::linux_t::seccomp_t::arch_t> archs;
         archs.reserve(it->size());
         for (const auto &elem : *it) {
             auto arch_str = elem.get<std::string_view>();
@@ -1159,7 +1150,7 @@ void from_json(const nlohmann::json &j, Config::linux_t::seccomp_t &v)
     }
 
     if (auto it = j.find("flags"); it != j.end() && !it->is_null()) {
-        Config::linux_t::seccomp_t::flag_t flags{ };
+        oci_config::linux_t::seccomp_t::flag_t flags{ };
         for (const auto &elem : *it) {
             auto flag_str = elem.get<std::string_view>();
             auto flag_opt = seccomp_flag_table.from_name(flag_str);
@@ -1196,7 +1187,7 @@ void from_json(const nlohmann::json &j, Config::linux_t::seccomp_t &v)
 
 #endif
 
-void from_json(const nlohmann::json &j, Config::linux_t &v)
+void from_json(const nlohmann::json &j, oci_config::linux_t &v)
 {
     if (auto it = j.find("uidMappings"); it != j.end() && !it->is_null()) {
         it->get_to(v.uid_mappings.emplace());
@@ -1285,7 +1276,8 @@ void from_json(const nlohmann::json &j, Config::linux_t &v)
         auto &offsets = v.time_offsets.emplace();
         for (const auto &[clock_name, offset_json] : it->items()) {
             auto [it, ignored] =
-              offsets.try_emplace(clock_name, offset_json.get<Config::linux_t::time_offset_t>());
+              offsets.try_emplace(clock_name,
+                                  offset_json.get<oci_config::linux_t::time_offset_t>());
             if (UNLIKELY(!ignored)) {
                 throw std::runtime_error("duplicated timeOffset :" + offset_json.dump());
             }
@@ -1315,7 +1307,7 @@ void from_json(const nlohmann::json &j, Config::linux_t &v)
 #endif
 }
 
-void from_json(const nlohmann::json &j, Config::hooks_t::hook_t &v)
+void from_json(const nlohmann::json &j, oci_config::hooks_t::hook_t &v)
 {
     j.at("path").get_to(v.path);
     if (UNLIKELY(!v.path.is_absolute())) {
@@ -1328,7 +1320,7 @@ void from_json(const nlohmann::json &j, Config::hooks_t::hook_t &v)
 
     if (auto it = j.find("env"); it != j.end() && !it->is_null()) {
         const auto &env = it->get_to(v.env.emplace());
-        auto invalid = std::find_if(env.cbegin(), env.cend(), is_invalid_env);
+        auto invalid = std::find_if(env.cbegin(), env.cend(), utils::is_invalid_env);
         if (UNLIKELY(invalid != v.env->cend())) {
             throw std::runtime_error("hook.env contains a invalid env: " + *invalid);
         }
@@ -1342,7 +1334,7 @@ void from_json(const nlohmann::json &j, Config::hooks_t::hook_t &v)
     }
 }
 
-void from_json(const nlohmann::json &j, Config::hooks_t &v)
+void from_json(const nlohmann::json &j, oci_config::hooks_t &v)
 {
     if (auto it = j.find("prestart"); it != j.end() && !it->is_null()) {
         it->get_to(v.prestart.emplace());
@@ -1369,7 +1361,7 @@ void from_json(const nlohmann::json &j, Config::hooks_t &v)
     }
 }
 
-void from_json(const nlohmann::json &j, Config::mount_t &v)
+void from_json(const nlohmann::json &j, oci_config::mount_t &v)
 {
     j.at("destination").get_to(v.destination);
 
@@ -1393,16 +1385,16 @@ void from_json(const nlohmann::json &j, Config::mount_t &v)
     }
 }
 
-void from_json(const nlohmann::json &j, Config::root_t &v)
+void from_json(const nlohmann::json &j, oci_config::root_t &v)
 {
     j.at("path").get_to(v.path);
     v.readonly = j.value("readonly", false);
 }
 
-void from_json(const nlohmann::json &j, Config &v)
+void from_json(const nlohmann::json &j, oci_config &v)
 {
     auto semver = linyaps_box::utils::semver(j.at("ociVersion").get_ref<const std::string &>());
-    if (UNLIKELY(!linyaps_box::utils::semver(Config::oci_version).is_compatible_with(semver))) {
+    if (UNLIKELY(!linyaps_box::utils::semver(oci_config::version).is_compatible_with(semver))) {
         throw std::runtime_error("unsupported OCI version: " + semver.to_string());
     }
 
@@ -1439,18 +1431,18 @@ void from_json(const nlohmann::json &j, Config &v)
     }
 }
 
-auto to_string_view(Config::linux_t::namespace_t::type type) noexcept -> std::string_view
+auto to_string_view(oci_config::linux_t::namespace_t::type type) noexcept -> std::string_view
 {
     return namespace_type_table.to_name(type).value_or(std::string_view{ });
 }
 
-auto to_string_view(linyaps_box::Config::process_t::rlimit_t::type_t type) noexcept
+auto to_string_view(linyaps_box::oci_config::process_t::rlimit_t::type_t type) noexcept
   -> std::string_view
 {
     return rlimit_type_table.to_name(type).value_or(std::string_view{ });
 }
 
-auto validate_namespace_path(const Config::linux_t::namespace_t &ns) -> void
+auto validate_namespace_path(const oci_config::linux_t::namespace_t &ns) -> void
 {
     if (!ns.path) {
         return;
@@ -1482,22 +1474,22 @@ auto validate_namespace_path(const Config::linux_t::namespace_t &ns) -> void
     }
 }
 
-auto Config::parse(std::string_view content) -> Config
+auto oci_config::parse(std::string_view content) -> oci_config
 {
-    return nlohmann::json::parse(content).get<Config>();
+    return nlohmann::json::parse(content).get<oci_config>();
 }
 
-auto Config::parse(const std::filesystem::path &path) -> Config
+auto oci_config::parse(const std::filesystem::path &path) -> oci_config
 {
     std::ifstream stream{ path, std::ios::binary | std::ios::in };
     if (UNLIKELY(!stream.is_open())) {
         throw std::filesystem::filesystem_error(
-          "failed to open config file",
+          "failed to open oci_config file",
           path,
           std::make_error_code(static_cast<std::errc>(errno)));
     }
 
-    return nlohmann::json::parse(stream).get<Config>();
+    return nlohmann::json::parse(stream).get<oci_config>();
 }
 
 } // namespace linyaps_box

--- a/src/linyaps_box/config.h
+++ b/src/linyaps_box/config.h
@@ -7,18 +7,16 @@
 #include <linux/ioprio.h>
 #include <linux/mempolicy.h>
 #include <linux/sched.h>
-#include <sys/mount.h>
+#include <nlohmann/json_fwd.hpp>
 
 #include <filesystem>
 #include <optional>
 #include <string>
-#include <string_view>
-#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
+#include <sched.h>
 #include <sys/resource.h>
-#include <sys/types.h>
 
 #ifdef LINYAPS_BOX_ENABLE_SECCOMP
 #  include <seccomp.h>
@@ -29,7 +27,6 @@
 #endif
 
 #include "linyaps_box/utils/enum_traits.h"
-#include "nlohmann/json_fwd.hpp"
 
 // clang-format off
 #include "linyaps_box/config/kernel_fallbacks.h"
@@ -37,12 +34,12 @@
 
 namespace linyaps_box {
 
-struct Config
+struct oci_config
 {
-    static constexpr auto oci_version = "1.3.0";
+    static constexpr auto version = "1.3.0";
 
-    static auto parse(std::string_view content) -> Config;
-    static auto parse(const std::filesystem::path &path) -> Config;
+    static auto parse(std::string_view content) -> oci_config;
+    static auto parse(const std::filesystem::path &path) -> oci_config;
 
     struct process_t
     {
@@ -226,8 +223,8 @@ struct Config
         std::optional<std::string> type;
         std::string data;
 
-        std::optional<std::vector<Config::id_mapping_t>> uid_mappings;
-        std::optional<std::vector<Config::id_mapping_t>> gid_mappings;
+        std::optional<std::vector<oci_config::id_mapping_t>> uid_mappings;
+        std::optional<std::vector<oci_config::id_mapping_t>> gid_mappings;
     };
 
     std::vector<mount_t> mounts;
@@ -253,8 +250,8 @@ struct Config
 
         std::optional<std::vector<namespace_t>> namespaces;
 
-        std::optional<std::vector<Config::id_mapping_t>> uid_mappings;
-        std::optional<std::vector<Config::id_mapping_t>> gid_mappings;
+        std::optional<std::vector<oci_config::id_mapping_t>> uid_mappings;
+        std::optional<std::vector<oci_config::id_mapping_t>> gid_mappings;
 
         struct time_offset_t
         {
@@ -583,37 +580,37 @@ struct Config
     std::optional<std::unordered_map<std::string, std::string>> annotations;
 };
 
-auto to_string_view(Config::linux_t::namespace_t::type type) noexcept -> std::string_view;
+auto to_string_view(oci_config::linux_t::namespace_t::type type) noexcept -> std::string_view;
 
-auto to_string_view(Config::process_t::rlimit_t::type_t type) noexcept -> std::string_view;
+auto to_string_view(oci_config::process_t::rlimit_t::type_t type) noexcept -> std::string_view;
 
-void validate_namespace_path(const Config::linux_t::namespace_t &ns);
+void validate_namespace_path(const oci_config::linux_t::namespace_t &ns);
 
-void from_json(const nlohmann::json &j, Config &v);
+void from_json(const nlohmann::json &j, oci_config &v);
 
 template <>
-struct utils::is_bitmask_enum<Config::linux_t::namespace_t::type> : std::true_type
+struct utils::is_bitmask_enum<oci_config::linux_t::namespace_t::type> : std::true_type
 {
 };
 
 template <>
-struct utils::is_bitmask_enum<Config::mount_t::extension> : std::true_type
+struct utils::is_bitmask_enum<oci_config::mount_t::extension> : std::true_type
 {
 };
 
 template <>
-struct utils::is_bitmask_enum<Config::process_t::scheduler_t::flag_t> : std::true_type
+struct utils::is_bitmask_enum<oci_config::process_t::scheduler_t::flag_t> : std::true_type
 {
 };
 
 template <>
-struct utils::is_bitmask_enum<Config::linux_t::memory_policy_t::flag_t> : std::true_type
+struct utils::is_bitmask_enum<oci_config::linux_t::memory_policy_t::flag_t> : std::true_type
 {
 };
 
 #ifdef LINYAPS_BOX_ENABLE_SECCOMP
 template <>
-struct utils::is_bitmask_enum<Config::linux_t::seccomp_t::flag_t> : std::true_type
+struct utils::is_bitmask_enum<oci_config::linux_t::seccomp_t::flag_t> : std::true_type
 {
 };
 #endif
@@ -625,5 +622,7 @@ using utils::operator~;
 using utils::operator|=;
 using utils::operator&=;
 using utils::operator^=;
+
+void from_json(const nlohmann::json &j, oci_config::process_t &v);
 
 } // namespace linyaps_box

--- a/src/linyaps_box/container.cpp
+++ b/src/linyaps_box/container.cpp
@@ -144,7 +144,7 @@ auto read_sync_message(linyaps_box::unix_socket &socket) -> sync_message
     return message;
 }
 
-void execute_hook(const linyaps_box::Config::hooks_t::hook_t &hook,
+void execute_hook(const linyaps_box::oci_config::hooks_t::hook_t &hook,
                   const linyaps_box::container_status_t &state)
 {
     auto [parent, child] = linyaps_box::unix_socket::pair();
@@ -291,7 +291,8 @@ struct clone_fn_args
 // NOTE: All function in this namespace are running in the container namespace.
 namespace container_ns {
 
-void initialize_container(const linyaps_box::Config &config, linyaps_box::unix_socket &socket)
+void initialize_container(const linyaps_box::oci_config &oci_config,
+                          linyaps_box::unix_socket &socket)
 {
     LINYAPS_BOX_DEBUG() << "Request OCI runtime in runtime namespace to configure namespace";
 
@@ -305,8 +306,8 @@ void initialize_container(const linyaps_box::Config &config, linyaps_box::unix_s
 
     LINYAPS_BOX_DEBUG() << "Container namespaces configured from runtime namespace";
 
-    if (config.process->oom_score_adj) {
-        auto score = std::to_string(config.process->oom_score_adj.value());
+    if (oci_config.process->oom_score_adj) {
+        auto score = std::to_string(oci_config.process->oom_score_adj.value());
         LINYAPS_BOX_DEBUG() << "Set oom score to " << score;
 
         std::ofstream ofs("/proc/self/oom_score_adj");
@@ -521,7 +522,7 @@ create_destination_symlink(const linyaps_box::utils::file_descriptor &root,
 [[nodiscard]] linyaps_box::utils::file_descriptor
 ensure_mount_destination(bool isDir,
                          const linyaps_box::utils::file_descriptor &root,
-                         const linyaps_box::Config::mount_t &mount)
+                         const linyaps_box::oci_config::mount_t &mount)
 try {
     auto open_flag = O_PATH | O_CLOEXEC;
     LINYAPS_BOX_DEBUG() << "Opening " << (isDir ? "directory " : "file ") << mount.destination
@@ -564,7 +565,7 @@ auto do_propagation_mount(const linyaps_box::utils::file_descriptor &destination
 }
 
 [[nodiscard]] linyaps_box::utils::file_descriptor do_bind_mount(
-  const linyaps_box::utils::file_descriptor &root, const linyaps_box::Config::mount_t &mount)
+  const linyaps_box::utils::file_descriptor &root, const linyaps_box::oci_config::mount_t &mount)
 {
     if (UNLIKELY(!mount.source)) {
         throw std::invalid_argument("bind mount requires source");
@@ -604,7 +605,7 @@ auto do_propagation_mount(const linyaps_box::utils::file_descriptor &destination
 }
 
 [[noreturn]] void do_cgroup_mount([[maybe_unused]] const linyaps_box::utils::file_descriptor &root,
-                                  [[maybe_unused]] const linyaps_box::Config::mount_t &mount,
+                                  [[maybe_unused]] const linyaps_box::oci_config::mount_t &mount,
                                   [[maybe_unused]] std::string_view unified_cgroup_path)
 {
     // TODO: implement
@@ -613,7 +614,7 @@ auto do_propagation_mount(const linyaps_box::utils::file_descriptor &destination
 
 [[nodiscard]] std::optional<remount_t> do_mount(linyaps_box::container &container,
                                                 linyaps_box::utils::file_descriptor &root,
-                                                const linyaps_box::Config::mount_t &mount)
+                                                const linyaps_box::oci_config::mount_t &mount)
 {
     // FIXME: this is a workaround, it should be fixed in the future
     static auto is_sys_rbind{ false };
@@ -636,8 +637,8 @@ auto do_propagation_mount(const linyaps_box::utils::file_descriptor &destination
             auto unshared_cgroup_ns = std::find_if(
               namespaces->cbegin(),
               namespaces->cend(),
-              [](const linyaps_box::Config::linux_t::namespace_t &ns) -> bool {
-                  return ns.type_ == linyaps_box::Config::linux_t::namespace_t::type::CGROUP;
+              [](const linyaps_box::oci_config::linux_t::namespace_t &ns) -> bool {
+                  return ns.type_ == linyaps_box::oci_config::linux_t::namespace_t::type::CGROUP;
               });
             if (mount.destination == "/sys/fs/cgroup" && is_sys_rbind) {
                 if (unshared_cgroup_ns != namespaces->cend()) {
@@ -694,6 +695,10 @@ auto do_propagation_mount(const linyaps_box::utils::file_descriptor &destination
     // https://web.git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=69879c01a0c3f70e0887cfb4d9ff439814361e46
     if (!mount.data.empty() && mount.type == "proc") {
         need_remount = true;
+    }
+
+    if (mount.destination == "/") {
+        root = linyaps_box::utils::open(root.current_path(), O_PATH | O_DIRECTORY | O_CLOEXEC);
     }
 
     if (!need_remount) {
@@ -760,14 +765,14 @@ public:
 
     void configure_rootfs()
     {
-        const auto &config = container.get().get_config();
+        const auto &oci_config = container.get().get_config();
 
-        auto has_mount_ns = config.linux && config.linux->namespaces
-          && std::any_of(config.linux->namespaces->begin(),
-                         config.linux->namespaces->end(),
+        auto has_mount_ns = oci_config.linux && oci_config.linux->namespaces
+          && std::any_of(oci_config.linux->namespaces->begin(),
+                         oci_config.linux->namespaces->end(),
                          [](const auto &ns) {
                              return ns.type_
-                               == linyaps_box::Config::linux_t::namespace_t::type::MOUNT;
+                               == linyaps_box::oci_config::linux_t::namespace_t::type::MOUNT;
                          });
         if (!has_mount_ns) {
             LINYAPS_BOX_DEBUG() << "no unshared mount namespace";
@@ -775,8 +780,8 @@ public:
         }
 
         // we will pivot root later
-        LINYAPS_BOX_DEBUG() << "configure rootfs";
-        auto prop = config.linux->rootfs_propagation;
+        LINYAPS_BOX_DEBUG() << "Configure rootfs";
+        auto prop = oci_config.linux->rootfs_propagation;
         if (prop == 0) {
             prop = MS_REC | MS_PRIVATE;
         }
@@ -796,7 +801,7 @@ public:
 
         LINYAPS_BOX_DEBUG() << "rebind container rootfs";
 
-        linyaps_box::Config::mount_t mount;
+        linyaps_box::oci_config::mount_t mount;
         mount.source = root.current_path();
         mount.destination = ".";
         mount.vfs_flags = MS_BIND | MS_REC;
@@ -809,7 +814,7 @@ public:
         // reopen rootfs after mount
         root = linyaps_box::utils::open(root.current_path(), O_PATH | O_CLOEXEC | O_DIRECTORY);
 
-        if (config.root->readonly) {
+        if (oci_config.root->readonly) {
             LINYAPS_BOX_DEBUG() << "remount bind rootfs to readonly";
             remount_t mount;
             mount.destination_fd = root.duplicate();
@@ -825,10 +830,10 @@ public:
         }
     }
 
-    void mount(const linyaps_box::Config::mount_t &mount)
+    void mount(const linyaps_box::oci_config::mount_t &mount)
     {
-        if ((mount.extension_flags & linyaps_box::Config::mount_t::extension::COPY_SYMLINK)
-            == linyaps_box::Config::mount_t::extension::COPY_SYMLINK) {
+        if ((mount.extension_flags & linyaps_box::oci_config::mount_t::extension::COPY_SYMLINK)
+            == linyaps_box::oci_config::mount_t::extension::COPY_SYMLINK) {
             auto ret = create_destination_symlink(root, mount.source.value(), mount.destination);
             return;
         }
@@ -876,7 +881,7 @@ public:
             // readonly path is not mounted yet
             vfs_flag &= ~MS_REMOUNT;
 
-            linyaps_box::Config::mount_t mount{ };
+            linyaps_box::oci_config::mount_t mount{ };
             mount.destination = path;
             mount.source = dst.proc_path();
             mount.vfs_flags = vfs_flag;
@@ -918,7 +923,7 @@ public:
             }
 
             auto ret = linyaps_box::utils::fstatat(dst, "");
-            auto mount = linyaps_box::Config::mount_t{ };
+            auto mount = linyaps_box::oci_config::mount_t{ };
 
             mount.destination = path;
             mount.vfs_flags = MS_RDONLY;
@@ -972,10 +977,10 @@ private:
     linyaps_box::utils::file_descriptor root;
     std::vector<remount_t> remounts;
 
-    // https://github.com/opencontainers/runtime-spec/blob/09fcb39bb7185b46dfb206bc8f3fea914c674779/config-linux.md#default-filesystems
+    // https://github.com/opencontainers/runtime-spec/blob/09fcb39bb7185b46dfb206bc8f3fea914c674779/oci_config-linux.md#default-filesystems
     void configure_default_filesystems()
     {
-        LINYAPS_BOX_DEBUG() << "configure default filesystems";
+        LINYAPS_BOX_DEBUG() << "Configure default filesystems";
 
         do {
             auto proc = linyaps_box::utils::open_at(root, "proc");
@@ -991,7 +996,7 @@ private:
                 break;
             }
 
-            linyaps_box::Config::mount_t mount;
+            linyaps_box::oci_config::mount_t mount;
             mount.source = "proc";
             mount.type = "proc";
             mount.destination = "/proc";
@@ -1011,7 +1016,7 @@ private:
                 break;
             }
 
-            linyaps_box::Config::mount_t mount;
+            linyaps_box::oci_config::mount_t mount;
             mount.source = "sysfs";
             mount.type = "sysfs";
             mount.destination = "/sys";
@@ -1050,7 +1055,7 @@ private:
                 break;
             }
 
-            linyaps_box::Config::mount_t mount;
+            linyaps_box::oci_config::mount_t mount;
             mount.source = "tmpfs";
             mount.destination = "/dev";
             mount.type = "tmpfs";
@@ -1069,7 +1074,7 @@ private:
                 }
             }
 
-            linyaps_box::Config::mount_t mount;
+            linyaps_box::oci_config::mount_t mount;
             mount.source = "devpts";
             mount.destination = "/dev/pts";
             mount.type = "devpts";
@@ -1088,7 +1093,7 @@ private:
                 }
             }
 
-            linyaps_box::Config::mount_t mount;
+            linyaps_box::oci_config::mount_t mount;
             mount.source = "shm";
             mount.destination = "/dev/shm";
             mount.type = "tmpfs";
@@ -1138,7 +1143,7 @@ private:
             // not available. Fallback to bind mount the host device.
             if (ec == std::errc::operation_not_permitted) {
                 LINYAPS_BOX_DEBUG() << "fallback to bind mount device";
-                linyaps_box::Config::mount_t mount;
+                linyaps_box::oci_config::mount_t mount;
                 mount.source = destination;
                 mount.destination = destination;
                 mount.type = "bind";
@@ -1164,7 +1169,7 @@ private:
         }
     }
 
-    // https://github.com/opencontainers/runtime-spec/blob/main/config-linux.md#default-devices
+    // https://github.com/opencontainers/runtime-spec/blob/main/oci_config-linux.md#default-devices
     void configure_default_devices()
     {
         LINYAPS_BOX_DEBUG() << "Configure default devices";
@@ -1194,7 +1199,7 @@ private:
 
             if (S_ISREG(ptmx_stat.st_mode)) {
                 // /dev/ptmx is a regular file: bind mount /dev/pts/ptmx over it
-                linyaps_box::Config::mount_t mount;
+                linyaps_box::oci_config::mount_t mount;
                 mount.source = root.current_path() / "dev/pts/ptmx";
                 mount.destination = "/dev/ptmx";
                 mount.type = "bind";
@@ -1252,9 +1257,9 @@ void configure_mounts(linyaps_box::container &container, const std::filesystem::
 {
     LINYAPS_BOX_DEBUG() << "Configure mounts";
 
-    const auto &config = container.get_config();
+    const auto &oci_config = container.get_config();
 
-    if (config.mounts.empty()) {
+    if (oci_config.mounts.empty()) {
         LINYAPS_BOX_DEBUG() << "Nothing to do";
         return;
     }
@@ -1276,46 +1281,9 @@ void configure_mounts(linyaps_box::container &container, const std::filesystem::
     LINYAPS_BOX_DEBUG() << "Mounts configured";
 }
 
-[[noreturn]] void execute_process(const linyaps_box::Config &config)
+[[noreturn]] void execute_process(const linyaps_box::oci_config &oci_config)
 {
-    const auto &process = *config.process;
-    std::vector<const char *> c_args;
-    c_args.reserve(process.args.size());
-    for (const auto &arg : process.args) {
-        c_args.push_back(arg.c_str());
-    }
-    c_args.push_back(nullptr);
-
-    std::vector<const char *> c_env;
-    if (process.env) {
-        c_env.reserve(process.env->size());
-        for (const auto &env : *process.env) {
-            c_env.push_back(env.c_str());
-        }
-    }
-    c_env.push_back(nullptr);
-
-    auto ret = chdir(process.cwd.c_str());
-    if (ret != 0) {
-        throw std::system_error(errno, std::system_category(), "chdir");
-    }
-
-    ret = setgid(process.user.gid);
-    if (ret != 0) {
-        throw std::system_error(errno, std::system_category(), "setgid");
-    }
-
-    if (process.user.additional_gids) {
-        ret = setgroups(process.user.additional_gids->size(), process.user.additional_gids->data());
-        if (ret != 0) {
-            throw std::system_error(errno, std::system_category(), "setgroups");
-        }
-    }
-
-    ret = setuid(process.user.uid);
-    if (ret != 0) {
-        throw std::system_error(errno, std::system_category(), "setuid");
-    }
+    const auto &process = *oci_config.process;
 
     LINYAPS_BOX_DEBUG() << "All opened file describers:\n" << linyaps_box::utils::inspect_fds();
 
@@ -1329,16 +1297,38 @@ void configure_mounts(linyaps_box::container &container, const std::filesystem::
         return ss.str();
     }();
 
-    execvpe(c_args.at(0),
-            const_cast<char *const *>(c_args.data()), // NOLINT
-            const_cast<char *const *>(c_env.data())); // NOLINT
+    std::vector<const char *> c_args;
+    c_args.reserve(process.args.size() + 1);
+    for (const auto &arg : process.args) {
+        c_args.push_back(arg.c_str());
+    }
+    c_args.push_back(nullptr);
+
+    std::vector<const char *> c_env;
+    if (process.env) {
+        c_env.reserve(process.env->size() + 1);
+        for (const auto &env : *process.env) {
+            c_env.push_back(env.c_str());
+        }
+    }
+    c_env.push_back(nullptr);
+
+    auto ret = ::chdir(process.cwd.c_str());
+    if (ret != 0) {
+        throw std::system_error(errno, std::system_category(), "chdir");
+    }
+
+    ::execvpe(c_args.at(0),
+              const_cast<char *const *>(c_args.data()),
+              const_cast<char *const *>(c_env.data()));
 
     throw std::system_error(errno, std::system_category(), "execvpe");
 }
 
-void wait_prestart_hooks_result(const linyaps_box::Config &config, linyaps_box::unix_socket &socket)
+void wait_prestart_hooks_result(const linyaps_box::oci_config &oci_config,
+                                linyaps_box::unix_socket &socket)
 {
-    if (!config.hooks || !config.hooks->prestart) {
+    if (!oci_config.hooks || !oci_config.hooks->prestart) {
         return;
     }
 
@@ -1361,9 +1351,10 @@ void wait_prestart_hooks_result(const linyaps_box::Config &config, linyaps_box::
     throw unexpected_sync_message(sync_message::PRESTART_HOOKS_EXECUTED, message);
 }
 
-void wait_create_runtime_result(const linyaps_box::Config &config, linyaps_box::unix_socket &socket)
+void wait_create_runtime_result(const linyaps_box::oci_config &oci_config,
+                                linyaps_box::unix_socket &socket)
 {
-    if (!config.hooks || !config.hooks->create_runtime) {
+    if (!oci_config.hooks || !oci_config.hooks->create_runtime) {
         return;
     }
 
@@ -1390,14 +1381,14 @@ void create_container_hooks(const linyaps_box::container &container,
                             const linyaps_box::container_status_t &status,
                             linyaps_box::unix_socket &socket)
 {
-    const auto &config = container.get_config();
-    if (!config.hooks || !config.hooks->create_container) {
+    const auto &oci_config = container.get_config();
+    if (!oci_config.hooks || !oci_config.hooks->create_container) {
         return;
     }
 
     LINYAPS_BOX_DEBUG() << "Execute create container hooks";
 
-    for (const auto &hook : config.hooks->create_container.value()) {
+    for (const auto &hook : oci_config.hooks->create_container.value()) {
         execute_hook(hook, status);
     }
 
@@ -1479,7 +1470,7 @@ void do_pivot_root(const linyaps_box::container &container,
     }
 
     // make sure that umount event couldn't propagate to host
-    do_propagation_mount(old_root, MS_REC | MS_PRIVATE);
+    container_ns::do_propagation_mount(old_root, MS_REC | MS_PRIVATE);
 
     // umount old root
     ret = umount2(".", MNT_DETACH);
@@ -1547,11 +1538,11 @@ security_status get_runtime_security_status()
     return status;
 }
 
-void set_capabilities(const linyaps_box::Config &config, int last_cap)
+void set_capabilities(const linyaps_box::oci_config &oci_config, int last_cap)
 {
 #ifdef LINYAPS_BOX_ENABLE_CAP
     LINYAPS_BOX_DEBUG() << "Set capabilities";
-    const auto &capabilities = config.process->capabilities;
+    const auto &capabilities = oci_config.process->capabilities;
     if (!capabilities) {
         return;
     }
@@ -1628,15 +1619,22 @@ void set_capabilities(const linyaps_box::Config &config, int last_cap)
     // keep current capabilities, we need these caps on later
     std::ignore = linyaps_box::utils::prctl(PR_SET_KEEPCAPS, 1L, 0L, 0L, 0L);
 
-    const auto &process = *config.process;
-    ret = setresuid(process.user.uid, process.user.uid, process.user.uid);
-    if (UNLIKELY(ret < 0)) {
-        throw std::system_error(errno, std::system_category(), "setresuid");
-    }
-
+    const auto &process = *oci_config.process;
     ret = setresgid(process.user.gid, process.user.gid, process.user.gid);
     if (UNLIKELY(ret < 0)) {
         throw std::system_error(errno, std::system_category(), "setresgid");
+    }
+
+    if (process.user.additional_gids) {
+        ret = setgroups(process.user.additional_gids->size(), process.user.additional_gids->data());
+        if (UNLIKELY(ret < 0)) {
+            throw std::system_error(errno, std::system_category(), "setgroups");
+        }
+    }
+
+    ret = setresuid(process.user.uid, process.user.uid, process.user.uid);
+    if (UNLIKELY(ret < 0)) {
+        throw std::system_error(errno, std::system_category(), "setresuid");
     }
 
     ret = cap_set_proc(caps.get());
@@ -1661,7 +1659,7 @@ void set_capabilities(const linyaps_box::Config &config, int last_cap)
 
 #endif
 
-    if (config.process->no_new_privileges) {
+    if (oci_config.process->no_new_privileges) {
         LINYAPS_BOX_DEBUG() << "Set no new privileges";
         std::ignore = linyaps_box::utils::prctl(PR_SET_NO_NEW_PRIVS, 1L, 0L, 0L, 0L);
     }
@@ -1671,14 +1669,14 @@ void start_container_hooks(const linyaps_box::container &container,
                            const linyaps_box::container_status_t &status,
                            linyaps_box::unix_socket &socket)
 {
-    const auto &config = container.get_config();
-    if (!config.hooks || !config.hooks->start_container) {
+    const auto &oci_config = container.get_config();
+    if (!oci_config.hooks || !oci_config.hooks->start_container) {
         return;
     }
 
     LINYAPS_BOX_DEBUG() << "Execute start container hooks";
 
-    for (const auto &hook : config.hooks->start_container.value()) {
+    for (const auto &hook : oci_config.hooks->start_container.value()) {
         execute_hook(hook, status);
     }
 
@@ -1689,35 +1687,9 @@ void start_container_hooks(const linyaps_box::container &container,
     LINYAPS_BOX_DEBUG() << "Sync message sent";
 }
 
-void close_other_fds(linyaps_box::utils::span<const int> except_fds)
+void processing_extensions(const linyaps_box::oci_config &oci_config)
 {
-    LINYAPS_BOX_DEBUG() << "Close all fds excepts " << [&]() -> std::string {
-        std::stringstream ss;
-        for (auto fd : except_fds) {
-            ss << fd << " ";
-        }
-        return ss.str();
-    }();
-
-    std::vector<int> sorted;
-    sorted.reserve(except_fds.size() + 1);
-    sorted.assign(except_fds.begin(), except_fds.end());
-    std::sort(sorted.begin(), sorted.end());
-    sorted.push_back(std::numeric_limits<int>::max());
-    for (auto fd = sorted.begin(); std::next(fd) != sorted.end(); ++fd) {
-        auto low = *fd + 1;
-        auto high = *std::next(fd) - 1;
-        if (low >= high) {
-            continue;
-        }
-
-        linyaps_box::utils::close_range(low, high, CLOSE_RANGE_CLOEXEC);
-    }
-}
-
-void processing_extensions(const linyaps_box::Config &config)
-{
-    if (!config.annotations) {
+    if (!oci_config.annotations) {
         return;
     }
 
@@ -1729,8 +1701,8 @@ void processing_extensions(const linyaps_box::Config &config)
     // we use this feature for avoiding two process has the same pid.
     // e.g some application will register a tray through dbus and use the pid as the part of
     // dbus object path, if two process has the same pid, the dbus object path will conflict
-    auto it = config.annotations->find("cn.org.linyaps.runtime.ns_last_pid");
-    while (it != config.annotations->end()) {
+    auto it = oci_config.annotations->find("cn.org.linyaps.runtime.ns_last_pid");
+    while (it != oci_config.annotations->end()) {
         LINYAPS_BOX_DEBUG() << "Processing ns_last_pid extension: " << it->second;
 
         // Validate input is a valid pid_t number
@@ -1796,12 +1768,12 @@ void configure_terminal(const linyaps_box::container &container,
 
     auto root = linyaps_box::utils::open("/", O_PATH | O_CLOEXEC | O_DIRECTORY);
 
-    linyaps_box::Config::mount_t mount{ };
+    linyaps_box::oci_config::mount_t mount{ };
     mount.source = slave.file_describer().current_path();
     mount.destination = "/dev/console";
     mount.vfs_flags = MS_BIND;
 
-    auto dest_fd = do_bind_mount(root, mount);
+    auto dest_fd = container_ns::do_bind_mount(root, mount);
     socket.send_fd(std::move(master).take());
 }
 
@@ -1838,20 +1810,12 @@ try {
         throw std::runtime_error("clone_fn: invalid socket fd");
     }
 
-    std::vector<int> except_fds{
-        STDIN_FILENO,
-        STDOUT_FILENO,
-        STDERR_FILENO,
-    };
-
-    for (auto fd = 0; fd < args.preserve_fds; ++fd) {
-        except_fds.push_back(fd + 3);
-    }
-    except_fds.push_back(static_cast<unsigned int>(args.socket.fd().get()));
-    close_other_fds(linyaps_box::utils::span<const int>(except_fds.data(), except_fds.size()));
+    linyaps_box::utils::close_range(3u + static_cast<unsigned>(args.preserve_fds),
+                                     std::numeric_limits<unsigned>::max(),
+                                     CLOSE_RANGE_CLOEXEC);
 
     auto &container = *args.container;
-    const auto &config = container.get_config();
+    const auto &oci_config = container.get_config();
     auto &socket = args.socket;
 
     auto rootfs = container.get_config().root->path;
@@ -1860,20 +1824,21 @@ try {
         rootfs = std::filesystem::canonical(container.get_bundle() / rootfs);
     }
 
-    initialize_container(container.get_config(), socket);
+    container_ns::initialize_container(container.get_config(), socket);
     auto [runtime_cap] = get_runtime_security_status(); // get runtime status before pivot root
-    configure_mounts(container, rootfs);
-    wait_prestart_hooks_result(config, socket);
-    wait_create_runtime_result(config, socket);
+    container_ns::configure_mounts(container, rootfs);
+    wait_prestart_hooks_result(oci_config, socket);
+    wait_create_runtime_result(oci_config, socket);
 
     auto status = container.status();
     create_container_hooks(container, status, socket);
     // TODO: selinux label/apparmor profile
-    auto has_mount_ns = config.linux && config.linux->namespaces
-      && std::any_of(config.linux->namespaces->cbegin(),
-                     config.linux->namespaces->cend(),
+    auto has_mount_ns = oci_config.linux && oci_config.linux->namespaces
+      && std::any_of(oci_config.linux->namespaces->cbegin(),
+                     oci_config.linux->namespaces->cend(),
                      [](const auto &ns) {
-                         return ns.type_ == linyaps_box::Config::linux_t::namespace_t::type::MOUNT;
+                         return ns.type_
+                           == linyaps_box::oci_config::linux_t::namespace_t::type::MOUNT;
                      });
     do_pivot_root(container, rootfs, has_mount_ns);
 
@@ -1884,8 +1849,8 @@ try {
 
     set_umask(container.get_config().process->user.umask);
     // processing all extensions before drop capabilities
-    processing_extensions(config);
-    set_capabilities(config, runtime_cap);
+    processing_extensions(oci_config);
+    set_capabilities(oci_config, runtime_cap);
 
     // unblock and reset all signals before we execute the target
     sigset_t set;
@@ -1894,7 +1859,7 @@ try {
     linyaps_box::utils::reset_signals(set);
 
     start_container_hooks(container, status, socket);
-    execute_process(config);
+    execute_process(oci_config);
 } catch (const std::exception &e) {
     LINYAPS_BOX_ERR() << "clone failed: " << e.what();
 
@@ -1925,7 +1890,7 @@ try {
 namespace runtime_ns {
 
 [[nodiscard]] unsigned generate_clone_flag(
-  const std::optional<std::vector<linyaps_box::Config::linux_t::namespace_t>> &namespaces)
+  const std::optional<std::vector<linyaps_box::oci_config::linux_t::namespace_t>> &namespaces)
 {
     LINYAPS_BOX_DEBUG() << "Generate clone flags";
 
@@ -1988,11 +1953,11 @@ private:
     void *stack_low;
 };
 
-void set_rlimits(const std::vector<linyaps_box::Config::process_t::rlimit_t> &rlimits)
+void set_rlimits(const std::vector<linyaps_box::oci_config::process_t::rlimit_t> &rlimits)
 {
     std::for_each(rlimits.begin(),
                   rlimits.end(),
-                  [](const linyaps_box::Config::process_t::rlimit_t &rlimit) {
+                  [](const linyaps_box::oci_config::process_t::rlimit_t &rlimit) {
                       const struct rlimit rl{ rlimit.soft, rlimit.hard };
                       auto resource = static_cast<int>(rlimit.type);
                       LINYAPS_BOX_DEBUG()
@@ -2007,7 +1972,7 @@ void set_rlimits(const std::vector<linyaps_box::Config::process_t::rlimit_t> &rl
 std::tuple<int, linyaps_box::unix_socket> start_container_process(
   linyaps_box::container &container, linyaps_box::run_container_options_t &options)
 {
-    const auto &config = container.get_config();
+    const auto &oci_config = container.get_config();
     LINYAPS_BOX_DEBUG() << "All opened file describers before open sockets:\n"
                         << linyaps_box::utils::inspect_fds();
 
@@ -2017,13 +1982,13 @@ std::tuple<int, linyaps_box::unix_socket> start_container_process(
                         << linyaps_box::utils::inspect_fds();
 
     // config rlimits before we enter new user namespace
-    if (const auto &rlimits = config.process->rlimits; rlimits) {
+    if (const auto &rlimits = oci_config.process->rlimits; rlimits) {
         set_rlimits(rlimits.value());
     }
 
-    std::optional<std::vector<linyaps_box::Config::linux_t::namespace_t>> namespaces;
-    if (config.linux && config.linux->namespaces) {
-        namespaces = config.linux->namespaces;
+    std::optional<std::vector<linyaps_box::oci_config::linux_t::namespace_t>> namespaces;
+    if (oci_config.linux && oci_config.linux->namespaces) {
+        namespaces = oci_config.linux->namespaces;
     }
 
     const int clone_flag = runtime_ns::generate_clone_flag(namespaces);
@@ -2137,8 +2102,8 @@ void configure_gid_mapping(pid_t pid, linyaps_box::container &container)
 {
     LINYAPS_BOX_DEBUG() << "Configure GID mappings";
 
-    const auto &config = container.get_config();
-    const auto &gid_mappings = config.linux->gid_mappings;
+    const auto &oci_config = container.get_config();
+    const auto &gid_mappings = oci_config.linux->gid_mappings;
     if (!gid_mappings) {
         LINYAPS_BOX_DEBUG() << "Nothing to do";
         return;
@@ -2218,8 +2183,8 @@ void configure_uid_mapping(pid_t pid, const linyaps_box::container &container)
 {
     LINYAPS_BOX_DEBUG() << "Configure UID mappings";
 
-    const auto &config = container.get_config();
-    const auto &uid_mappings = config.linux->uid_mappings;
+    const auto &oci_config = container.get_config();
+    const auto &uid_mappings = oci_config.linux->uid_mappings;
     if (!uid_mappings) {
         LINYAPS_BOX_DEBUG() << "Nothing to do";
         return;
@@ -2330,9 +2295,9 @@ void configure_container_namespaces(linyaps_box::container &container,
 
             if (std::find_if(namespaces->cbegin(),
                              namespaces->cend(),
-                             [](const linyaps_box::Config::linux_t::namespace_t &ns) -> bool {
+                             [](const linyaps_box::oci_config::linux_t::namespace_t &ns) -> bool {
                                  return ns.type_
-                                   == linyaps_box::Config::linux_t::namespace_t::type::USER;
+                                   == linyaps_box::oci_config::linux_t::namespace_t::type::USER;
                              })
                 != namespaces->end()) {
                 auto pid = container.status().PID;
@@ -2488,17 +2453,17 @@ void poststop_hooks(const linyaps_box::container &container) noexcept
 linyaps_box::container::container(status_directory status_dir,
                                   const create_container_options_t &options)
     : container_ref(std::move(status_dir), options.ID)
-    , bundle(options.bundle)
+    , bundle(std::filesystem::canonical(options.bundle))
 {
     auto config = options.config;
     if (config.is_relative()) {
         config = bundle / config;
     }
 
-    LINYAPS_BOX_DEBUG() << "load config from " << config;
-    this->config = linyaps_box::Config::parse(config);
+    LINYAPS_BOX_DEBUG() << "load oci_config from " << config;
+    this->config = linyaps_box::oci_config::parse(config);
     auto &mount = this->config.mounts;
-    std::for_each(mount.begin(), mount.end(), [this](Config::mount_t &mount) {
+    std::for_each(mount.begin(), mount.end(), [this](oci_config::mount_t &mount) {
         if (mount.destination.is_relative()) {
             throw std::runtime_error("destination of mount point is relative");
         }
@@ -2532,7 +2497,7 @@ linyaps_box::container::container(status_directory status_dir,
 #endif
     {
         container_status_t status;
-        status.oci_version = linyaps_box::Config::oci_version;
+        status.oci_version = linyaps_box::oci_config::version;
         status.ID = options.ID;
         status.PID = getpid();
         status.status = container_status_t::runtime_status::CREATING;
@@ -2558,7 +2523,7 @@ linyaps_box::container::container(status_directory status_dir,
     }
 }
 
-const linyaps_box::Config &linyaps_box::container::get_config() const
+const linyaps_box::oci_config &linyaps_box::container::get_config() const
 {
     return this->config;
 }

--- a/src/linyaps_box/container.h
+++ b/src/linyaps_box/container.h
@@ -37,7 +37,7 @@ public:
     container(container &&) = delete;
     auto operator=(container &&) -> container & = delete;
 
-    [[nodiscard]] auto get_config() const -> const linyaps_box::Config &;
+    [[nodiscard]] auto get_config() const -> const linyaps_box::oci_config &;
     [[nodiscard]] auto get_bundle() const -> const std::filesystem::path &;
     [[nodiscard]] auto run(run_container_options_t options) -> int;
 
@@ -66,7 +66,7 @@ public:
 
 private:
     void cgroup_preenter(const cgroup_options &options, utils::file_descriptor &dirfd);
-    linyaps_box::Config config;
+    linyaps_box::oci_config config;
     std::filesystem::path bundle;
     std::unique_ptr<cgroup_manager> manager;
     unsigned long rootfs_propagation_{ 0 };

--- a/src/linyaps_box/container_monitor.cpp
+++ b/src/linyaps_box/container_monitor.cpp
@@ -5,7 +5,6 @@
 #include "linyaps_box/container_monitor.h"
 
 #include "linyaps_box/utils/file.h"
-#include "linyaps_box/utils/log.h"
 #include "linyaps_box/utils/process.h"
 #include "linyaps_box/utils/signal.h"
 #include "linyaps_box/utils/terminal.h"
@@ -16,6 +15,61 @@
 #include <algorithm>
 
 namespace linyaps_box {
+namespace {
+
+// Detect a local terminal to mirror window-resize events from.
+// Prefers stdin, then stdout; falls back to /dev/tty, then /dev/console.
+auto detect_host_tty(const linyaps_box::utils::file_descriptor &in,
+                     const linyaps_box::utils::file_descriptor &out)
+  -> std::optional<terminal_slave>
+{
+    if (utils::isatty(in)) {
+        return terminal_slave{ in.duplicate() };
+    }
+
+    if (utils::isatty(out)) {
+        return terminal_slave{ out.duplicate() };
+    }
+
+    // No controlling terminal — try /dev/tty, then /dev/console as last resort.
+    for (const auto *path : { "/dev/tty", "/dev/console" }) {
+        try {
+            return terminal_slave{ utils::open(path, O_RDWR | O_CLOEXEC) };
+        } catch (const std::system_error &) {
+            continue;
+        }
+    }
+
+    return std::nullopt;
+}
+
+// Dispatch EPOLLERR / EPOLLHUP on a forwarder's src/dst fds.
+void handle_fd_error(const struct epoll_event &ev,
+                     std::optional<io::Forwarder> &in_fwd,
+                     std::optional<io::Forwarder> &out_fwd)
+{
+    if ((ev.events & (EPOLLERR | EPOLLHUP)) == 0) {
+        return;
+    }
+
+    auto mark = [fd = ev.data.fd](io::Forwarder &fwd) {
+        if (fwd.src().get() == fd) {
+            fwd.mark_src_eof();
+        }
+        if (fwd.dst().get() == fd) {
+            fwd.mark_dst_failed();
+        }
+    };
+
+    if (in_fwd) {
+        mark(*in_fwd);
+    }
+    if (out_fwd) {
+        mark(*out_fwd);
+    }
+}
+
+} // anonymous namespace
 
 auto container_monitor::enable_signal_forwarding() -> void
 {
@@ -25,25 +79,20 @@ auto container_monitor::enable_signal_forwarding() -> void
 
     signal_fd = utils::create_signalfd(set);
 
-    // try to reap child process. Child process may exit before we create signalfd and it wouldn't
-    // receive SIGCHLD anymore. If we don't do this, the child process (or its children) will be
-    // zombie process
-
+    // Reap any children that exited before signalfd was installed.
+    // Without this they'd become zombies — signalfd only delivers SIGCHLD
+    // for future events.
     while (true) {
         auto ret = linyaps_box::utils::waitpid(-1, WNOHANG);
-        if (ret.status == linyaps_box::utils::WaitStatus::Reaped) {
-            if (ret.pid == pid) {
-                // maybe child exited and output something, we should't exit here immediately
-                LINYAPS_BOX_DEBUG() << "child exited early with code " << ret.exit_code;
-                child_exited = true;
-                exit_code = WIFSIGNALED(ret.exit_code) ? 128 + WTERMSIG(ret.exit_code)
-                                                       : WEXITSTATUS(ret.exit_code);
-            }
-
-            continue;
+        if (ret.status != linyaps_box::utils::WaitStatus::Reaped) {
+            break;
         }
 
-        break;
+        if (ret.pid == pid) {
+            child_exited = true;
+            exit_code = WIFSIGNALED(ret.exit_code) ? 128 + WTERMSIG(ret.exit_code)
+                                                   : WEXITSTATUS(ret.exit_code);
+        }
     }
 
     auto signalfd_pollable = epoll.add(signal_fd, EPOLLIN);
@@ -99,19 +148,16 @@ auto container_monitor::enable_io_forwarding(terminal_master master,
                                              const linyaps_box::utils::file_descriptor &in,
                                              const linyaps_box::utils::file_descriptor &out) -> void
 {
-    if (utils::isatty(in)) {
-        host_tty.emplace(in.duplicate());
-    } else if (utils::isatty(out)) {
-        host_tty.emplace(out.duplicate());
-    } else {
-        auto default_tty = utils::open("/dev/tty", O_RDWR | O_CLOEXEC);
-        host_tty.emplace(std::move(default_tty));
+    host_tty = detect_host_tty(in, out);
+    if (host_tty) {
+        host_tty->set_raw();
     }
-
-    host_tty->set_raw();
 
     this->master = std::move(master);
 
+    // The PTY master fd is used bidirectionally: we write stdin into it AND
+    // read its output back to stdout.  epoll needs two independent fd
+    // registrations, so we duplicate the master fd here.
     this->master->get().set_nonblock(true);
     master_out = this->master.value().get().duplicate();
     master_out->set_nonblock(true);
@@ -129,33 +175,32 @@ auto container_monitor::enable_io_forwarding(terminal_master master,
     out_fwd->set_src(master_out.value());
     out_fwd->set_dst(out);
 
-    if (in_fwd) {
-        in_fwd->drive();
-    }
+    // Prime the IO loop — drain any data already buffered.
+    auto drive_and_cleanup = [](std::optional<io::Forwarder> &fwd) {
+        if (!fwd) {
+            return;
+        }
+        fwd->drive();
+        if (fwd->is_finished()) {
+            fwd.reset();
+        }
+    };
 
-    if (out_fwd) {
-        out_fwd->drive();
-    }
-
-    if (in_fwd && in_fwd->is_finished()) {
-        in_fwd.reset();
-    }
-
-    if (out_fwd && out_fwd->is_finished()) {
-        out_fwd.reset();
-    }
+    drive_and_cleanup(in_fwd);
+    drive_and_cleanup(out_fwd);
 }
 
 auto container_monitor::wait_container_exit() -> int
 {
-    // After we enable io forwarding, there may be some data in
-    // the buffers, we should try to forward them immediately before waiting for epoll events.
+    // After IO forwarding is set up, there may already be data in flight.
+    // Spin once with timeout=0 to drain it without blocking.
     bool need_immediate_spin{ true };
+
     while (!child_exited || out_fwd) {
-        auto timeout = need_immediate_spin ? 0 : -1;
+        const auto timeout = need_immediate_spin ? 0 : -1;
         const auto events = epoll.wait(timeout);
 
-        // handle signals at first to avoid unnecessary latency
+        // Handle signals before data forwarding to keep latency low.
         const auto *triggered_signal = std::find_if(events.cbegin(),
                                                     events.cend(),
                                                     [signal_fd = signal_fd.get()](const auto &e) {
@@ -165,11 +210,13 @@ auto container_monitor::wait_container_exit() -> int
         if (triggered_signal != events.cend()) {
             handle_signals();
 
+            // Once the child has exited, the PTY will shut down soon.
+            // Mark the forwarders so the event loop can drain remaining
+            // output and then terminate.
             if (child_exited) {
                 if (in_fwd) {
                     in_fwd->mark_dst_failed();
                 }
-
                 if (out_fwd) {
                     out_fwd->mark_src_eof();
                 }
@@ -180,28 +227,7 @@ auto container_monitor::wait_container_exit() -> int
             if (ev.data.fd == signal_fd.get()) {
                 continue;
             }
-
-            if ((ev.events & (EPOLLERR | EPOLLHUP)) != 0) {
-                if (in_fwd) {
-                    if (ev.data.fd == in_fwd->src().get()) {
-                        in_fwd->mark_src_eof();
-                    }
-
-                    if (ev.data.fd == in_fwd->dst().get()) {
-                        in_fwd->mark_dst_failed();
-                    }
-                }
-
-                if (out_fwd) {
-                    if (ev.data.fd == out_fwd->src().get()) {
-                        out_fwd->mark_src_eof();
-                    }
-
-                    if (ev.data.fd == out_fwd->dst().get()) {
-                        out_fwd->mark_dst_failed();
-                    }
-                }
-            }
+            handle_fd_error(ev, in_fwd, out_fwd);
         }
 
         bool in_work{ false };
@@ -210,17 +236,17 @@ auto container_monitor::wait_container_exit() -> int
         if (in_fwd) {
             in_work = in_fwd->drive();
         }
-
         if (out_fwd) {
             out_work = out_fwd->drive();
         }
 
         need_immediate_spin = in_work || out_work;
 
+        // Release finished forwarders so the loop exit condition can
+        // eventually be satisfied.
         if (in_fwd && in_fwd->is_finished()) {
             in_fwd.reset();
         }
-
         if (out_fwd && out_fwd->is_finished()) {
             out_fwd.reset();
         }

--- a/src/linyaps_box/container_monitor.h
+++ b/src/linyaps_box/container_monitor.h
@@ -26,7 +26,7 @@ public:
     auto enable_io_forwarding(terminal_master master,
                               const linyaps_box::utils::file_descriptor &in,
                               const linyaps_box::utils::file_descriptor &out) -> void;
-    auto wait_container_exit() -> int;
+    [[nodiscard]] auto wait_container_exit() -> int;
 
 private:
     auto handle_signals() -> void;

--- a/src/linyaps_box/container_ref.cpp
+++ b/src/linyaps_box/container_ref.cpp
@@ -5,145 +5,427 @@
 #include "linyaps_box/container_ref.h"
 
 #include "linyaps_box/container_monitor.h"
-#include "linyaps_box/socket.h"
 #include "linyaps_box/terminal.h"
+#include "linyaps_box/utils/close_range.h"
 #include "linyaps_box/utils/defer.h"
 #include "linyaps_box/utils/log.h"
+#include "linyaps_box/utils/platform.h"
 #include "linyaps_box/utils/process.h"
 #include "linyaps_box/utils/session.h"
+#include "linyaps_box/utils/setns.h"
 
+#include <algorithm>
 #include <csignal> // IWYU pragma: keep
+#include <cstdint>
+#include <fstream>
+#include <limits>
 #include <utility>
+#include <vector>
 
+#include <grp.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
-linyaps_box::container_ref::container_ref(status_directory status_dir, std::string id)
-    : id_(std::move(id))
-    , status_dir_(std::move(status_dir))
+namespace {
+
+enum class SyncType : uint8_t {
+    GrandchildPid,
+    ConsoleFd,
+    Proceed,
+};
+
+struct SyncMessage
 {
+    SyncType type;
+    pid_t pid;
+};
+
+auto resolve_final_process(linyaps_box::exec_container_option &option,
+                           const linyaps_box::oci_config &config)
+  -> linyaps_box::oci_config::process_t &
+{
+    if (!option.proc) {
+        option.proc = config.process ? *config.process : linyaps_box::oci_config::process_t{ };
+    }
+
+    auto &proc = *option.proc;
+
+    if (option.cwd) {
+        proc.cwd = std::move(*option.cwd);
+    }
+
+    if (proc.cwd.empty()) {
+        proc.cwd = "/";
+    }
+
+    if (option.tty) {
+        proc.terminal = option.tty;
+    }
+
+    if (option.no_new_privs) {
+        proc.no_new_privileges = option.no_new_privs;
+    }
+
+    if (!option.extra_envs.empty()) {
+        if (!proc.env) {
+            proc.env.emplace();
+        }
+
+        proc.env->insert(proc.env->end(),
+                         std::make_move_iterator(option.extra_envs.begin()),
+                         std::make_move_iterator(option.extra_envs.end()));
+    }
+
+    if (!option.command.empty()) {
+        proc.args = std::move(option.command);
+    }
+
+    if (option.uid) {
+        proc.user.uid = *option.uid;
+    }
+
+    if (option.gid) {
+        proc.user.gid = *option.gid;
+    }
+
+#ifdef LINYAPS_BOX_ENABLE_CAP
+    if (option.caps) {
+        if (!proc.capabilities) {
+            proc.capabilities.emplace();
+        }
+
+        proc.capabilities->effective = *option.caps;
+        proc.capabilities->ambient = *option.caps;
+        proc.capabilities->bounding = *option.caps;
+        proc.capabilities->permitted = *option.caps;
+    }
+#endif
+
+    return proc;
 }
 
-linyaps_box::container_ref::~container_ref() noexcept = default;
-
-linyaps_box::container_status_t linyaps_box::container_ref::status() const
+auto has_pid_namespace(const linyaps_box::oci_config &config) -> bool
 {
-    return status_dir_.read();
+    if (!config.linux || !config.linux->namespaces) {
+        return false;
+    }
+
+    return std::any_of(config.linux->namespaces->cbegin(),
+                       config.linux->namespaces->cend(),
+                       [](const auto &ns) {
+                           return ns.type_
+                             == linyaps_box::oci_config::linux_t::namespace_t::type::PID;
+                       });
 }
 
-void linyaps_box::container_ref::kill(int signal) const
+void child_setup_terminal(const linyaps_box::oci_config::process_t &proc,
+                          linyaps_box::unix_socket &child_sock,
+                          const linyaps_box::exec_container_option &option)
 {
-    auto pid = this->status().PID;
-
-    LINYAPS_BOX_DEBUG() << "kill process " << pid << " with signal " << signal;
-    if (::kill(pid, signal) == 0) {
+    if (!proc.terminal) {
         return;
     }
 
-    std::stringstream ss;
-    ss << "failed to kill process " << pid << " with signal " << signal;
-    throw std::system_error(errno, std::system_category(), std::move(ss).str());
+    auto [master, slave] = linyaps_box::create_pty_pair();
+
+    slave.setup_stdio();
+    if (proc.console_size) {
+        slave.set_size({ proc.console_size->height, proc.console_size->width, 0, 0 });
+    }
+
+    if (option.console_socket) {
+        option.console_socket->send_fd(std::move(master).take());
+    } else {
+        child_sock.send_msg_with_fd(std::move(master).take(),
+                                    SyncMessage{ SyncType::ConsoleFd, 0 });
+    }
 }
 
-auto linyaps_box::container_ref::exec(exec_container_option option) -> int
+void child_apply_credentials(const linyaps_box::oci_config::process_t &proc)
 {
-    auto target = std::to_string(this->status().PID);
-
-    std::ignore = utils::prctl(PR_SET_CHILD_SUBREAPER, 1L, 0L, 0L, 0L);
-
-    std::optional<unix_socket> recv_socketpair;
-    if (option.proc.terminal && !option.console_socket) {
-        auto [socket1, socket2] = linyaps_box::unix_socket::pair();
-        option.console_socket = unix_socket{ std::move(socket1) };
-        recv_socketpair = unix_socket{ std::move(socket2) };
+    if (proc.user.umask) {
+        ::umask(*proc.user.umask);
     }
 
-    auto child = fork();
-    if (child < 0) {
-        throw std::system_error(errno, std::system_category(), "fork");
+    if (proc.user.uid == 0 && proc.user.gid == 0 && !proc.user.additional_gids) {
+        return;
     }
 
-    if (child == 0) {
-        if (option.console_socket) {
-            utils::setsid();
-            auto [master, slave] = create_pty_pair();
-
-            slave.setup_stdio();
-            slave.set_size({ });
-
-            option.console_socket->send_fd(std::move(master).take());
-            option.console_socket.reset();
-        }
-
-        std::vector<const char *> argv{ "nsenter", "--target", target.c_str() };
-
-        auto path = status_dir_.config();
-        auto config = Config::parse(path);
-        const auto &linux = config.linux;
-        if (!linux) {
-            throw std::runtime_error("container config missing linux section");
-        }
-
-        // FIXME: we assume that container always unshare some namespaces for now
-        // support exec commands without setns in the future
-        for (const auto &ns : linux->namespaces.value()) {
-            switch (ns.type_) {
-            case Config::linux_t::namespace_t::type::IPC: {
-                argv.push_back("--ipc");
-            } break;
-            case Config::linux_t::namespace_t::type::UTS: {
-                argv.push_back("--uts");
-            } break;
-            case Config::linux_t::namespace_t::type::MOUNT: {
-                argv.push_back("--mount");
-            } break;
-            case Config::linux_t::namespace_t::type::PID: {
-                argv.push_back("--pid");
-            } break;
-            case Config::linux_t::namespace_t::type::NET: {
-                argv.push_back("--net");
-            } break;
-            case Config::linux_t::namespace_t::type::USER: {
-                argv.push_back("--user");
-            } break;
-            case Config::linux_t::namespace_t::type::CGROUP: {
-                argv.push_back("--cgroup");
-            } break;
-            case Config::linux_t::namespace_t::type::TIME: {
-                argv.push_back("--time");
-            } break;
-            }
-        }
-        argv.push_back("--preserve-credentials");
-
-        for (const auto &arg : option.proc.args) {
-            argv.push_back(arg.c_str());
-        }
-        argv.push_back(nullptr);
-
-        std::vector<const char *> c_env;
-        if (option.proc.env) {
-            c_env.reserve(option.proc.env->size());
-            for (const auto &env : *option.proc.env) {
-                c_env.push_back(env.c_str());
-            }
-        }
-        c_env.push_back(nullptr);
-
-        ::execvpe("nsenter", const_cast<char **>(argv.data()), const_cast<char **>(c_env.data()));
+    if (::setresgid(proc.user.gid, proc.user.gid, proc.user.gid) != 0) {
         _exit(EXIT_FAILURE);
     }
 
-    container_monitor monitor{ child };
+    if (proc.user.additional_gids) {
+        if (::setgroups(proc.user.additional_gids->size(), proc.user.additional_gids->data())
+            != 0) {
+            _exit(EXIT_FAILURE);
+        }
+    }
+
+    if (::setresuid(proc.user.uid, proc.user.uid, proc.user.uid) != 0) {
+        _exit(EXIT_FAILURE);
+    }
+
+    for (auto fd : { STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO }) {
+        if (::fchown(fd, proc.user.uid, proc.user.gid) != 0) {
+            if (errno != EINVAL && errno != ENOSYS) {
+                _exit(EXIT_FAILURE);
+            }
+        }
+    }
+}
+
+void child_apply_environment(const linyaps_box::oci_config::process_t &proc,
+                             const linyaps_box::oci_config &config)
+{
+    ::clearenv();
+
+    if (config.process) {
+        for (const auto &env : *config.process->env) {
+            if (linyaps_box::utils::is_invalid_env(env)) {
+                continue;
+            }
+            auto eq = env.find('=');
+            ::setenv(env.substr(0, eq).c_str(), env.substr(eq + 1).c_str(), 1);
+        }
+    }
+
+    if (proc.env) {
+        for (const auto &env : *proc.env) {
+            if (linyaps_box::utils::is_invalid_env(env)) {
+                continue;
+            }
+            auto eq = env.find('=');
+            ::setenv(env.substr(0, eq).c_str(), env.substr(eq + 1).c_str(), 1);
+        }
+    }
+}
+
+void child_apply_rlimits(const linyaps_box::oci_config::process_t &proc)
+{
+    if (!proc.rlimits) {
+        return;
+    }
+
+    for (const auto &rl : *proc.rlimits) {
+        auto resource = static_cast<int>(rl.type);
+        const struct rlimit limit{ rl.soft, rl.hard };
+        if (::setrlimit(resource, &limit) != 0) {
+            _exit(EXIT_FAILURE);
+        }
+    }
+}
+
+#ifdef LINYAPS_BOX_ENABLE_CAP
+void child_apply_capabilities(const linyaps_box::oci_config::process_t &proc,
+                              const linyaps_box::oci_config &config)
+{
+    // Determine which caps to apply: prefer the exec-specific set, fall back to
+    // the container's config.json default if the exec set is entirely empty.
+    auto effective_caps =
+      [&]() -> std::optional<linyaps_box::oci_config::process_t::capabilities_t> {
+        if (!proc.capabilities) {
+            return config.process->capabilities;
+        }
+
+        auto all_empty = [](const linyaps_box::oci_config::process_t::capabilities_t &c) {
+            return (!c.effective || c.effective->empty()) && (!c.bounding || c.bounding->empty())
+              && (!c.inheritable || c.inheritable->empty())
+              && (!c.permitted || c.permitted->empty()) && (!c.ambient || c.ambient->empty());
+        };
+
+        if (all_empty(*proc.capabilities)) {
+            return config.process->capabilities;
+        }
+
+        return proc.capabilities;
+    }();
+
+    if (!effective_caps) {
+        return;
+    }
+
+    auto should_apply = [](const linyaps_box::oci_config::process_t::capabilities_t &c) {
+        return (c.effective && !c.effective->empty()) || (c.bounding && !c.bounding->empty())
+          || (c.inheritable && !c.inheritable->empty()) || (c.permitted && !c.permitted->empty())
+          || (c.ambient && !c.ambient->empty());
+    };
+
+    if (!should_apply(*effective_caps)) {
+        return;
+    }
+
+    LINYAPS_BOX_DEBUG() << "Set capabilities for exec";
+
+    // Drop every cap not in the bounding set.
+    if (effective_caps->bounding) {
+        const auto &bounding_set = *effective_caps->bounding;
+        std::ifstream cap_file("/proc/sys/kernel/cap_last_cap");
+        unsigned long last_cap{ 0 };
+        cap_file >> last_cap;
+        for (unsigned long cap = 0; cap < last_cap; ++cap) {
+            if (std::find(bounding_set.cbegin(), bounding_set.cend(), static_cast<int>(cap))
+                == bounding_set.cend()) {
+                if (cap_drop_bound(static_cast<int>(cap)) < 0) {
+                    throw std::system_error(errno, std::system_category(), "cap_drop_bound");
+                }
+            }
+        }
+    }
+
+    auto *cap = cap_init();
+    if (cap == nullptr) {
+        throw std::system_error(errno, std::system_category(), "cap_init");
+    }
+    const std::unique_ptr<_cap_struct, decltype(&cap_free)> caps(cap, cap_free);
+
+    auto set_cap_flag = [&caps](const std::vector<cap_value_t> &cap_set, cap_flag_t flag) {
+        if (cap_set.empty()) {
+            return;
+        }
+        auto ret = cap_set_flag(caps.get(), flag, cap_set.size(), cap_set.data(), CAP_SET);
+        if (ret < 0) {
+            throw std::system_error(errno, std::system_category(), "cap_set_flag");
+        }
+    };
+
+    if (effective_caps->effective) {
+        set_cap_flag(*effective_caps->effective, CAP_EFFECTIVE);
+    }
+
+    if (effective_caps->permitted) {
+        set_cap_flag(*effective_caps->permitted, CAP_PERMITTED);
+    }
+
+    if (effective_caps->inheritable) {
+        set_cap_flag(*effective_caps->inheritable, CAP_INHERITABLE);
+    }
+
+    if (cap_set_proc(caps.get()) < 0) {
+        throw std::system_error(errno, std::system_category(), "cap_set_proc");
+    }
+
+    std::ignore = linyaps_box::utils::prctl(PR_SET_KEEPCAPS, 1);
+
+    if (cap_set_proc(caps.get()) < 0) {
+        throw std::system_error(errno, std::system_category(), "cap_set_proc");
+    }
+
+    std::ignore = linyaps_box::utils::prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0L, 0L, 0L);
+    if (effective_caps->ambient) {
+        for (const auto &ambient : *effective_caps->ambient) {
+            std::ignore =
+              linyaps_box::utils::prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, ambient, 0L, 0L);
+        }
+    }
+}
+#endif // LINYAPS_BOX_ENABLE_CAP
+
+[[noreturn]] void exec_child_process(pid_t target_pid,
+                                     const linyaps_box::oci_config &config,
+                                     const linyaps_box::oci_config::process_t &proc,
+                                     const linyaps_box::exec_container_option &option,
+                                     linyaps_box::unix_socket child_sock)
+try {
+    bool pid_ns{ false };
+    if (config.linux && config.linux->namespaces) {
+        linyaps_box::utils::join_container_namespaces(target_pid, *config.linux);
+        pid_ns = has_pid_namespace(config);
+    }
+
+    // Double-fork for PID namespace
+    if (pid_ns) {
+        auto grandchild = ::fork();
+        if (grandchild < 0) {
+            _exit(EXIT_FAILURE);
+        }
+
+        if (grandchild > 0) {
+            child_sock.send_msg(SyncMessage{ SyncType::GrandchildPid, grandchild });
+            _exit(EXIT_SUCCESS);
+        }
+    } else {
+        child_sock.send_msg(SyncMessage{ SyncType::GrandchildPid, ::getpid() });
+    }
+
+    linyaps_box::utils::setsid();
+
+    child_setup_terminal(proc, child_sock, option);
+
+    // Sync socket is no longer needed — close before fd cleanup and exec.
+    child_sock.close();
+
+    child_apply_environment(proc, config);
+
+    child_apply_rlimits(proc);
+
+    linyaps_box::utils::close_range(3U + static_cast<unsigned>(option.preserve_fds),
+                                    std::numeric_limits<unsigned>::max(),
+                                    CLOSE_RANGE_CLOEXEC);
+
+    child_apply_credentials(proc);
+
+    if (proc.no_new_privileges) {
+        LINYAPS_BOX_DEBUG() << "Set no new privileges";
+        std::ignore = linyaps_box::utils::prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+    }
+
+#ifdef LINYAPS_BOX_ENABLE_CAP
+    child_apply_capabilities(proc, config);
+#endif
+
+    std::vector<const char *> c_args;
+    c_args.reserve(proc.args.size() + 1);
+    for (const auto &arg : proc.args) {
+        c_args.push_back(arg.c_str());
+    }
+    c_args.push_back(nullptr);
+
+    std::vector<const char *> c_env;
+    if (proc.env) {
+        c_env.reserve(proc.env->size() + 1);
+        for (const auto &env : *proc.env) {
+            c_env.push_back(env.c_str());
+        }
+    }
+    c_env.push_back(nullptr);
+
+    auto ret = ::chdir(proc.cwd.c_str());
+    if (ret != 0) {
+        throw std::system_error(errno, std::system_category(), "chdir");
+    }
+
+    ::execvpe(c_args.at(0),
+              const_cast<char *const *>(c_args.data()),
+              const_cast<char *const *>(c_env.data()));
+
+    throw std::system_error(errno, std::system_category(), "execvpe");
+} catch (const std::exception &e) {
+    LINYAPS_BOX_ERR() << "child process fatal error: " << e.what();
+    _exit(EXIT_FAILURE);
+}
+
+auto exec_parent_process(linyaps_box::unix_socket &parent_sock,
+                         const linyaps_box::oci_config::process_t &proc,
+                         const linyaps_box::exec_container_option &option) -> int
+{
+    auto pid_msg = parent_sock.recv_msg<SyncMessage>();
+    if (pid_msg.type != SyncType::GrandchildPid) {
+        throw std::runtime_error("unexpected sync message type");
+    }
+
+    linyaps_box::container_monitor monitor{ pid_msg.pid };
     monitor.enable_signal_forwarding();
 
-    auto in = utils::file_descriptor{ STDIN_FILENO, false };
-    auto out = utils::file_descriptor{ STDOUT_FILENO, false };
+    auto in = linyaps_box::utils::file_descriptor{ STDIN_FILENO, false };
+    auto out = linyaps_box::utils::file_descriptor{ STDOUT_FILENO, false };
 
     bool changed{ false };
     auto in_flags = in.flags();
     auto out_flags = out.flags();
 
-    auto restore_if_changed = utils::make_defer([&]() noexcept {
+    auto restore_if_changed = linyaps_box::utils::make_defer([&]() noexcept {
         if (!changed) {
             return;
         }
@@ -158,34 +440,89 @@ auto linyaps_box::container_ref::exec(exec_container_option option) -> int
         }
     });
 
-    [&recv_socketpair, &monitor, &in, &out, &changed]() {
-        if (!recv_socketpair) {
-            return;
+    if (proc.terminal && !option.console_socket) {
+        auto [msg, master_fd] = parent_sock.recv_msg_with_fd<SyncMessage>();
+        if (msg.type != SyncType::ConsoleFd) {
+            throw std::runtime_error("unexpected sync message type");
         }
-
-        LINYAPS_BOX_DEBUG() << "Container requires a terminal";
-
-        std::string payload;
-        auto master = terminal_master{ recv_socketpair->recv_fd(payload) };
-
-        recv_socketpair->release();
 
         in.set_nonblock(true);
         out.set_nonblock(true);
         changed = true;
 
-        monitor.enable_io_forwarding(std::move(master), in, out);
-    }();
+        monitor.enable_io_forwarding(linyaps_box::terminal_master{ std::move(master_fd) }, in, out);
+    }
+
+    parent_sock.close();
 
     return monitor.wait_container_exit();
 }
 
-const linyaps_box::status_directory &linyaps_box::container_ref::status_dir() const
+} // anonymous namespace
+
+namespace linyaps_box {
+
+container_ref::container_ref(status_directory status_dir, std::string id)
+    : id_(std::move(id))
+    , status_dir_(std::move(status_dir))
+{
+}
+
+container_ref::~container_ref() noexcept = default;
+
+container_status_t linyaps_box::container_ref::status() const
+{
+    return status_dir_.read();
+}
+
+void container_ref::kill(int signal) const
+{
+    auto pid = this->status().PID;
+
+    LINYAPS_BOX_DEBUG() << "kill process " << pid << " with signal " << signal;
+    if (::kill(pid, signal) == 0) {
+        return;
+    }
+
+    std::stringstream ss;
+    ss << "failed to kill process " << pid << " with signal " << signal;
+    throw std::system_error(errno, std::system_category(), std::move(ss).str());
+}
+
+auto container_ref::exec(exec_container_option option) const -> int
+{
+    auto target_pid = this->status().PID;
+
+    std::ignore = utils::prctl(PR_SET_CHILD_SUBREAPER, 1L, 0L, 0L, 0L);
+
+    auto config = oci_config::parse(status_dir_.config());
+    auto &proc = resolve_final_process(option, config);
+
+    auto [parent_sock, child_sock] = unix_socket::pair();
+
+    auto child = ::fork();
+    if (UNLIKELY(child < 0)) {
+        throw std::system_error(errno, std::system_category(), "fork");
+    }
+
+    if (child == 0) {
+        parent_sock.close();
+        exec_child_process(target_pid, config, proc, option, std::move(child_sock));
+    }
+
+    child_sock.close();
+
+    return exec_parent_process(parent_sock, proc, option);
+}
+
+const status_directory &container_ref::status_dir() const
 {
     return status_dir_;
 }
 
-const std::string &linyaps_box::container_ref::get_id() const
+const std::string &container_ref::get_id() const
 {
     return id_;
 }
+
+} // namespace linyaps_box

--- a/src/linyaps_box/container_ref.h
+++ b/src/linyaps_box/container_ref.h
@@ -11,12 +11,27 @@
 
 #include <string>
 
+#include <sys/types.h>
+
 namespace linyaps_box {
 
 struct exec_container_option
 {
-    int preserve_fds;
-    Config::process_t proc;
+    int preserve_fds{ 0 };
+    std::optional<oci_config::process_t> proc;
+
+    // Per-field overrides applied on top of option.proc or config.json's process:
+    std::optional<uid_t> uid;
+    std::optional<gid_t> gid;
+    std::optional<std::filesystem::path> cwd;
+    std::optional<bool> tty;
+    std::optional<bool> no_new_privs;
+    std::vector<std::string> extra_envs;
+    std::vector<std::string> command;
+#ifdef LINYAPS_BOX_ENABLE_CAP
+    std::optional<std::vector<cap_value_t>> caps;
+#endif
+
     std::optional<unix_socket> console_socket;
 };
 
@@ -33,7 +48,7 @@ public:
 
     [[nodiscard]] auto status() const -> container_status_t;
     void kill(int signal) const;
-    [[nodiscard]] auto exec(exec_container_option option) -> int;
+    [[nodiscard]] auto exec(exec_container_option option) const -> int;
 
 protected:
     [[nodiscard]] auto status_dir() const -> const status_directory &;

--- a/src/linyaps_box/status_directory_manager.cpp
+++ b/src/linyaps_box/status_directory_manager.cpp
@@ -6,10 +6,21 @@
 
 #include "linyaps_box/utils/log.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <utility>
 
 namespace linyaps_box {
+
+namespace {
+
+auto is_valid_id_char(char c) noexcept -> bool
+{
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+      || c == '_' || c == '+' || c == '-' || c == '.';
+}
+
+} // namespace
 
 status_directory_manager::status_directory_manager(std::filesystem::path root)
     : root_(std::move(root))
@@ -42,8 +53,24 @@ auto status_directory_manager::list() const -> std::vector<std::string>
     return ret;
 }
 
+auto status_directory_manager::validate_id(std::string_view id) -> void
+{
+    if (id.empty()) {
+        throw std::invalid_argument("container ID must not be empty");
+    }
+
+    if (id.front() == '.') {
+        throw std::invalid_argument("invalid container ID: " + std::string(id));
+    }
+
+    if (!std::all_of(id.begin(), id.end(), is_valid_id_char)) {
+        throw std::invalid_argument("invalid container ID: " + std::string(id));
+    }
+}
+
 auto status_directory_manager::get(std::string_view id) const -> status_directory
 {
+    validate_id(id);
     return status_directory(root_ / id);
 }
 

--- a/src/linyaps_box/status_directory_manager.h
+++ b/src/linyaps_box/status_directory_manager.h
@@ -22,6 +22,8 @@ public:
     [[nodiscard]] auto get(std::string_view id) const -> status_directory;
 
 private:
+    static auto validate_id(std::string_view id) -> void;
+
     std::filesystem::path root_;
 };
 

--- a/src/linyaps_box/unix_socket.cpp
+++ b/src/linyaps_box/unix_socket.cpp
@@ -26,30 +26,10 @@ unix_socket unix_socket::connect(const std::filesystem::path &path)
     return unix_socket(std::move(socket));
 }
 
-// TODO: support request/response
-// https://github.com/opencontainers/runtime-tools/blob/v0.9.0/docs/command-line-interface.md#console-socket
-auto unix_socket::send_fd(utils::file_descriptor &&fd, std::string_view payload) const -> void
+auto unix_socket::send_cmsg(struct iovec &iov, int fd) const -> void
 {
-    if (!fd.valid()) {
-        throw std::runtime_error("invalid file descriptor");
-    }
-
-    LINYAPS_BOX_DEBUG() << "Send fd \n"
-                        << utils::inspect_fd(fd.get()) << "\n to socket \n"
-                        << utils::inspect_fd(socket_.native_handle());
-
-    const auto raw_fd = fd.get();
-    alignas(struct cmsghdr) std::array<std::byte, CMSG_SPACE(sizeof(raw_fd))> ctrl_buf{ };
-
-    std::byte placeholder{ 0 };
-    struct iovec iov{ };
-    if (payload.empty()) {
-        iov.iov_base = &placeholder;
-        iov.iov_len = sizeof(placeholder);
-    } else {
-        iov.iov_base = const_cast<char *>(payload.data());
-        iov.iov_len = payload.size();
-    }
+    LINYAPS_BOX_DEBUG() << "Send control message";
+    alignas(struct cmsghdr) std::array<std::byte, CMSG_SPACE(sizeof(fd))> ctrl_buf{ };
 
     struct msghdr msg{ };
     msg.msg_iov = &iov;
@@ -62,21 +42,87 @@ auto unix_socket::send_fd(utils::file_descriptor &&fd, std::string_view payload)
     ctrl_msg->cmsg_type = SCM_RIGHTS;
     ctrl_msg->cmsg_len = CMSG_LEN(sizeof(int));
 
-    std::memcpy(CMSG_DATA(ctrl_msg), &raw_fd, sizeof(raw_fd));
+    std::memcpy(CMSG_DATA(ctrl_msg), &fd, sizeof(fd));
     msg.msg_controllen = ctrl_msg->cmsg_len;
 
     while (true) {
         auto ret = ::sendmsg(socket_.native_handle(), &msg, 0);
-        if (ret < 0) {
-            if (errno == EINTR) {
-                continue;
-            }
-
-            throw std::system_error(errno, std::system_category(), "sendmsg");
+        if (ret >= 0) {
+            break;
         }
 
-        break;
+        if (errno == EINTR) {
+            continue;
+        }
+        throw std::system_error(errno, std::system_category(), "sendmsg");
     }
+}
+
+// TODO: if msg_flags contains MSG_TRUNC， then the message was truncated
+//  we need to read more data from the socket
+//  currently, we just ignore it
+auto unix_socket::recv_cmsg(struct iovec &iov, size_t &data_len) const -> int
+{
+    alignas(struct cmsghdr) std::array<std::byte, CMSG_SPACE(sizeof(int))> cmsg_buf{ };
+
+    struct msghdr msg{ };
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsg_buf.data();
+    msg.msg_controllen = cmsg_buf.size();
+
+    while (true) {
+        auto len = ::recvmsg(socket_.native_handle(), &msg, 0);
+        if (len > 0) {
+            data_len = static_cast<size_t>(len);
+            break;
+        }
+        if (len == 0) {
+            throw std::runtime_error("socket closed by peer");
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        throw std::system_error(errno, std::system_category(), "recvmsg");
+    }
+
+    auto *cmsg = CMSG_FIRSTHDR(&msg);
+    if (cmsg == nullptr || cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS) {
+        throw std::runtime_error("no file descriptor received in control message");
+    }
+
+    int received_fd{ -1 };
+    std::memcpy(&received_fd, CMSG_DATA(cmsg), sizeof(int));
+    if (received_fd < 0) {
+        throw std::runtime_error("invalid file descriptor received in control message");
+    }
+
+    return received_fd;
+}
+
+// TODO: support request/response
+// https://github.com/opencontainers/runtime-tools/blob/v0.9.0/docs/command-line-interface.md#console-socket
+auto unix_socket::send_fd(utils::file_descriptor fd, std::string_view payload) const -> void
+{
+    if (!fd.valid()) {
+        throw std::runtime_error("invalid file descriptor");
+    }
+
+    LINYAPS_BOX_DEBUG() << "Send fd \n"
+                        << utils::inspect_fd(fd.get()) << "\n to socket \n"
+                        << utils::inspect_fd(socket_.native_handle());
+
+    std::byte placeholder{ 0 };
+    struct iovec iov{ };
+    if (payload.empty()) {
+        iov.iov_base = &placeholder;
+        iov.iov_len = sizeof(placeholder);
+    } else {
+        iov.iov_base = const_cast<char *>(payload.data());
+        iov.iov_len = payload.size();
+    }
+
+    send_cmsg(iov, fd.get());
 }
 
 auto unix_socket::recv_fd(std::string &payload) const -> utils::file_descriptor
@@ -87,49 +133,10 @@ auto unix_socket::recv_fd(std::string &payload) const -> utils::file_descriptor
     constexpr auto batch_size = 4096;
     payload.resize(batch_size);
 
-    struct msghdr msg{ };
     struct iovec iov{ payload.data(), batch_size };
-    msg.msg_iov = &iov;
-    msg.msg_iovlen = 1;
-
-    alignas(struct cmsghdr) std::array<std::byte, CMSG_SPACE(sizeof(int))> cmsg_buf{ };
-    msg.msg_control = cmsg_buf.data();
-    msg.msg_controllen = cmsg_buf.size();
-
-    ssize_t len{ 0 };
-    while (true) {
-        len = ::recvmsg(socket_.native_handle(), &msg, 0);
-        if (len > 0) {
-            break;
-        }
-
-        if (len == 0) {
-            throw std::runtime_error("Socket closed by peer");
-        }
-
-        if (errno == EINTR) {
-            continue;
-        }
-
-        throw std::system_error(errno, std::system_category(), "recvmsg");
-    }
-
-    payload.resize(len);
-
-    // TODO: if msg_flags contains MSG_TRUNC， then the message was truncated
-    //  we need to read more data from the socket
-    //  currently, we just ignore it
-
-    auto *cmsg = CMSG_FIRSTHDR(&msg);
-    if (cmsg == nullptr || cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS) {
-        throw std::runtime_error("No file descriptor received in control message");
-    }
-
-    int received_fd{ -1 };
-    std::memcpy(&received_fd, CMSG_DATA(cmsg), sizeof(int));
-    if (received_fd < 0) {
-        throw std::runtime_error("Invalid file descriptor received in control message");
-    }
+    size_t received_len{ 0 };
+    auto received_fd = recv_cmsg(iov, received_len);
+    payload.resize(received_len);
 
     LINYAPS_BOX_DEBUG() << "Received fd " << utils::inspect_fd(received_fd);
 

--- a/src/linyaps_box/unix_socket.h
+++ b/src/linyaps_box/unix_socket.h
@@ -5,6 +5,9 @@
 #pragma once
 
 #include "linyaps_box/socket.h"
+#include "linyaps_box/utils/inspect.h"
+#include "linyaps_box/utils/log.h"
+#include "linyaps_box/utils/utils.h"
 
 namespace linyaps_box {
 class unix_socket
@@ -22,9 +25,63 @@ public:
 
     ~unix_socket() = default;
 
-    auto send_fd(utils::file_descriptor &&fd, std::string_view payload = { }) const -> void;
+    auto send_fd(utils::file_descriptor fd, std::string_view payload = { }) const -> void;
 
     [[nodiscard]] auto recv_fd(std::string &payload) const -> utils::file_descriptor;
+
+    template <typename T>
+    auto send_msg(const T &msg) const -> void
+    {
+        static_assert(std::is_trivially_copyable_v<T>);
+        auto result = socket_.fd().write(msg);
+        if (UNLIKELY(result.status != utils::IOStatus::Success)) {
+            throw std::runtime_error("send_msg failed");
+        }
+    }
+
+    template <typename T>
+    [[nodiscard]] auto recv_msg() const -> T
+    {
+        static_assert(std::is_trivially_copyable_v<T>);
+        T msg{ };
+        auto result = socket_.fd().read(msg);
+        if (UNLIKELY(result.status != utils::IOStatus::Success)) {
+            throw std::runtime_error("recv_msg failed");
+        }
+
+        return msg;
+    }
+
+    template <typename T>
+    auto send_msg_with_fd(utils::file_descriptor fd, const T &msg) const -> void
+    {
+        static_assert(std::is_trivially_copyable_v<T>);
+        if (!fd.valid()) {
+            throw std::runtime_error("invalid file descriptor for send_msg_with_fd");
+        }
+
+        LINYAPS_BOX_DEBUG() << "Send fd " << utils::inspect_fd(fd.get());
+        struct iovec iov{ };
+        iov.iov_base = const_cast<T *>(&msg);
+        iov.iov_len = sizeof(msg);
+        send_cmsg(iov, fd.get());
+    }
+
+    template <typename T>
+    [[nodiscard]] auto recv_msg_with_fd() const -> std::pair<T, utils::file_descriptor>
+    {
+        static_assert(std::is_trivially_copyable_v<T>);
+        LINYAPS_BOX_DEBUG() << "Receive fd from socket "
+                            << utils::inspect_fd(socket_.native_handle());
+        T msg{ };
+        struct iovec iov{ };
+        iov.iov_base = &msg;
+        iov.iov_len = sizeof(msg);
+        size_t data_len{ 0 };
+        auto received_fd = recv_cmsg(iov, data_len);
+        LINYAPS_BOX_DEBUG() << "Received fd " << utils::inspect_fd(received_fd);
+        return { msg, utils::file_descriptor{ received_fd } };
+    }
 
     [[nodiscard]] auto fd() const & noexcept -> const utils::file_descriptor &
     {
@@ -46,6 +103,9 @@ private:
         : socket_(fd, socket::passkey{ })
     {
     }
+
+    auto send_cmsg(struct iovec &iov, int fd) const -> void;
+    [[nodiscard]] auto recv_cmsg(struct iovec &iov, size_t &data_len) const -> int;
 
     socket socket_;
 };

--- a/src/linyaps_box/utils/close_range.cpp
+++ b/src/linyaps_box/utils/close_range.cpp
@@ -90,10 +90,10 @@ void linyaps_box::utils::close_range(uint first, uint last, int flags)
         std::stringstream ss;
         ss << '[';
         if ((static_cast<uint>(flags) & CLOSE_RANGE_CLOEXEC) != 0) {
-            ss << "CLOSE_RANGE_CLOEXEC ";
+            ss << " CLOSE_RANGE_CLOEXEC";
         }
         if ((static_cast<uint>(flags) & CLOSE_RANGE_UNSHARE) != 0) {
-            ss << "CLOSE_RANGE_UNSHARE ";
+            ss << " CLOSE_RANGE_UNSHARE ";
         }
         ss << ']';
         return ss.str();

--- a/src/linyaps_box/utils/platform.cpp
+++ b/src/linyaps_box/utils/platform.cpp
@@ -6,43 +6,72 @@
 
 #include "linyaps_box/utils/log.h"
 
-#include <climits> // IWYU pragma: keep
+#include <algorithm>
+#include <array>
 #include <csignal>
 #include <cstring>
-#include <stdexcept>
-#include <unordered_map>
 
-#include <sys/resource.h>
 #include <unistd.h>
+
+namespace {
+struct SignalItem
+{
+    std::string_view name;
+    int value;
+};
+} // namespace
 
 namespace linyaps_box::utils {
 auto str_to_signal(std::string_view str) -> int
 {
-    // Only support standard signals for now,
-    // TODO: support real-time signal in the future
-    const std::unordered_map<std::string_view, int> sigMap{
-        { "SIGABRT", SIGABRT },   { "SIGALRM", SIGALRM }, { "SIGBUS", SIGBUS },
-        { "SIGCHLD", SIGCHLD },   { "SIGCONT", SIGCONT }, { "SIGFPE", SIGFPE },
-        { "SIGHUP", SIGHUP },     { "SIGILL", SIGILL },   { "SIGINT", SIGINT },
-        { "SIGKILL", SIGKILL },   { "SIGPIPE", SIGPIPE }, { "SIGPOLL", SIGPOLL },
-        { "SIGPROF", SIGPROF },   { "SIGPWR", SIGPWR },   { "SIGQUIT", SIGQUIT },
-        { "SIGSEGV", SIGSEGV },   { "SIGSTOP", SIGSTOP }, { "SIGSYS", SIGSYS },
-        { "SIGTERM", SIGTERM },   { "SIGTRAP", SIGTRAP }, { "SIGTSTP", SIGTSTP },
-        { "SIGTTIN", SIGTTIN },   { "SIGTTOU", SIGTTOU }, { "SIGURG", SIGURG },
-        { "SIGUSR1", SIGUSR1 },   { "SIGUSR2", SIGUSR2 }, { "SIGVTALRM", SIGVTALRM },
-        { "SIGWINCH", SIGWINCH }, { "SIGXCPU", SIGXCPU }, { "SIGXFSZ", SIGXFSZ },
-        { "SIGIO", SIGIO },       { "SIGIOT", SIGIOT },
+    if (str.rfind("SIG", 0) != std::string_view::npos) {
+        str.remove_prefix(3);
+    }
+
+    // TODO: support real-time signal in the future?
+    static constexpr std::array sig_list{
+        SignalItem{ "ABRT", SIGABRT },     SignalItem{ "ALRM", SIGALRM },
+        SignalItem{ "BUS", SIGBUS },       SignalItem{ "CHLD", SIGCHLD },
 #ifdef SIGCLD
-        { "SIGCLD", SIGCLD },
+        SignalItem{ "CLD", SIGCLD }, // alias for CHLD
 #endif
+        SignalItem{ "CONT", SIGCONT },     SignalItem{ "FPE", SIGFPE },
+        SignalItem{ "HUP", SIGHUP },       SignalItem{ "ILL", SIGILL },
+        SignalItem{ "INT", SIGINT },       SignalItem{ "IO", SIGIO },
+        SignalItem{ "IOT", SIGIOT },       SignalItem{ "KILL", SIGKILL },
+        SignalItem{ "PIPE", SIGPIPE },     SignalItem{ "POLL", SIGPOLL },
+        SignalItem{ "PROF", SIGPROF },     SignalItem{ "PWR", SIGPWR },
+        SignalItem{ "QUIT", SIGQUIT },     SignalItem{ "SEGV", SIGSEGV },
+        SignalItem{ "STOP", SIGSTOP },     SignalItem{ "SYS", SIGSYS },
+        SignalItem{ "TERM", SIGTERM },     SignalItem{ "TRAP", SIGTRAP },
+        SignalItem{ "TSTP", SIGTSTP },     SignalItem{ "TTIN", SIGTTIN },
+        SignalItem{ "TTOU", SIGTTOU },     SignalItem{ "URG", SIGURG },
+        SignalItem{ "USR1", SIGUSR1 },     SignalItem{ "USR2", SIGUSR2 },
+        SignalItem{ "VTALRM", SIGVTALRM }, SignalItem{ "WINCH", SIGWINCH },
+        SignalItem{ "XCPU", SIGXCPU },     SignalItem{ "XFSZ", SIGXFSZ }
     };
 
-    auto it = sigMap.find(str);
-    if (it == sigMap.end()) {
+    constexpr auto sorted [[maybe_unused]] = []() noexcept {
+        for (size_t i = 1; i < sig_list.size(); ++i) {
+            if (sig_list[i - 1].name >= sig_list[i].name) {
+                return false;
+            }
+        }
+        return true;
+    }();
+    static_assert(sorted, "signal list must be sorted alphabetically");
+
+    const auto *it = std::lower_bound(sig_list.cbegin(),
+                                      sig_list.cend(),
+                                      str,
+                                      [](const SignalItem &item, std::string_view val) -> bool {
+                                          return item.name < val;
+                                      });
+    if (it == sig_list.cend() || it->name != str) {
         throw std::invalid_argument("invalid signal name: " + std::string{ str });
     }
 
-    return it->second;
+    return it->value;
 }
 
 auto get_path_max(const std::filesystem::path &fs_dir) noexcept -> std::size_t
@@ -87,6 +116,24 @@ auto get_page_size() noexcept -> std::size_t
     }();
 
     return page_size;
+}
+
+auto is_invalid_env(std::string_view env) noexcept -> bool
+{
+    auto pos = env.find('=');
+    if (pos == std::string_view::npos) {
+        return true;
+    }
+
+    if (pos == 0) {
+        return true;
+    }
+
+    if (env.find('\0') != std::string_view::npos) {
+        return true;
+    }
+
+    return false;
 }
 
 } // namespace linyaps_box::utils

--- a/src/linyaps_box/utils/platform.h
+++ b/src/linyaps_box/utils/platform.h
@@ -10,4 +10,6 @@ namespace linyaps_box::utils {
 auto str_to_signal(std::string_view str) -> int;
 auto get_path_max(const std::filesystem::path &fs_dir) noexcept -> std::size_t;
 auto get_page_size() noexcept -> std::size_t;
+// see: https://pubs.opengroup.org/onlinepubs/9799919799/
+auto is_invalid_env(std::string_view env) noexcept -> bool;
 } // namespace linyaps_box::utils

--- a/src/linyaps_box/utils/setns.cpp
+++ b/src/linyaps_box/utils/setns.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/utils/setns.h"
+
+#include "linyaps_box/utils/file.h"
+#include "linyaps_box/utils/log.h"
+#include "linyaps_box/utils/utils.h"
+
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include <fcntl.h>
+#include <sched.h>
+#include <unistd.h>
+
+namespace {
+
+auto to_proc_ns_string(linyaps_box::oci_config::linux_t::namespace_t::type type) noexcept
+  -> std::string_view
+{
+    switch (type) {
+    case linyaps_box::oci_config::linux_t::namespace_t::type::IPC:
+        return "ipc";
+    case linyaps_box::oci_config::linux_t::namespace_t::type::UTS:
+        return "uts";
+    case linyaps_box::oci_config::linux_t::namespace_t::type::MOUNT:
+        return "mnt";
+    case linyaps_box::oci_config::linux_t::namespace_t::type::PID:
+        return "pid";
+    case linyaps_box::oci_config::linux_t::namespace_t::type::NET:
+        return "net";
+    case linyaps_box::oci_config::linux_t::namespace_t::type::USER:
+        return "user";
+    case linyaps_box::oci_config::linux_t::namespace_t::type::CGROUP:
+        return "cgroup";
+    case linyaps_box::oci_config::linux_t::namespace_t::type::TIME:
+        return "time";
+    }
+
+    __builtin_unreachable();
+}
+
+} // namespace
+
+namespace linyaps_box::utils {
+
+auto open_namespace_fd(pid_t target_pid, oci_config::linux_t::namespace_t::type ns_type)
+  -> file_descriptor
+{
+    auto path = std::filesystem::path{ "/proc" } / std::to_string(target_pid) / "ns"
+      / to_proc_ns_string(ns_type);
+    return utils::open(path, O_RDONLY | O_CLOEXEC);
+}
+
+void setns(const file_descriptor &ns_fd, oci_config::linux_t::namespace_t::type ns_type)
+{
+    // nstype is 0 for /proc/PID/ns/* file descriptors (kernel detects type from fd).
+    // When PIDFD support is added, nstype will be derived from ns_type.
+    std::ignore = ns_type;
+    if (UNLIKELY(::setns(ns_fd.get(), 0) < 0)) {
+        throw std::system_error(errno, std::system_category(), "setns");
+    }
+}
+
+void join_namespace(const file_descriptor &ns_fd, oci_config::linux_t::namespace_t::type ns_type)
+{
+    setns(ns_fd, ns_type);
+}
+
+void join_container_namespaces(pid_t target_pid, const oci_config::linux_t &linux_config)
+{
+    if (!linux_config.namespaces) {
+        return;
+    }
+
+    std::vector<std::pair<oci_config::linux_t::namespace_t::type, file_descriptor>> ns_fds;
+    ns_fds.reserve(linux_config.namespaces->size());
+    for (const auto &ns : *linux_config.namespaces) {
+        ns_fds.emplace_back(ns.type_, open_namespace_fd(target_pid, ns.type_));
+    }
+
+    for (auto &[type, fd] : ns_fds) {
+        if (type != oci_config::linux_t::namespace_t::type::USER) {
+            continue;
+        }
+
+        join_namespace(fd, type);
+        break;
+    }
+
+    for (auto &[type, fd] : ns_fds) {
+        if (type == oci_config::linux_t::namespace_t::type::USER) {
+            continue;
+        }
+
+        try {
+            join_namespace(fd, type);
+        } catch (const std::system_error &e) {
+            if (e.code().value() == EINVAL) {
+                LINYAPS_BOX_WARNING() << "setns for " << to_string_view(type) << " not supported";
+                continue;
+            }
+
+            throw;
+        }
+    }
+}
+
+} // namespace linyaps_box::utils

--- a/src/linyaps_box/utils/setns.h
+++ b/src/linyaps_box/utils/setns.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/config.h"
+#include "linyaps_box/utils/file_describer.h"
+
+#include <sys/types.h>
+
+namespace linyaps_box::utils {
+
+auto open_namespace_fd(pid_t target_pid, oci_config::linux_t::namespace_t::type ns_type)
+  -> file_descriptor;
+
+auto setns(const file_descriptor &ns_fd, oci_config::linux_t::namespace_t::type ns_type) -> void;
+
+auto join_namespace(const file_descriptor &ns_fd, oci_config::linux_t::namespace_t::type ns_type)
+  -> void;
+
+auto join_container_namespaces(pid_t target_pid, const oci_config::linux_t &linux_config) -> void;
+
+} // namespace linyaps_box::utils


### PR DESCRIPTION
Replace nsenter binary exec with direct setns() syscalls. The nsenter binary is not guaranteed available on all systems; calling setns() directly is more portable and gives fine-grained control over namespace joining order (user NS first, then others).

- Add utils/setns for opening namespace fds and joining container namespaces in the correct order
- Rewrite container_ref::exec to fork+setns instead of fork+exec nsenter
- Add --process JSON file support for exec (OCI runtime spec)
- Validate container IDs to prevent path traversal
- Make all commands return int, accept explicit global_options
- Change parse() to return std::optional<options> for error handling
- Rename Config alias to oci_config across codebase
- Refactor CLI option parsing into self-contained validator functions