### PR TITLE
refactor(log): deduplicate dispatch_log and eliminate redundant serialization copy

### DIFF
--- a/src/linyaps_box/log/log_api.h
+++ b/src/linyaps_box/log/log_api.h
@@ -95,6 +95,23 @@ inline auto warn(std::string_view file,
 }
 
 template <typename... Args>
+inline auto warn(std::string_view file,
+                 std::string_view function,
+                 int line,
+                 int errno_val,
+                 fmt::format_string<Args...> fmt,
+                 Args &&...args) noexcept -> void
+{
+    dispatch(level::warn,
+             errno_val,
+             fmt.get(),
+             fmt::make_format_args(args...),
+             file,
+             function,
+             line);
+}
+
+template <typename... Args>
 inline auto info(std::string_view file,
                  std::string_view function,
                  int line,

--- a/src/linyaps_box/log/logger.cpp
+++ b/src/linyaps_box/log/logger.cpp
@@ -91,7 +91,7 @@ auto dispatch(level lvl,
               std::string_view function,
               int line) noexcept -> void
 {
-    global_logger::instance().dispatch_log(lvl, errno_val, fmt_str, args, file, function, line);
+    global_logger::instance().dispatch_log(lvl, fmt_str, args, file, function, line, errno_val);
 }
 
 auto global_logger::instance() noexcept -> global_logger &
@@ -122,11 +122,12 @@ auto global_logger::get_format() const noexcept -> output_format
 
 auto global_logger::set_sinks(std::vector<sink_variant> sinks) noexcept -> void
 {
-    sinks_ = std::move(sinks);
+    sinks_.swap(sinks);
 }
 
 auto global_logger::set_sink(sink_variant sink) noexcept -> void
 {
+    // for exception safety
     std::vector<sink_variant> tmp;
     tmp.push_back(std::move(sink));
     sinks_.swap(tmp);
@@ -142,38 +143,8 @@ void global_logger::dispatch_log(level lvl,
                                  fmt::format_args args,
                                  std::string_view file,
                                  std::string_view function,
-                                 int line) const noexcept
-{
-    if (UNLIKELY(lvl > level_)) {
-        return;
-    }
-
-    thread_local fmt::memory_buffer buf;
-    buf.clear();
-    fmt::vformat_to(std::back_inserter(buf), fmt::locale_ref{ }, fmt_str, args);
-
-    const log_context ctx{
-        lvl,
-        std::string_view{ buf.data(), buf.size() },
-        std::chrono::system_clock::now(),
-        ::getpid(),
-        0,
-#ifdef LINYAPS_BOX_LOG_ENABLE_SOURCE_LOCATION
-        file,
-        function,
-        line,
-#endif
-    };
-    dispatch_to_sinks(ctx);
-}
-
-void global_logger::dispatch_log(level lvl,
-                                 int errno_val,
-                                 fmt::string_view fmt_str,
-                                 fmt::format_args args,
-                                 std::string_view file,
-                                 std::string_view function,
-                                 int line) const noexcept
+                                 int line,
+                                 int errno_val) const noexcept
 {
     if (UNLIKELY(lvl > level_)) {
         return;

--- a/src/linyaps_box/log/logger.h
+++ b/src/linyaps_box/log/logger.h
@@ -42,15 +42,8 @@ public:
                       fmt::format_args args,
                       std::string_view file,
                       std::string_view function,
-                      int line) const noexcept -> void;
-
-    auto dispatch_log(level lvl,
-                      int errno_val,
-                      fmt::string_view fmt_str,
-                      fmt::format_args args,
-                      std::string_view file,
-                      std::string_view function,
-                      int line) const noexcept -> void;
+                      int line,
+                      int errno_val = 0) const noexcept -> void;
 
     auto dispatch_to_sinks(const log_context &ctx) const noexcept -> void;
 

--- a/src/linyaps_box/log/macro.h
+++ b/src/linyaps_box/log/macro.h
@@ -67,6 +67,20 @@
         }                                                                                         \
     } while (false)
 
+#define LINYAPS_BOX_LOG_WARN_ERRNO(errno_val, ...)                                                \
+    do {                                                                                          \
+        if constexpr (LINYAPS_BOX_LOG_ACTIVE_LEVEL                                                \
+                      >= static_cast<int>(::linyaps_box::log::level::warn)) {                     \
+            if (::linyaps_box::log::get_current_log_level() >= ::linyaps_box::log::level::warn) { \
+                ::linyaps_box::log::warn(::linyaps_box::log::log_basename(__FILE__),              \
+                                         __func__,                                                \
+                                         __LINE__,                                                \
+                                         errno_val,                                               \
+                                         __VA_ARGS__);                                            \
+            }                                                                                     \
+        }                                                                                         \
+    } while (false)
+
 #define LINYAPS_BOX_LOG_INFO(...)                                                                 \
     do {                                                                                          \
         if constexpr (LINYAPS_BOX_LOG_ACTIVE_LEVEL                                                \

--- a/src/linyaps_box/log/sinks/sync_socket_sink.cpp
+++ b/src/linyaps_box/log/sinks/sync_socket_sink.cpp
@@ -4,7 +4,9 @@
 
 #include "linyaps_box/log/sinks/sync_socket_sink.h"
 
-#include <sys/uio.h>
+#include "linyaps_box/log/formatter.h"
+#include "linyaps_box/utils/span.h"
+
 #include <unistd.h>
 
 namespace linyaps_box::log {
@@ -18,34 +20,13 @@ auto sync_socket_sink::log(const log_context &ctx) const noexcept -> void
 try {
     channel.get().send_log(ctx);
 } catch (...) {
-    // If the parent is gone, fall back to stderr
+    thread_local fmt::memory_buffer buf;
+    buf.clear();
+    format_log(buf, ctx, output_format::text, { });
+
     const utils::file_descriptor stderr_fd{ STDERR_FILENO, false };
-    std::string_view prefix;
-    switch (ctx.lvl) {
-    case level::fatal:
-        prefix = "[FATAL] ";
-        break;
-    case level::error:
-        prefix = "[ERROR] ";
-        break;
-    case level::warn:
-        prefix = "[WARN]  ";
-        break;
-    case level::info:
-        prefix = "[INFO]  ";
-        break;
-    case level::debug:
-        prefix = "[DEBUG] ";
-        break;
-    }
-
-    const std::array<struct iovec, 3> iov{
-        { { const_cast<char *>(prefix.data()), prefix.size() },
-          { const_cast<char *>(ctx.msg.data()), ctx.msg.size() },
-          { const_cast<char *>("\n"), 1 } },
-    };
-
-    std::ignore = stderr_fd.write_vecs(iov); // we couldn't handle error at this point, just ignore
+    auto bytes = utils::as_bytes(utils::span(buf.data(), buf.size()));
+    std::ignore = stderr_fd.write_span(bytes);
 }
 
 } // namespace linyaps_box::log

--- a/src/linyaps_box/protocol/message.cpp
+++ b/src/linyaps_box/protocol/message.cpp
@@ -176,6 +176,37 @@ auto deserialize(utils::span<const std::byte> wire) -> message
     }
 }
 
+namespace {
+
+auto serialize_log_into(std::vector<std::byte> &buf,
+                        uint8_t lvl,
+                        std::string_view message,
+                        int errno_val,
+                        pid_t pid,
+                        int64_t time_ns
+#ifdef LINYAPS_BOX_LOG_ENABLE_SOURCE_LOCATION
+                        ,
+                        std::string_view file,
+                        int line,
+                        std::string_view function
+#endif
+                        ) -> void
+{
+    append_pod(buf, msg_id::log);
+    append_pod(buf, lvl);
+    append_string(buf, message);
+#ifdef LINYAPS_BOX_LOG_ENABLE_SOURCE_LOCATION
+    append_string(buf, file);
+    append_pod(buf, line);
+    append_string(buf, function);
+#endif
+    append_pod(buf, errno_val);
+    append_pod(buf, pid);
+    append_pod<std::int64_t>(buf, time_ns);
+}
+
+} // namespace
+
 auto serialize_log(const msg::log &m) -> std::vector<std::byte>
 {
     std::vector<std::byte> buf;
@@ -187,19 +218,52 @@ auto serialize_log(const msg::log &m) -> std::vector<std::byte>
     buf.reserve(sizeof(msg_id) + 1 + m.message.size() + sizeof(int) + sizeof(pid_t)
                 + sizeof(std::int64_t) + sizeof(uint32_t));
 #endif
-    append_pod(buf, msg_id::log);
-    append_pod(buf, static_cast<uint8_t>(m.lvl));
-    append_string(buf, m.message);
-#ifdef LINYAPS_BOX_LOG_ENABLE_SOURCE_LOCATION
-    append_string(buf, m.file);
-    append_pod(buf, m.line);
-    append_string(buf, m.function);
-#endif
-    append_pod(buf, m.errno_);
-    append_pod(buf, m.pid);
     const auto ns = m.time.count();
     static_assert(std::is_signed_v<decltype(ns)>);
-    append_pod<std::int64_t>(buf, ns);
+    serialize_log_into(buf,
+                       static_cast<uint8_t>(m.lvl),
+                       m.message,
+                       m.errno_,
+                       m.pid,
+                       ns
+#ifdef LINYAPS_BOX_LOG_ENABLE_SOURCE_LOCATION
+                       ,
+                       m.file,
+                       m.line,
+                       m.function
+#endif
+    );
+    return buf;
+}
+
+auto serialize_log(const linyaps_box::log::log_context &ctx) -> std::vector<std::byte>
+{
+    std::vector<std::byte> buf;
+#ifdef LINYAPS_BOX_LOG_ENABLE_SOURCE_LOCATION
+    buf.reserve(sizeof(msg_id) + 1 + ctx.msg.size() + ctx.file.size() + ctx.function.size()
+                + sizeof(int) + sizeof(int) + sizeof(pid_t) + sizeof(std::int64_t)
+                + (3 * sizeof(uint32_t)));
+#else
+    buf.reserve(sizeof(msg_id) + 1 + ctx.msg.size() + sizeof(int) + sizeof(pid_t)
+                + sizeof(std::int64_t) + sizeof(uint32_t));
+#endif
+    const auto ns =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(ctx.wall_time.time_since_epoch())
+        .count();
+    static_assert(std::is_signed_v<decltype(ns)>);
+    serialize_log_into(buf,
+                       static_cast<uint8_t>(ctx.lvl),
+                       ctx.msg,
+                       ctx.errno_,
+                       ctx.pid,
+                       ns
+#ifdef LINYAPS_BOX_LOG_ENABLE_SOURCE_LOCATION
+                       ,
+                       ctx.file,
+                       ctx.line,
+                       ctx.function
+#endif
+    );
     return buf;
 }
 

--- a/src/linyaps_box/protocol/message.h
+++ b/src/linyaps_box/protocol/message.h
@@ -82,9 +82,13 @@ struct datagram
 };
 
 [[nodiscard]] auto serialize(const message &msg) -> std::vector<std::byte>;
+
 [[nodiscard]] auto deserialize(utils::span<const std::byte> wire) -> message;
 
 [[nodiscard]] auto serialize_log(const msg::log &m) -> std::vector<std::byte>;
+
+[[nodiscard]] auto serialize_log(const linyaps_box::log::log_context &ctx)
+  -> std::vector<std::byte>;
 
 } // namespace linyaps_box::protocol::msg
 

--- a/src/linyaps_box/protocol/message_channel.cpp
+++ b/src/linyaps_box/protocol/message_channel.cpp
@@ -117,19 +117,7 @@ auto message_channel_base::send_stage(stage::type s) const -> void
 
 auto message_channel_base::send_log(const linyaps_box::log::log_context &ctx) const -> void
 {
-    const msg::log m{ std::string{ ctx.msg },
-#ifdef LINYAPS_BOX_LOG_ENABLE_SOURCE_LOCATION
-                      std::string{ ctx.file },
-                      std::string{ ctx.function },
-                      ctx.line,
-#endif
-                      ctx.errno_,
-                      std::chrono::duration_cast<std::chrono::nanoseconds>(
-                        ctx.wall_time.time_since_epoch()),
-                      ctx.pid,
-                      ctx.lvl };
-
-    auto buffer = msg::serialize_log(m);
+    auto buffer = msg::serialize_log(ctx);
     send_raw(socket_, utils::span(buffer), { });
 }
 


### PR DESCRIPTION
- Merge two dispatch_log overloads into one with errno_val=0 default
- Replace sync_socket_sink fallback hardcoded prefix with format_log output
- Add serialize_log(log_context) overload to skip msg::log intermediate
- Remove hardcoded string copies in send_log; extract serialization core
- Add LINYAPS_BOX_LOG_WARN_ERRNO for API symmetry
- Align set_sinks with set_sink swap pattern for exception safety