### PR TITLE
feat(span): replace SFINAE with static_assert, add debug checks and tests

### DIFF
--- a/src/linyaps_box/utils/span.h
+++ b/src/linyaps_box/utils/span.h
@@ -83,6 +83,47 @@ struct is_span_compatible_iter<It,
 template <typename It, typename T>
 inline constexpr bool is_span_compatible_iter_v = is_span_compatible_iter<It, T>::value;
 
+template <typename It, typename = void>
+struct is_contiguous_iterator : std::false_type
+{
+};
+
+template <typename It>
+struct is_contiguous_iterator<It,
+                              std::void_t<decltype(*std::declval<It &>()),
+                                          decltype(std::declval<It &>() - std::declval<It &>()),
+                                          decltype(detail::to_address(std::declval<It &>()))>>
+    : std::true_type
+{
+};
+
+template <typename It>
+inline constexpr bool is_contiguous_iterator_v = is_contiguous_iterator<It>::value;
+
+template <typename It, typename = void>
+struct has_data_and_size : std::false_type
+{
+};
+
+template <typename It>
+struct has_data_and_size<
+  It,
+  std::void_t<decltype(std::data(std::declval<It &>())), decltype(std::size(std::declval<It &>()))>>
+    : std::true_type
+{
+};
+
+template <typename It>
+inline constexpr bool has_data_and_size_v = has_data_and_size<It>::value;
+
+template <typename It>
+constexpr auto span_to_address(It &&it) noexcept
+{
+    static_assert(is_contiguous_iterator_v<std::decay_t<It>>,
+                  "span: It must be a contiguous iterator");
+    return detail::to_address(std::forward<It>(it));
+}
+
 struct view_base
 {
 };
@@ -118,9 +159,10 @@ struct is_compatible_container : std::false_type
 template <typename Container, typename T>
 struct is_compatible_container<Container,
                                T,
-                               std::void_t<decltype(std::declval<Container &>().data()),
-                                           decltype(std::declval<Container &>().size())>>
-    : is_array_convertible<T, std::remove_pointer_t<decltype(std::declval<Container &>().data())>>
+                               std::void_t<decltype(std::data(std::declval<Container &>())),
+                                           decltype(std::size(std::declval<Container &>()))>>
+    : is_array_convertible<T,
+                           std::remove_pointer_t<decltype(std::data(std::declval<Container &>()))>>
 {
 };
 
@@ -178,15 +220,6 @@ template <typename T, std::size_t Extent>
 class span : public detail::view_base
 {
 private:
-    struct internal_static_construct_tag
-    {
-    };
-
-    constexpr span(T *ptr, [[maybe_unused]] internal_static_construct_tag tag) noexcept
-        : storage_(ptr, Extent)
-    {
-    }
-
     template <std::size_t Offset, std::size_t Count>
     static constexpr std::size_t subspan_extent()
     {
@@ -202,13 +235,12 @@ private:
 public:
     using element_type = T;
     using value_type = std::remove_cv_t<T>;
-    using pointer = T *;
-    using const_pointer = const T *;
-    using reference = T &;
-    using const_reference = const T &;
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
-
+    using pointer = element_type *;
+    using const_pointer = const element_type *;
+    using reference = element_type &;
+    using const_reference = const element_type &;
     using iterator = T *;
     using const_iterator = const T *;
     using reverse_iterator = std::reverse_iterator<iterator>;
@@ -226,119 +258,169 @@ public:
     constexpr span(pointer ptr, size_type count) noexcept
         : storage_(ptr, count)
     {
+        assert((count == 0 || ptr != nullptr) && "span: null pointer with non-zero count");
     }
 
     template <std::size_t E = Extent, std::enable_if_t<E != dynamic_extent> * = nullptr>
     constexpr explicit span(pointer ptr, size_type count) noexcept
         : storage_(ptr, count)
     {
-        assert(count == E);
+        assert(count == E && "span: size mismatch for fixed-extent span");
+        assert((count == 0 || ptr != nullptr) && "span: null pointer with non-zero count");
     }
 
     template <std::size_t E = Extent, std::enable_if_t<E == dynamic_extent> * = nullptr>
     constexpr span(pointer first, pointer last) noexcept
         : storage_(first, static_cast<size_type>(last - first))
     {
+        assert(first <= last && "span: (first,last) last precedes first");
     }
 
     template <std::size_t E = Extent, std::enable_if_t<E != dynamic_extent> * = nullptr>
     constexpr explicit span(pointer first, pointer last) noexcept
         : storage_(first, static_cast<size_type>(last - first))
     {
-        assert(static_cast<size_type>(last - first) == E);
+        assert(first <= last && "span: (first,last) last precedes first");
+        assert(static_cast<size_type>(last - first) == E
+               && "span: size mismatch for fixed-extent span");
     }
 
     // (It, count) for dynamic extent — implicit
-    template <
-      typename It,
-      std::size_t E = Extent,
-      std::enable_if_t<E == dynamic_extent && detail::is_span_compatible_iter_v<It, T>> * = nullptr>
+    template <typename It,
+              std::size_t E = Extent,
+              std::enable_if_t<E == dynamic_extent> * = nullptr>
     constexpr span(It first, size_type count) noexcept
-        : storage_(detail::to_address(first), count)
+        : storage_(detail::span_to_address(first), count)
     {
+        static_assert(
+          detail::is_array_convertible_v<T,
+                                         std::remove_reference_t<decltype(*std::declval<It &>())>>,
+          "span: iterator value type is not compatible");
+        static_assert(
+          std::is_convertible_v<decltype(detail::to_address(std::declval<It &>())), T *>,
+          "span: iterator to_address result is not convertible to span pointer");
+        assert((count == 0 || detail::to_address(first) != nullptr)
+               && "span: null pointer with non-zero count");
     }
 
     // (It, count) for fixed extent — explicit
-    template <
-      typename It,
-      std::size_t E = Extent,
-      std::enable_if_t<E != dynamic_extent && detail::is_span_compatible_iter_v<It, T>> * = nullptr>
+    template <typename It,
+              std::size_t E = Extent,
+              std::enable_if_t<E != dynamic_extent> * = nullptr>
     constexpr explicit span(It first, size_type count) noexcept
-        : storage_(detail::to_address(first), count)
+        : storage_(detail::span_to_address(first), count)
     {
-        assert(count == E);
+        static_assert(
+          detail::is_array_convertible_v<T,
+                                         std::remove_reference_t<decltype(*std::declval<It &>())>>,
+          "span: iterator value type is not compatible");
+        static_assert(
+          std::is_convertible_v<decltype(detail::to_address(std::declval<It &>())), T *>,
+          "span: iterator to_address result is not convertible to span pointer");
+        assert(count == E && "span: size mismatch for fixed-extent span");
+        assert((count == 0 || detail::to_address(first) != nullptr)
+               && "span: null pointer with non-zero count");
     }
 
     // (It, End) for dynamic extent — implicit
-    template <typename It,
-              typename End,
-              std::size_t E = Extent,
-              std::enable_if_t<E == dynamic_extent && !std::is_convertible_v<End, size_type>
-                               && detail::is_span_compatible_iter_v<It, T>> * = nullptr>
-    constexpr span(It first, End last) noexcept
-        : storage_(detail::to_address(first), static_cast<size_type>(last - first))
+    template <
+      typename It,
+      typename End,
+      std::size_t E = Extent,
+      std::enable_if_t<E == dynamic_extent && !std::is_convertible_v<End, size_type>> * = nullptr>
+    constexpr span(It first, End last) noexcept(noexcept(last - first))
+        : storage_(detail::span_to_address(first), static_cast<size_type>(last - first))
     {
+        static_assert(
+          detail::is_array_convertible_v<T,
+                                         std::remove_reference_t<decltype(*std::declval<It &>())>>,
+          "span: iterator value type is not compatible");
+        static_assert(
+          std::is_convertible_v<decltype(detail::to_address(std::declval<It &>())), T *>,
+          "span: iterator to_address result is not convertible to span pointer");
+        assert((last - first >= 0) && "span: (It,End) last precedes first");
     }
 
     // (It, End) for fixed extent — explicit
-    template <typename It,
-              typename End,
-              std::size_t E = Extent,
-              std::enable_if_t<E != dynamic_extent && !std::is_convertible_v<End, size_type>
-                               && detail::is_span_compatible_iter_v<It, T>> * = nullptr>
-    constexpr explicit span(It first, End last) noexcept
-        : storage_(detail::to_address(first), static_cast<size_type>(last - first))
+    template <
+      typename It,
+      typename End,
+      std::size_t E = Extent,
+      std::enable_if_t<E != dynamic_extent && !std::is_convertible_v<End, size_type>> * = nullptr>
+    constexpr explicit span(It first, End last) noexcept(noexcept(last - first))
+        : storage_(detail::span_to_address(first), static_cast<size_type>(last - first))
     {
-        assert(static_cast<size_type>(last - first) == E);
+        static_assert(
+          detail::is_array_convertible_v<T,
+                                         std::remove_reference_t<decltype(*std::declval<It &>())>>,
+          "span: iterator value type is not compatible");
+        static_assert(
+          std::is_convertible_v<decltype(detail::to_address(std::declval<It &>())), T *>,
+          "span: iterator to_address result is not convertible to span pointer");
+        assert((last - first >= 0) && "span: (It,End) last precedes first");
+        assert(static_cast<size_type>(last - first) == E
+               && "span: size mismatch for fixed-extent span");
     }
 
-    template <std::size_t N, typename = std::enable_if_t<Extent == dynamic_extent || Extent == N>>
+    template <std::size_t N>
     constexpr span(detail::type_identity_t<element_type> (&arr)[N]) noexcept
         : storage_(arr, N)
     {
+        static_assert(Extent == dynamic_extent || Extent == N,
+                      "span: array size does not match fixed extent");
     }
 
     template <typename U,
               std::size_t N,
-              typename = std::enable_if_t<(Extent == dynamic_extent || Extent == N)
-                                          && detail::is_array_convertible_v<T, U>>>
+              typename = std::enable_if_t<Extent == dynamic_extent || Extent == N>>
     constexpr span(std::array<U, N> &arr) noexcept
         : storage_(arr.data(), N)
     {
+        static_assert(detail::is_array_convertible_v<T, U>,
+                      "span: array element type is not compatible");
     }
 
     template <typename U,
               std::size_t N,
-              typename = std::enable_if_t<(Extent == dynamic_extent || Extent == N)
-                                          && detail::is_array_convertible_v<T, const U>>>
+              typename = std::enable_if_t<Extent == dynamic_extent || Extent == N>>
     constexpr span(const std::array<U, N> &arr) noexcept
         : storage_(arr.data(), N)
     {
+        static_assert(detail::is_array_convertible_v<T, const U>,
+                      "span: array element type is not compatible");
     }
 
     template <typename Container,
               std::enable_if_t<!std::is_same_v<detail::remove_cvref_t<Container>, span>
                                && !std::is_array_v<std::remove_reference_t<Container>>
-                               && detail::is_compatible_container<Container, T>::value
+                               && detail::has_data_and_size_v<Container>
                                && (std::is_lvalue_reference_v<Container>
                                    || detail::is_view_v<detail::remove_cvref_t<Container>>)
                                && Extent == dynamic_extent> * = nullptr>
     constexpr span(Container &&cont)
         : storage_(std::forward<Container>(cont).data(), std::forward<Container>(cont).size())
     {
+        static_assert(detail::is_array_convertible_v<
+                        T,
+                        std::remove_pointer_t<decltype(std::data(std::declval<Container &>()))>>,
+                      "span: container element type is not compatible");
     }
 
     template <typename Container,
               std::enable_if_t<!std::is_same_v<detail::remove_cvref_t<Container>, span>
                                && !std::is_array_v<std::remove_reference_t<Container>>
-                               && detail::is_compatible_container<Container, T>::value
+                               && detail::has_data_and_size_v<Container>
                                && (std::is_lvalue_reference_v<Container>
                                    || detail::is_view_v<detail::remove_cvref_t<Container>>)
                                && Extent != dynamic_extent> * = nullptr>
     constexpr explicit span(Container &&cont)
         : storage_(std::forward<Container>(cont).data(), std::forward<Container>(cont).size())
     {
-        assert(cont.size() == Extent);
+        static_assert(detail::is_array_convertible_v<
+                        T,
+                        std::remove_pointer_t<decltype(std::data(std::declval<Container &>()))>>,
+                      "span: container element type is not compatible");
+        assert(cont.size() == Extent && "span: container size mismatch for fixed-extent span");
     }
 
     template <typename U,
@@ -351,7 +433,7 @@ public:
         : storage_(other.data(), other.size())
     {
         if constexpr (Extent != dynamic_extent) {
-            assert(other.size() == Extent);
+            assert(other.size() == Extent && "span: span size mismatch for fixed-extent span");
         }
     }
 
@@ -364,7 +446,7 @@ public:
     constexpr explicit span(const span<U, OtherExtent> &other) noexcept
         : storage_(other.data(), other.size())
     {
-        assert(other.size() == Extent);
+        assert(other.size() == Extent && "span: span size mismatch for fixed-extent span");
     }
 
     ~span() = default;
@@ -386,7 +468,7 @@ public:
 
     [[nodiscard]] constexpr reference operator[](size_type idx) const noexcept
     {
-        assert(idx < size());
+        assert(idx < size() && "span: index out of range");
         return data()[idx];
     }
 
@@ -400,13 +482,13 @@ public:
 
     [[nodiscard]] constexpr reference front() const noexcept
     {
-        assert(!empty());
+        assert(!empty() && "span: front() called on empty span");
         return data()[0];
     }
 
     [[nodiscard]] constexpr reference back() const noexcept
     {
-        assert(!empty());
+        assert(!empty() && "span: back() called on empty span");
         return data()[size() - 1];
     }
 
@@ -428,28 +510,38 @@ public:
         return reverse_iterator(begin());
     }
 
+    [[nodiscard]] constexpr const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    [[nodiscard]] constexpr const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
     template <std::size_t Count>
     [[nodiscard]] constexpr span<element_type, Count> first() const noexcept
     {
         if constexpr (Extent == dynamic_extent) {
-            assert(Count <= size());
+            assert(Count <= size() && "span::first<Count>(): Count out of range");
         } else {
             static_assert(Count <= Extent, "Count out of bounds in span::first()");
         }
 
-        return { data(), internal_static_construct_tag{ } };
+        return span<element_type, Count>(data(), Count);
     }
 
     template <std::size_t Count>
     [[nodiscard]] constexpr span<element_type, Count> last() const noexcept
     {
         if constexpr (Extent == dynamic_extent) {
-            assert(Count <= size());
+            assert(Count <= size() && "span::last<Count>(): Count out of range");
         } else {
             static_assert(Count <= Extent, "Count out of bounds in span::last()");
         }
 
-        return { data() + (size() - Count), internal_static_construct_tag{ } };
+        return span<element_type, Count>(data() + (size() - Count), Count);
     }
 
     template <std::size_t Offset, std::size_t Count = dynamic_extent>
@@ -457,7 +549,7 @@ public:
       -> span<element_type, subspan_extent<Offset, Count>()>
     {
         if constexpr (Extent == dynamic_extent) {
-            assert(Offset <= size());
+            assert(Offset <= size() && "span::subspan<Offset,Count>(): Offset out of range");
         } else {
             static_assert(Offset <= Extent, "Offset out of bounds in span::subspan()");
         }
@@ -466,13 +558,14 @@ public:
 
         if constexpr (E != dynamic_extent) {
             if constexpr (Extent == dynamic_extent && Count != dynamic_extent) {
-                assert(Count <= (size() - Offset));
+                assert(Count <= (size() - Offset)
+                       && "span::subspan<Offset,Count>(): Count out of range");
             } else if constexpr (Extent != dynamic_extent) {
                 static_assert(Count == dynamic_extent || Count <= (Extent - Offset),
                               "Count out of bounds");
             }
 
-            return { data() + Offset, internal_static_construct_tag{ } };
+            return span<element_type, E>(data() + Offset, E);
         } else {
             return { data() + Offset, Count == dynamic_extent ? size() - Offset : Count };
         }
@@ -480,25 +573,25 @@ public:
 
     [[nodiscard]] constexpr span<element_type, dynamic_extent> first(size_type count) const noexcept
     {
-        assert(count <= size());
+        assert(count <= size() && "span::first(count): count out of range");
         return { data(), count };
     }
 
     [[nodiscard]] constexpr span<element_type, dynamic_extent> last(size_type count) const noexcept
     {
-        assert(count <= size());
+        assert(count <= size() && "span::last(count): count out of range");
         return { data() + (size() - count), count };
     }
 
     [[nodiscard]] constexpr span<element_type, dynamic_extent>
     subspan(size_type offset, size_type count = dynamic_extent) const noexcept
     {
-        assert(offset <= size());
+        assert(offset <= size() && "span::subspan(offset,count): offset out of range");
         if (count == dynamic_extent) {
             return { data() + offset, size() - offset };
         }
 
-        assert(offset + count <= size());
+        assert(count <= size() - offset && "span::subspan(offset,count): count out of range");
         return { data() + offset, count };
     }
 
@@ -520,6 +613,9 @@ span(It, std::size_t) -> span<std::remove_reference_t<decltype(*std::declval<It 
 
 template <typename It, typename End>
 span(It, End) -> span<std::remove_reference_t<decltype(*std::declval<It &>())>>;
+
+template <typename Container>
+span(Container &&) -> span<std::remove_pointer_t<decltype(std::data(std::declval<Container &>()))>>;
 
 template <typename T, std::size_t Extent, std::enable_if_t<!std::is_volatile_v<T>, int> = 0>
 [[nodiscard]] constexpr auto as_bytes(span<T, Extent> s) noexcept

--- a/tests/ll-box-ut/src/span_test.cpp
+++ b/tests/ll-box-ut/src/span_test.cpp
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <cstring>
+#include <numeric>
 #include <vector>
 
 namespace utils = linyaps_box::utils;
@@ -215,6 +216,26 @@ TEST(SpanCTAD, ItEnd)
     static_assert(decltype(s)::extent == utils::dynamic_extent);
 }
 
+TEST(SpanCTAD, Container)
+{
+    std::vector<int> v{ 1, 2, 3 };
+    const utils::span s(v);
+    EXPECT_EQ(s.size(), 3);
+    EXPECT_EQ(s[1], 2);
+    static_assert(std::is_same_v<decltype(s)::element_type, int>);
+    static_assert(decltype(s)::extent == utils::dynamic_extent);
+}
+
+TEST(SpanCTAD, ConstContainer)
+{
+    const std::vector<int> v{ 4, 5 };
+    const utils::span s(v);
+    EXPECT_EQ(s.size(), 2);
+    EXPECT_EQ(s[0], 4);
+    static_assert(std::is_same_v<decltype(s)::element_type, const int>);
+    static_assert(decltype(s)::extent == utils::dynamic_extent);
+}
+
 namespace {
 
 template <typename T, typename = void>
@@ -269,4 +290,209 @@ TEST(SpanBytes, AsWritableBytes)
     EXPECT_EQ(arr[0], 0);
     bytes[0] = std::byte(1);
     EXPECT_EQ(arr[0], 1);
+}
+
+TEST(SpanElementAccess, OperatorIndex)
+{
+    std::array arr{ 1, 2, 3 };
+    const utils::span s(arr);
+    EXPECT_EQ(s[0], 1);
+    EXPECT_EQ(s[2], 3);
+    s[1] = 42;
+    EXPECT_EQ(arr[1], 42);
+}
+
+TEST(SpanElementAccess, FrontBack)
+{
+    std::array arr{ 10, 20, 30 };
+    const utils::span s(arr);
+    EXPECT_EQ(s.front(), 10);
+    EXPECT_EQ(s.back(), 30);
+    s.front() = 1;
+    s.back() = 3;
+    EXPECT_EQ(arr[0], 1);
+    EXPECT_EQ(arr[2], 3);
+}
+
+TEST(SpanElementAccess, FrontBackConstSpan)
+{
+    const std::array arr{ 1, 2, 3 };
+    const utils::span s(arr);
+    EXPECT_EQ(s.front(), 1);
+    EXPECT_EQ(s.back(), 3);
+}
+
+TEST(SpanIterators, ForwardIteration)
+{
+    std::array arr{ 10, 20, 30 };
+    const utils::span s(arr);
+
+    auto sum = std::accumulate(s.cbegin(), s.cend(), 0);
+    EXPECT_EQ(sum, 60);
+
+    int count = 0;
+    for ([[maybe_unused]] auto val : s) {
+        ++count;
+    }
+    EXPECT_EQ(count, 3);
+
+    *s.begin() = 99;
+    EXPECT_EQ(arr[0], 99);
+}
+
+TEST(SpanIterators, ReverseIteration)
+{
+    std::array arr{ 1, 2, 3 };
+    const utils::span s(arr);
+    auto rit = s.rbegin();
+    EXPECT_EQ(*rit, 3);
+    ++rit;
+    EXPECT_EQ(*rit, 2);
+    ++rit;
+    EXPECT_EQ(*rit, 1);
+    ++rit;
+    EXPECT_EQ(rit, s.rend());
+}
+
+TEST(SpanIterators, ConstIterators)
+{
+    const std::array arr{ 1, 2, 3 };
+    const utils::span s(arr);
+    EXPECT_EQ(*s.cbegin(), 1);
+    EXPECT_EQ(s.cend(), s.cbegin() + 3);
+    EXPECT_EQ(*s.crbegin(), 3);
+    EXPECT_EQ(s.crend(), s.crbegin() + 3);
+}
+
+TEST(SpanIterators, ReverseMutate)
+{
+    std::array arr{ 1, 2, 3 };
+    const utils::span s(arr);
+    *s.rbegin() = 99;
+    EXPECT_EQ(arr[2], 99);
+}
+
+TEST(SpanSubviews, TemplateFirst)
+{
+    std::array arr{ 1, 2, 3, 4, 5 };
+    const utils::span s(arr);
+    auto first2 = s.first<2>();
+    EXPECT_EQ(first2.size(), 2);
+    EXPECT_EQ(first2[0], 1);
+    EXPECT_EQ(first2[1], 2);
+    static_assert(decltype(first2)::extent == 2);
+}
+
+TEST(SpanSubviews, TemplateLast)
+{
+    std::array arr{ 1, 2, 3, 4, 5 };
+    const utils::span s(arr);
+    auto last3 = s.last<3>();
+    EXPECT_EQ(last3.size(), 3);
+    EXPECT_EQ(last3[0], 3);
+    EXPECT_EQ(last3[2], 5);
+    static_assert(decltype(last3)::extent == 3);
+}
+
+TEST(SpanSubviews, TemplateSubspan)
+{
+    std::array arr{ 0, 1, 2, 3, 4 };
+    const utils::span s(arr);
+    auto sub = s.subspan<1, 3>();
+    EXPECT_EQ(sub.size(), 3);
+    EXPECT_EQ(sub[0], 1);
+    EXPECT_EQ(sub[2], 3);
+    static_assert(decltype(sub)::extent == 3);
+}
+
+TEST(SpanSubviews, RuntimeFirst)
+{
+    std::array arr{ 1, 2, 3, 4, 5 };
+    const utils::span s(arr);
+    auto first2 = s.first(2);
+    EXPECT_EQ(first2.size(), 2);
+    EXPECT_EQ(first2[0], 1);
+    EXPECT_EQ(first2[1], 2);
+}
+
+TEST(SpanSubviews, RuntimeLast)
+{
+    std::array arr{ 1, 2, 3, 4, 5 };
+    const utils::span s(arr);
+    auto last3 = s.last(3);
+    EXPECT_EQ(last3.size(), 3);
+    EXPECT_EQ(last3[0], 3);
+    EXPECT_EQ(last3[2], 5);
+}
+
+TEST(SpanSubviews, RuntimeSubspanAll)
+{
+    std::array arr{ 0, 1, 2, 3, 4 };
+    const utils::span s(arr);
+    auto sub = s.subspan(0);
+    EXPECT_EQ(sub.size(), 5);
+    EXPECT_EQ(sub[0], 0);
+    EXPECT_EQ(sub[4], 4);
+}
+
+TEST(SpanObservers, SizeBytesAndEmpty)
+{
+    std::array arr{ 1, 2, 3 };
+    const utils::span s(arr);
+    EXPECT_EQ(s.size_bytes(), sizeof(int) * 3);
+    EXPECT_FALSE(s.empty());
+    EXPECT_EQ(s.data(), arr.data());
+
+    const utils::span<int> empty;
+    EXPECT_TRUE(empty.empty());
+    EXPECT_EQ(empty.size_bytes(), 0);
+    EXPECT_EQ(empty.data(), nullptr);
+}
+
+TEST(SpanConstructor, DefaultConstructed)
+{
+    const utils::span<int> s;
+    EXPECT_EQ(s.size(), 0);
+    EXPECT_EQ(s.data(), nullptr);
+    EXPECT_TRUE(s.empty());
+}
+
+TEST(SpanConstructor, ConstConversion)
+{
+    std::array arr{ 1, 2, 3 };
+    const utils::span mutable_s(arr);
+    const utils::span const_s(mutable_s);
+    EXPECT_EQ(const_s.size(), 3);
+    EXPECT_EQ(const_s[0], 1);
+    EXPECT_EQ(const_s[2], 3);
+}
+
+TEST(SpanCopy, CopyConstructor)
+{
+    std::array arr{ 1, 2, 3 };
+    const utils::span s1(arr);
+    const utils::span s2(s1);
+    EXPECT_EQ(s1.size(), s2.size());
+    EXPECT_EQ(s1.data(), s2.data());
+    EXPECT_EQ(s2[1], 2);
+}
+
+TEST(SpanCopy, CopyAssignment)
+{
+    std::array arr{ 1, 2, 3 };
+    const utils::span s1(arr);
+    utils::span<int> s2;
+    s2 = s1;
+    EXPECT_EQ(s1.size(), s2.size());
+    EXPECT_EQ(s1.data(), s2.data());
+    EXPECT_EQ(s2[0], 1);
+}
+
+TEST(SpanBytes, AsBytesFixedExtent)
+{
+    const std::array arr{ 0x01020304 };
+    const utils::span<const int, 1> s(arr);
+    auto bytes = utils::as_bytes(s);
+    EXPECT_EQ(bytes.size(), sizeof(int));
+    static_assert(decltype(bytes)::extent == sizeof(int));
 }


### PR DESCRIPTION
- Split is_span_compatible_iter into is_contiguous_iterator + static_assert
- Replace type SFINAE with static_assert in array/container/iterator ctors
- span_to_address helper with static_assert guards non-iterator types
- Add null+nonzero, first>last range checks with descriptive messages
- Add crbegin/crend, container CTAD deduction guide
- Use std::data/std::size instead of member calls
- Fix template subviews cross-specialization private ctor bug
- LWG 3358: (It,End) conditional noexcept
- LWG 3103: avoid unsigned overflow in subspan runtime check
- Add 18 tests (iterators, subviews, front/back, copy, observers, ctors)