### PR TITLE
build: replace if-blocks with genexps, fix REUSE

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -27,7 +27,11 @@ ColumnLimit: 100
 # Disable reflow of some specific comments
 # qdoc comments: indentation rules are different.
 # Translation comments and SPDX license identifiers are also excluded.
-CommentPragmas: "^!|^:|^ SPDX-License-Identifier:"
+#
+# NOTE: '[I]' is used here to obfuscate the 'SPDX-License-Identifier' keyword.
+# Regular 'I' would cause the REUSE compliance tool to misinterpret this configuration
+# line as a valid license expression, leading to a linter parsing error.
+CommentPragmas: "^!|^:|^ SPDX-License-[I]dentifier:"
 
 PointerAlignment: Right
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,13 +92,11 @@ set(linyaps-box_ACTIVE_LOG_LEVEL
 
 set(linyaps-box_ENABLE_CPM
     OFF
-    CACHE BOOL "enable CPM"
-)
+    CACHE BOOL "enable CPM")
 
 set(linyaps-box_HARDENING
     ON
-    CACHE BOOL "enable hardening"
-)
+    CACHE BOOL "enable hardening")
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -111,8 +109,7 @@ endif()
 # if just want to try local packages at first set CPM_USE_LOCAL_PACKAGES ON
 set(linyaps-box_CPM_LOCAL_PACKAGES_ONLY
     OFF
-    CACHE BOOL "use local packages only"
-)
+    CACHE BOOL "use local packages only")
 
 # ==============================================================================
 
@@ -122,10 +119,8 @@ if(linyaps-box_HARDENING)
       "${CMAKE_EXE_LINKER_FLAGS} -pie -Wl,-z,relro -Wl,-z,now")
   add_compile_options(-fstack-protector-strong)
 
-  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-    message(STATUS "Non-Debug build, enabling FORTIFY_SOURCE")
-    add_compile_definitions(_FORTIFY_SOURCE=2)
-  endif()
+  message(STATUS "Non-Debug build, enabling FORTIFY_SOURCE")
+  add_compile_definitions("$<$<NOT:$<CONFIG:Debug>>:_FORTIFY_SOURCE=2>")
 endif()
 
 set(linyaps-box_LIBRARY linyaps-box)
@@ -295,11 +290,11 @@ if(linyaps-box_ENABLE_CPM)
     EXCLUDE_FROM_ALL ON
     OPTIONS "BUILD_TESTING OFF")
   CPMFindPackage(
-  NAME fmt
-  VERSION 10.1.0
-  GITHUB_REPOSITORY fmtlib/fmt
-  GIT_TAG 12.2.0
-  EXCLUDE_FROM_ALL ON)
+    NAME fmt
+    VERSION 10.1.0
+    GITHUB_REPOSITORY fmtlib/fmt
+    GIT_TAG 12.2.0
+    EXCLUDE_FROM_ALL ON)
 endif()
 
 # find minimal version
@@ -329,13 +324,11 @@ endif()
 
 list(APPEND linyaps-box_LIBRARY_LINK_LIBRARIES CLI11::CLI11)
 
-set(FMT_TARGET fmt::fmt)
-if(linyaps-box_STATIC)
-  set(FMT_TARGET fmt::fmt-header-only)
-endif()
+set(FMT_TARGET
+    "$<IF:$<BOOL:${linyaps-box_STATIC}>,fmt::fmt-header-only,fmt::fmt>")
 
 find_package(fmt 10.1.0 QUIET)
-if (NOT fmt_FOUND)
+if(NOT fmt_FOUND)
   # if fmt is not found in local system. just use fmt::fmt with static linkage
   # for boosting compiling speed.
   set(FMT_TARGET fmt::fmt)
@@ -393,10 +386,9 @@ target_compile_definitions(
     "LINYAPS_BOX_ACTIVE_LOG_LEVEL=${linyaps-box_ACTIVE_LOG_LEVEL}")
 target_compile_options("${linyaps-box_LIBRARY}"
                        PRIVATE -fmacro-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=.)
-if(linyaps-box_STATIC)
-  target_compile_definitions("${linyaps-box_LIBRARY}"
-                             PUBLIC "LINYAPS_BOX_STATIC_LINK")
-endif()
+target_compile_definitions(
+  "${linyaps-box_LIBRARY}"
+  PUBLIC "$<$<BOOL:${linyaps-box_STATIC}>:LINYAPS_BOX_STATIC_LINK>")
 
 if(linyaps-box_ENABLE_SECCOMP)
   target_compile_definitions("${linyaps-box_LIBRARY}"
@@ -413,18 +405,22 @@ if(linyaps-box_ENABLE_CAP)
 endif()
 
 if(linyaps-box_ENABLE_COVERAGE)
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    target_compile_options("${linyaps-box_LIBRARY}"
-                           PRIVATE -fprofile-instr-generate -fcoverage-mapping)
-    target_link_options("${linyaps-box_LIBRARY}" PUBLIC
-                        -fprofile-instr-generate -fcoverage-mapping)
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_compile_options("${linyaps-box_LIBRARY}" PRIVATE --coverage)
-    target_link_options("${linyaps-box_LIBRARY}" PUBLIC --coverage)
-  else()
+  if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_CXX_COMPILER_ID
+                                                   STREQUAL "GNU")
     message(
       FATAL_ERROR "Coverage is not supported for ${CMAKE_CXX_COMPILER_ID}.")
   endif()
+  target_compile_options(
+    "${linyaps-box_LIBRARY}"
+    PRIVATE "$<$<CXX_COMPILER_ID:Clang,AppleClang>:-fprofile-instr-generate>"
+            "$<$<CXX_COMPILER_ID:Clang,AppleClang>:-fcoverage-mapping>"
+            "$<$<CXX_COMPILER_ID:GNU>:--coverage>")
+  target_link_options(
+    "${linyaps-box_LIBRARY}"
+    PUBLIC
+    "$<$<CXX_COMPILER_ID:Clang,AppleClang>:-fprofile-instr-generate>"
+    "$<$<CXX_COMPILER_ID:Clang,AppleClang>:-fcoverage-mapping>"
+    "$<$<CXX_COMPILER_ID:GNU>:--coverage>")
 endif()
 
 # ==============================================================================
@@ -439,10 +435,10 @@ add_executable("${linyaps-box_APP}" ${linyaps-box_APP_SOURCE})
 target_include_directories("${linyaps-box_APP}"
                            ${linyaps-box_APP_SOURCE_INCLUDE_DIRS})
 target_link_libraries("${linyaps-box_APP}" ${linyaps-box_APP_LINK_LIBRARIES})
-if(linyaps-box_STATIC)
-  target_link_options("${linyaps-box_APP}" PRIVATE -static -static-libgcc
-                      -static-libstdc++)
-endif()
+target_link_options(
+  "${linyaps-box_APP}" PRIVATE "$<$<BOOL:${linyaps-box_STATIC}>:-static>"
+  "$<$<BOOL:${linyaps-box_STATIC}>:-static-libgcc>"
+  "$<$<BOOL:${linyaps-box_STATIC}>:-static-libstdc++>")
 target_compile_features("${linyaps-box_APP}" PRIVATE cxx_std_17)
 set_property(TARGET "${linyaps-box_APP}" PROPERTY CXX_STANDARD 17)
 set_property(TARGET "${linyaps-box_APP}" PROPERTY CXX_EXTENSIONS OFF)

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,19 +1,26 @@
 version = 1
 SPDX-PackageName = "linyaps-box"
-SPDX-PackageSupplier = "UnionTech Software Technology Co., Ltd. <>"
+SPDX-PackageSupplier = "UnionTech Software Technology Co., Ltd."
 SPDX-PackageDownloadLocation = "https://github.com/OpenAtom-Linyaps/linyaps-box"
 
 [[annotations]]
 path = [
-    "**/CMakeLists.txt",
-    "**/CMakePresets.json",
-    "**/.gitignore",
+    "CMakeLists.txt",
+    "src/**/CMakeLists.txt",
+    "tests/**/CMakeLists.txt",
+    "CMakePresets.json",
+    ".gitignore",
+    "tests/**/.gitignore",
     ".clang-format",
     ".cmake-format.py",
-    "cmake.external/**",
-    "external/*/CMakeLists.txt",
+    "cmake.external/CLI11/**",
+    "cmake.external/nlohmann_json/**",
+    "cmake.external/zeus_expected/**",
+    "external/CLI11/CMakeLists.txt",
+    "external/nlohmann_json/CMakeLists.txt",
+    "external/zeus_expected/CMakeLists.txt",
 ]
-precedence = "aggregate"
+precedence = "closest"
 SPDX-FileCopyrightText = "UnionTech Software Technology Co., Ltd."
 SPDX-License-Identifier = "CC0-1.0"
 
@@ -28,45 +35,42 @@ path = [
 ]
 
 exclude = ["**/cmake_test_discovery_*.json"]
-precedence = "aggregate"
+precedence = "closest"
 SPDX-FileCopyrightText = "UnionTech Software Technology Co., Ltd."
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = ["README.md", "README.zh_CN.md"]
-precedence = "aggregate"
+precedence = "closest"
 SPDX-FileCopyrightText = "UnionTech Software Technology Co., Ltd."
 SPDX-License-Identifier = "CC-BY-4.0"
 
 [[annotations]]
 path = ["cmake/CPM.cmake"]
-precedence = "aggregate"
+precedence = "override"
 SPDX-FileCopyrightText = "2019-2023 Lars Melchior and contributors"
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]
 path = ["external/nlohmann_json/include/**"]
-precedence = "aggregate"
+precedence = "override"
 SPDX-FileCopyrightText = "2013-2025 Niels Lohmann <https://nlohmann.me>"
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]
 path = ["external/CLI11/include/**"]
-precedence = "aggregate"
+precedence = "override"
 SPDX-FileCopyrightText = "2017-2026 University of Cincinnati, developed by Henry Schreiner under NSF AWARD 1414736."
 SPDX-License-Identifier = "BSD-3-Clause"
 
 [[annotations]]
 path = ["external/zeus_expected/include/**"]
-precedence = "aggregate"
+precedence = "override"
 SPDX-FileCopyrightText = "2024 zeus-cpp"
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]
-path = [
-    "external/fmt/**",
-    "cmake.external/fmt/**"
-]
-precedence = "aggregate"
+path = ["external/fmt/**", "cmake.external/fmt/JoinPaths.py"]
+precedence = "override"
 SPDX-FileCopyrightText = "2012 - present, Victor Zverovich and {fmt} contributors"
 SPDX-License-Identifier = "MIT"

--- a/cmake.external/fmt/.cmake-format.py
+++ b/cmake.external/fmt/.cmake-format.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: None
+#
+# SPDX-License-Identifier: CC0-1.0
+
+with section("format"):
+    disable = True

--- a/external/CLI11/CMakeLists.txt
+++ b/external/CLI11/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_library(CLI11 INTERFACE)
 add_library(CLI11::CLI11 ALIAS CLI11)
-target_include_directories(CLI11 INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include/")
+target_include_directories(CLI11 INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)

--- a/external/nlohmann_json/CMakeLists.txt
+++ b/external/nlohmann_json/CMakeLists.txt
@@ -2,4 +2,6 @@
 
 add_library(nlohmann_json INTERFACE)
 add_library(nlohmann_json::nlohmann_json ALIAS nlohmann_json)
-target_include_directories(nlohmann_json INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include/")
+target_include_directories(nlohmann_json INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)

--- a/external/zeus_expected/CMakeLists.txt
+++ b/external/zeus_expected/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(zeus_expected INTERFACE)
 add_library(zeus::expected ALIAS zeus_expected)
-target_include_directories(zeus_expected
-                           INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include/")
+target_include_directories(zeus_expected INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)


### PR DESCRIPTION
REUSE 5.x requires `override` precedence for third-party code and `closest` for project code. Obfuscate SPDX-License-Identifier in .clang-format to prevent false-positive parsing.