### PR TITLE
fix(tty): set initial console size before exec

### DIFF
--- a/src/linyaps_box/container.cpp
+++ b/src/linyaps_box/container.cpp
@@ -2578,39 +2578,7 @@ int linyaps_box::container::run(run_container_options_t options)
         // TODO: cgroup preenter
         auto [child_pid, socket] = runtime_ns::start_container_process(*this, options);
 
-        {
-            auto status = this->status();
-            if (status.status != container_status_t::runtime_status::CREATING) {
-                throw std::runtime_error("unexpected container status before creating: "
-                                         + std::to_string(static_cast<int>(status.status)));
-            }
-            status.PID = child_pid;
-            status.status = container_status_t::runtime_status::CREATED;
-            this->status_dir().write(status);
-        }
-
-        runtime_ns::configure_container_namespaces(*this, socket);
-        runtime_ns::prestart_hooks(*this, socket);
-        runtime_ns::create_runtime_hooks(*this, socket);
-        runtime_ns::wait_create_container_result(*this, socket);
-
-        runtime_ns::wait_socket_close(socket);
-
-        {
-            auto status = this->status();
-            if (status.status != container_status_t::runtime_status::CREATED) {
-                throw std::runtime_error("unexpected container status before running: "
-                                         + std::to_string(static_cast<int>(status.status)));
-            }
-            status.PID = child_pid;
-            status.status = container_status_t::runtime_status::RUNNING;
-            this->status_dir().write(status);
-        }
-
-        runtime_ns::poststart_hooks(*this);
-
         container_monitor monitor(child_pid);
-        monitor.enable_signal_forwarding();
 
         auto in = utils::file_descriptor{ STDIN_FILENO, false };
         auto out = utils::file_descriptor{ STDOUT_FILENO, false };
@@ -2635,22 +2603,59 @@ int linyaps_box::container::run(run_container_options_t options)
               }
           });
 
-        [&recv_socketpair, &monitor, &in, &out, &changed]() -> void {
-            if (!recv_socketpair) {
-                return;
+        if (recv_socketpair) {
+            monitor.acquire_host_tty(in, out);
+        }
+
+        {
+            auto status = this->status();
+            if (status.status != container_status_t::runtime_status::CREATING) {
+                throw std::runtime_error("unexpected container status before creating: "
+                                         + std::to_string(static_cast<int>(status.status)));
             }
+            status.PID = child_pid;
+            status.status = container_status_t::runtime_status::CREATED;
+            this->status_dir().write(status);
+        }
 
-            LINYAPS_BOX_DEBUG() << "Container requires a terminal";
+        runtime_ns::configure_container_namespaces(*this, socket);
+        runtime_ns::prestart_hooks(*this, socket);
+        runtime_ns::create_runtime_hooks(*this, socket);
+        runtime_ns::wait_create_container_result(*this, socket);
 
-            auto master = runtime_ns::recv_master_tty(recv_socketpair.value());
+        std::optional<terminal_master> early_master;
+        if (recv_socketpair) {
+            early_master = runtime_ns::recv_master_tty(recv_socketpair.value());
             recv_socketpair->release();
+            if (!config.process.console_size) {
+                early_master->resize(monitor.host_tty_size());
+            }
+        }
 
+        runtime_ns::wait_socket_close(socket);
+
+        {
+            auto status = this->status();
+            if (status.status != container_status_t::runtime_status::CREATED) {
+                throw std::runtime_error("unexpected container status before running: "
+                                         + std::to_string(static_cast<int>(status.status)));
+            }
+            status.PID = child_pid;
+            status.status = container_status_t::runtime_status::RUNNING;
+            this->status_dir().write(status);
+        }
+
+        runtime_ns::poststart_hooks(*this);
+
+        monitor.enable_signal_forwarding();
+
+        if (early_master) {
             in.set_nonblock(true);
             out.set_nonblock(true);
             changed = true;
 
-            monitor.enable_io_forwarding(std::move(master), in, out);
-        }();
+            monitor.attach_terminal(std::move(*early_master), in, out);
+        }
 
         // TODO: support detach from the parent's process
         // Now we wait for the container process to exit

--- a/src/linyaps_box/container_monitor.cpp
+++ b/src/linyaps_box/container_monitor.cpp
@@ -95,10 +95,13 @@ auto container_monitor::handle_signals() -> void
     }
 }
 
-auto container_monitor::enable_io_forwarding(terminal_master master,
-                                             const linyaps_box::utils::file_descriptor &in,
-                                             const linyaps_box::utils::file_descriptor &out) -> void
+auto container_monitor::acquire_host_tty(const utils::file_descriptor &in,
+                                         const utils::file_descriptor &out) -> void
 {
+    if (host_tty) {
+        return;
+    }
+
     if (utils::isatty(in)) {
         host_tty.emplace(in.duplicate());
     } else if (utils::isatty(out)) {
@@ -107,8 +110,26 @@ auto container_monitor::enable_io_forwarding(terminal_master master,
         auto default_tty = utils::open("/dev/tty", O_RDWR | O_CLOEXEC);
         host_tty.emplace(std::move(default_tty));
     }
+}
 
-    host_tty->set_raw();
+auto container_monitor::host_tty_size() -> struct winsize
+{
+    if (!host_tty) {
+        return { };
+    }
+
+    return host_tty->get_size();
+
+}
+
+auto container_monitor::attach_terminal(terminal_master master,
+                                        const utils::file_descriptor &in,
+                                        const utils::file_descriptor &out) -> void
+
+{
+    if (host_tty) {
+        host_tty->set_raw();
+    }
 
     this->master = std::move(master);
 
@@ -144,6 +165,14 @@ auto container_monitor::enable_io_forwarding(terminal_master master,
     if (out_fwd && out_fwd->is_finished()) {
         out_fwd.reset();
     }
+}
+
+auto container_monitor::enable_io_forwarding(terminal_master master,
+                                             const utils::file_descriptor &in,
+                                             const utils::file_descriptor &out) -> void
+{
+    acquire_host_tty(in, out);
+    attach_terminal(std::move(master), in, out);
 }
 
 auto container_monitor::wait_container_exit() -> int

--- a/src/linyaps_box/container_monitor.h
+++ b/src/linyaps_box/container_monitor.h
@@ -23,6 +23,12 @@ public:
     ~container_monitor() noexcept = default;
 
     auto enable_signal_forwarding() -> void;
+    auto acquire_host_tty(const linyaps_box::utils::file_descriptor &in,
+                          const linyaps_box::utils::file_descriptor &out) -> void;
+    [[nodiscard]] auto host_tty_size() -> struct winsize;
+    auto attach_terminal(terminal_master master,
+                         const linyaps_box::utils::file_descriptor &in,
+                         const linyaps_box::utils::file_descriptor &out) -> void;
     auto enable_io_forwarding(terminal_master master,
                               const linyaps_box::utils::file_descriptor &in,
                               const linyaps_box::utils::file_descriptor &out) -> void;

--- a/src/linyaps_box/terminal.cpp
+++ b/src/linyaps_box/terminal.cpp
@@ -29,6 +29,11 @@ auto create_pty_pair() -> std::pair<terminal_master, terminal_slave>
 
 auto terminal_master::resize(struct winsize size) -> void
 {
+    if (size.ws_col == 0 || size.ws_row == 0) {
+        auto default_tty = utils::open("/dev/tty", O_RDWR | O_CLOEXEC);
+        std::ignore = utils::ioctl(default_tty, TIOCGWINSZ, &size);
+    }
+
     std::ignore = utils::ioctl(master_, TIOCSWINSZ, &size);
 }
 


### PR DESCRIPTION
When config.json omits process.consoleSize the container pty kept its default 0x0 until the first SIGWINCH, so early reads of TIOCGWINSZ (e.g. `stty size`) returned zeros. Resize the master from the host terminal right after receiving its fd, before the child execs, so the initial size is always correct. consoleSize, when set, is still honored by the in-container slave.set_size().