### PR TITLE
perf: reduce allocations and syscalls in hot paths

### DIFF
--- a/src/linyaps_box/container.cpp
+++ b/src/linyaps_box/container.cpp
@@ -685,6 +685,8 @@ auto do_propagation_mount(const linyaps_box::utils::file_descriptor &destination
     }
 
     bool need_remount{ false };
+    // we will do all bind/ro mount at finalize so we can
+    // create missing destinations
     if ((mount.vfs_flags & (MS_RDONLY | MS_BIND)) != 0) {
         need_remount = true;
     }
@@ -811,7 +813,7 @@ public:
             do_remount(ret.value());
         }
 
-        // reopen rootfs after mount
+        // reopen rootfs after mount to refresh vfs state
         root = linyaps_box::utils::open(root.current_path(), O_PATH | O_CLOEXEC | O_DIRECTORY);
 
         if (oci_config.root->readonly) {
@@ -2122,8 +2124,10 @@ void configure_gid_mapping(pid_t pid, linyaps_box::container &container)
         }
 
         const auto &mapping = gid_mappings_v[0];
-        content.append(std::to_string(mapping.host_id) + " ");
-        content.append(std::to_string(mapping.container_id) + " ");
+        content.append(std::to_string(mapping.host_id));
+        content.push_back(' ');
+        content.append(std::to_string(mapping.container_id));
+        content.push_back(' ');
         content.append(std::to_string(mapping.size));
 
         auto file = linyaps_box::utils::open(self_process / "gid_map",
@@ -2158,8 +2162,10 @@ void configure_gid_mapping(pid_t pid, linyaps_box::container &container)
     content.clear();
     for (std::size_t i = 0; i < len; ++i) {
         const auto &mapping = gid_mappings_v[i];
-        content.append(std::to_string(mapping.host_id) + " ");
-        content.append(std::to_string(mapping.container_id) + " ");
+        content.append(std::to_string(mapping.host_id));
+        content.push_back(' ');
+        content.append(std::to_string(mapping.container_id));
+        content.push_back(' ');
         content.append(std::to_string(mapping.size));
 
         if (i != len - 1) {
@@ -2202,8 +2208,10 @@ void configure_uid_mapping(pid_t pid, const linyaps_box::container &container)
     if (is_single_mapping) {
         const auto &mapping = uid_mappings_v[0];
 
-        content.append(std::to_string(mapping.host_id) + " ");
-        content.append(std::to_string(mapping.container_id) + " ");
+        content.append(std::to_string(mapping.host_id));
+        content.push_back(' ');
+        content.append(std::to_string(mapping.container_id));
+        content.push_back(' ');
         content.append(std::to_string(mapping.size));
 
         auto file = linyaps_box::utils::open(self_process / "uid_map",
@@ -2241,8 +2249,10 @@ void configure_uid_mapping(pid_t pid, const linyaps_box::container &container)
     content.clear();
     for (std::size_t i = 0; i < len; ++i) {
         const auto &mapping = uid_mappings_v[i];
-        content.append(std::to_string(mapping.host_id) + " ");
-        content.append(std::to_string(mapping.container_id) + " ");
+        content.append(std::to_string(mapping.host_id));
+        content.push_back(' ');
+        content.append(std::to_string(mapping.container_id));
+        content.push_back(' ');
         content.append(std::to_string(mapping.size));
 
         if (i != len - 1) {
@@ -2587,6 +2597,7 @@ int linyaps_box::container::run(run_container_options_t options)
                 throw std::runtime_error("unexpected container status before running: "
                                          + std::to_string(static_cast<int>(status.status)));
             }
+
             status.PID = child_pid;
             status.status = container_status_t::runtime_status::RUNNING;
             this->status_dir().write(status);

--- a/src/linyaps_box/container_status.cpp
+++ b/src/linyaps_box/container_status.cpp
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "linyaps_box/container_status.h"
 
 namespace linyaps_box {
-auto to_string(linyaps_box::container_status_t::runtime_status status) -> std::string
+auto to_string_view(linyaps_box::container_status_t::runtime_status status) -> std::string_view
 {
     switch (status) {
     case linyaps_box::container_status_t::runtime_status::CREATING:
@@ -21,7 +21,7 @@ auto to_string(linyaps_box::container_status_t::runtime_status status) -> std::s
     }
 }
 
-auto from_string(std::string_view status) -> linyaps_box::container_status_t::runtime_status
+auto from_string_view(std::string_view status) -> linyaps_box::container_status_t::runtime_status
 {
     if (status == "creating") {
         return linyaps_box::container_status_t::runtime_status::CREATING;
@@ -43,7 +43,7 @@ auto status_to_json(const linyaps_box::container_status_t &status) -> nlohmann::
 {
     return nlohmann::json::object({ { "id", status.ID },
                                     { "pid", status.PID },
-                                    { "status", to_string(status.status) },
+                                    { "status", to_string_view(status.status) },
                                     { "bundle", status.bundle.string() },
                                     { "created", status.created },
                                     { "owner", status.owner },

--- a/src/linyaps_box/container_status.h
+++ b/src/linyaps_box/container_status.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -8,6 +8,7 @@
 
 #include <filesystem>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 namespace linyaps_box {
@@ -26,8 +27,8 @@ struct container_status_t
     std::unordered_map<std::string, std::string> annotations;
 };
 
-auto to_string(linyaps_box::container_status_t::runtime_status status) -> std::string;
-auto from_string(std::string_view status) -> linyaps_box::container_status_t::runtime_status;
+auto to_string_view(linyaps_box::container_status_t::runtime_status status) -> std::string_view;
+auto from_string_view(std::string_view status) -> linyaps_box::container_status_t::runtime_status;
 auto status_to_json(const linyaps_box::container_status_t &status) -> nlohmann::json;
 
 } // namespace linyaps_box

--- a/src/linyaps_box/status_directory.cpp
+++ b/src/linyaps_box/status_directory.cpp
@@ -32,10 +32,10 @@ auto read_status(const std::filesystem::path &path) -> linyaps_box::container_st
 
     linyaps_box::container_status_t ret{ };
 
-    ret.oci_version = j.at("ociVersion");
-    ret.PID = j.at("pid");
-    ret.ID = j.at("id");
-    ret.status = linyaps_box::from_string(j.at("status").get<std::string>());
+    j.at("ociVersion").get_to(ret.oci_version);
+    j.at("pid").get_to(ret.PID);
+    j.at("id").get_to(ret.ID);
+    ret.status = linyaps_box::from_string_view(j.at("status").get<std::string_view>());
     if (::kill(ret.PID, 0) != 0) {
         if (errno == ESRCH) {
             ret.status = linyaps_box::container_status_t::runtime_status::STOPPED;
@@ -47,10 +47,10 @@ auto read_status(const std::filesystem::path &path) -> linyaps_box::container_st
         // EPERM: process exists but we lack permission, keep status from JSON
     }
 
-    ret.bundle = j.at("bundle").get<std::filesystem::path>();
-    ret.created = j.at("created");
-    ret.owner = j.at("owner");
-    ret.annotations = j.at("annotations");
+    j.at("bundle").get_to(ret.bundle);
+    j.at("created").get_to(ret.created);
+    j.at("owner").get_to(ret.owner);
+    j.at("annotations").get_to(ret.annotations);
 
     return ret;
 }
@@ -71,7 +71,7 @@ void linyaps_box::status_directory::write(const container_status_t &status) cons
 {
     auto j = nlohmann::json::object({ { "id", status.ID },
                                       { "pid", status.PID },
-                                      { "status", to_string(status.status) },
+                                      { "status", to_string_view(status.status) },
                                       { "bundle", status.bundle },
                                       { "created", status.created },
                                       { "owner", status.owner },

--- a/src/linyaps_box/utils/file_describer.cpp
+++ b/src/linyaps_box/utils/file_describer.cpp
@@ -210,8 +210,7 @@ auto linyaps_box::utils::file_descriptor::proc_path() const -> std::filesystem::
         return std::filesystem::current_path();
     }
 
-    return std::filesystem::current_path().root_path() / "proc" / "self" / "fd"
-      / std::to_string(fd_);
+    return "/proc/self/fd/" + std::to_string(fd_);
 }
 
 auto linyaps_box::utils::file_descriptor::current_path() const -> std::filesystem::path

--- a/src/linyaps_box/utils/mkdir.cpp
+++ b/src/linyaps_box/utils/mkdir.cpp
@@ -6,6 +6,7 @@
 
 #include "linyaps_box/utils/inspect.h"
 #include "linyaps_box/utils/log.h"
+#include "linyaps_box/utils/utils.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -44,21 +45,33 @@ auto linyaps_box::utils::mkdir(const file_descriptor &root, std::filesystem::pat
             return current;
         }
 
-        if (::mkdirat(current.get(), part.c_str(), mode) != 0 && errno != EEXIST) {
-            LINYAPS_BOX_DEBUG() << "current path: " << utils::inspect_path(current.get())
-                                << " perm:" << utils::inspect_permissions(current.get());
-            throw std::system_error(errno,
-                                    std::system_category(),
-                                    "mkdirat: failed to create "
-                                      + (current.current_path() / part).string());
-        }
-
-        fd = ::openat(current.get(), part.c_str(), O_PATH);
+        // Try openat first – for directories that already exist we save one mkdirat syscall.
+        fd = ::openat(current.get(), part.c_str(), O_PATH | O_CLOEXEC);
         if (fd == -1) {
-            throw std::system_error(errno,
-                                    std::system_category(),
-                                    "openat: failed to open "
-                                      + (current.current_path() / part).string());
+            if (UNLIKELY(errno != ENOENT)) {
+                LINYAPS_BOX_DEBUG() << "current path: " << utils::inspect_path(current.get())
+                                    << " perm:" << utils::inspect_permissions(current.get());
+                throw std::system_error(errno,
+                                        std::system_category(),
+                                        "openat: " + (current.current_path() / part).string());
+            }
+
+            if (UNLIKELY(::mkdirat(current.get(), part.c_str(), mode) != 0)) {
+                LINYAPS_BOX_DEBUG() << "current path: " << utils::inspect_path(current.get())
+                                    << " perm:" << utils::inspect_permissions(current.get());
+                throw std::system_error(errno,
+                                        std::system_category(),
+                                        "mkdirat: failed to create "
+                                          + (current.current_path() / part).string());
+            }
+
+            fd = ::openat(current.get(), part.c_str(), O_PATH | O_CLOEXEC);
+            if (UNLIKELY(fd == -1)) {
+                throw std::system_error(errno,
+                                        std::system_category(),
+                                        "openat: failed to open "
+                                          + (current.current_path() / part).string());
+            }
         }
 
         current = file_descriptor(fd);


### PR DESCRIPTION
- Use string_view for status serialization to avoid string allocations
- Use get_to + string_view in JSON parsing to skip intermediate copies
- Hardcode /proc/self/fd/ in proc_path() to avoid current_path() syscall
- Try openat before mkdirat to save a syscall when directory exists
- Use O_CLOEXEC and UNLIKELY annotations in mkdir error paths
- Eliminate temporary strings in uid/gid mapping formatting