### PR TITLE
perf(build): prune transitive heavy includes

### DIFF
--- a/src/linyaps_box/app.cpp
+++ b/src/linyaps_box/app.cpp
@@ -13,6 +13,8 @@
 #include "linyaps_box/log/sink_factory.h"
 #include "linyaps_box/utils/utils.h"
 
+#include <fmt/ostream.h>
+
 #include <iostream>
 
 namespace linyaps_box {

--- a/src/linyaps_box/config.cpp
+++ b/src/linyaps_box/config.cpp
@@ -7,7 +7,7 @@
 #include "linyaps_box/config/enum_tables.h"
 #include "linyaps_box/config/mount_options.h"
 #include "linyaps_box/config/validate.h"
-#include "linyaps_box/utils/enum_traits.h"
+#include "linyaps_box/utils/enum_formatter.h"
 #include "linyaps_box/utils/semver.h"
 #include "linyaps_box/utils/utils.h"
 

--- a/src/linyaps_box/container.cpp
+++ b/src/linyaps_box/container.cpp
@@ -27,6 +27,7 @@
 
 #include <linux/magic.h>
 #include <linux/sched.h>
+#include <nlohmann/json.hpp>
 #include <sys/mount.h>
 #include <sys/signalfd.h>
 #include <sys/statfs.h>

--- a/src/linyaps_box/container_monitor.cpp
+++ b/src/linyaps_box/container_monitor.cpp
@@ -11,6 +11,7 @@
 #include "linyaps_box/utils/signal.h"
 #include "linyaps_box/utils/utils.h"
 
+#include <fmt/std.h>
 #include <sys/signalfd.h>
 
 #include <algorithm>

--- a/src/linyaps_box/container_status.cpp
+++ b/src/linyaps_box/container_status.cpp
@@ -8,6 +8,8 @@
 #include "linyaps_box/utils/time.h"
 #include "linyaps_box/utils/utils.h"
 
+#include <nlohmann/json.hpp>
+
 #include <csignal> // IWYU pragma: keep
 #include <system_error>
 
@@ -113,5 +115,15 @@ auto to_oci_json(container_status s, runtime_status rs) -> nlohmann::json
                                     { "annotations", std::move(s.annotations) },
                                     { "ociVersion", std::move(s.oci_version) } });
 }
+
+namespace detail {
+
+auto format_container_status_json(const container_status &status, bool pretty) -> std::string
+{
+    auto json = nlohmann::json(status);
+    return json.dump(pretty ? 4 : -1);
+}
+
+} // namespace detail
 
 } // namespace linyaps_box

--- a/src/linyaps_box/container_status.h
+++ b/src/linyaps_box/container_status.h
@@ -7,7 +7,7 @@
 #include "linyaps_box/utils/time.h"
 
 #include <fmt/format.h>
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 #include <cstdint>
 #include <filesystem>
@@ -38,6 +38,10 @@ auto to_string_view(runtime_status s) -> std::string_view;
 auto derive_status(const container_status &s) -> runtime_status;
 
 auto to_oci_json(container_status s, runtime_status rs) -> nlohmann::json;
+
+namespace detail {
+auto format_container_status_json(const container_status &status, bool pretty) -> std::string;
+} // namespace detail
 
 } // namespace linyaps_box
 
@@ -97,8 +101,9 @@ struct fmt::formatter<linyaps_box::container_status>
               std::string_view{ time_buf.data(), len });
         }
 
-        auto json = nlohmann::json(status);
-        auto tab = presentation == Presentation::pretty_json ? 4 : -1;
-        return fmt::format_to(ctx.out(), "{}", json.dump(tab));
+        auto json_str = linyaps_box::detail::format_container_status_json(
+          status,
+          presentation == Presentation::pretty_json);
+        return fmt::format_to(ctx.out(), "{}", json_str);
     }
 };

--- a/src/linyaps_box/infra/rootfs.cpp
+++ b/src/linyaps_box/infra/rootfs.cpp
@@ -10,10 +10,12 @@
 #include "linyaps_box/os/kernel_constants.h"
 #include "linyaps_box/utils/utils.h"
 
+#include <fmt/std.h>
 #include <linux/magic.h>
 #include <sys/statfs.h>
 #include <sys/syscall.h>
 
+#include <algorithm>
 #include <deque>
 #include <memory>
 #include <string>

--- a/src/linyaps_box/log/macro.h
+++ b/src/linyaps_box/log/macro.h
@@ -7,7 +7,6 @@
 #include "linyaps_box/log/utils.h"
 
 #include <fmt/format.h>
-#include <fmt/std.h>
 
 #include <string_view>
 

--- a/src/linyaps_box/log/utils.h
+++ b/src/linyaps_box/log/utils.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <fmt/format.h>
-
 #include <chrono>
 #include <cstdint>
 #include <string_view>

--- a/src/linyaps_box/os/fs.h
+++ b/src/linyaps_box/os/fs.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "linyaps_box/os/result.h"
-#include "linyaps_box/utils/enum_traits.h"
+#include "linyaps_box/utils/enum_formatter.h"
 #include "linyaps_box/utils/file_describer.h"
 #include "linyaps_box/utils/utils.h"
 

--- a/src/linyaps_box/os/net.h
+++ b/src/linyaps_box/os/net.h
@@ -6,7 +6,7 @@
 
 #include "linyaps_box/os/io.h"
 #include "linyaps_box/os/result.h"
-#include "linyaps_box/utils/enum_traits.h"
+#include "linyaps_box/utils/enum_formatter.h"
 #include "linyaps_box/utils/file_describer.h"
 
 #include <cstring>

--- a/src/linyaps_box/os/result.h
+++ b/src/linyaps_box/os/result.h
@@ -4,8 +4,10 @@
 
 #pragma once
 
-#include <fmt/format.h>
 #include <zeus/expected.hpp>
+
+#include <string_view>
+#include <system_error>
 
 namespace linyaps_box::os {
 

--- a/src/linyaps_box/security/privilege.cpp
+++ b/src/linyaps_box/security/privilege.cpp
@@ -9,8 +9,10 @@
 #include "linyaps_box/utils/defer.h"
 #include "linyaps_box/utils/utils.h"
 
+#include <fmt/std.h>
 #include <sys/prctl.h>
 
+#include <algorithm>
 #include <fstream>
 #include <system_error>
 

--- a/src/linyaps_box/status_directory.cpp
+++ b/src/linyaps_box/status_directory.cpp
@@ -11,7 +11,7 @@
 #include "linyaps_box/utils/file_describer.h"
 #include "linyaps_box/utils/utils.h"
 
-#include <fmt/format.h>
+#include <fmt/std.h>
 #include <nlohmann/json.hpp>
 
 namespace {

--- a/src/linyaps_box/utils/enum_formatter.h
+++ b/src/linyaps_box/utils/enum_formatter.h
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/utils/enum_traits.h"
+
+#include <fmt/format.h>
+
+#include <algorithm>
+
+// Out-of-line definitions of the fmt-dependent methods of enum_table.
+// Kept separate from enum_traits.h so that headers which only need the
+// bitmask / enum-table infrastructure (e.g. config.h) do not pull in
+// <fmt/format.h>.
+
+template <typename E, std::size_t N>
+template <typename OutputIt>
+OutputIt linyaps_box::utils::enum_table<E, N>::format_to(OutputIt out, E value) const
+{
+    if constexpr (is_bitmask_enum_v<E>) {
+        return format_flags_to(out, value);
+    } else {
+        return format_single_to(out, value);
+    }
+}
+
+template <typename E, std::size_t N>
+template <typename OutputIt>
+OutputIt linyaps_box::utils::enum_table<E, N>::format_single_to(OutputIt out, E value) const
+{
+    if (auto name = to_name(value)) {
+        return std::copy(name->begin(), name->end(), out);
+    }
+
+    using U = std::underlying_type_t<E>;
+    return fmt::format_to(out, "{}", static_cast<U>(value));
+}
+
+template <typename E, std::size_t N>
+template <typename OutputIt>
+OutputIt linyaps_box::utils::enum_table<E, N>::format_flags_to(OutputIt out, E flags) const
+{
+    using U = std::underlying_type_t<E>;
+    auto val = static_cast<U>(flags);
+
+    if (val == 0) {
+        if (auto name = to_name(flags)) {
+            return std::copy(name->begin(), name->end(), out);
+        }
+
+        static constexpr std::string_view none_sv = "none";
+        return std::copy(none_sv.begin(), none_sv.end(), out);
+    }
+
+    bool first = true;
+    for (const auto &entry : entries) {
+        const auto mask = static_cast<U>(entry.value);
+        if (mask != 0 && (val & mask) == mask) {
+            if (!first) {
+                *out++ = '|';
+            }
+
+            out = std::copy(entry.name.begin(), entry.name.end(), out);
+            first = false;
+            val &= ~mask;
+
+            if (val == 0) {
+                break;
+            }
+        }
+    }
+
+    if (val != 0) {
+        if (!first) {
+            *out++ = '|';
+        }
+
+        out = fmt::format_to(out, "0x{:x}", val);
+    }
+
+    return out;
+}
+
+template <typename E>
+struct fmt::formatter<E, std::enable_if_t<linyaps_box::utils::has_enum_table_v<E>, char>>
+{
+    enum class Presentation : uint8_t { Default, Hex, Decimal };
+    Presentation presentation{ Presentation::Default };
+
+    constexpr auto parse(fmt::format_parse_context &ctx)
+    {
+        const auto *it = ctx.begin();
+        const auto *end = ctx.end();
+        if (it != end && *it != '}') {
+            if (*it == 'x') {
+                presentation = Presentation::Hex;
+            } else if (*it == 'd') {
+                presentation = Presentation::Decimal;
+            } else {
+                throw fmt::format_error("invalid format specifier for enum");
+            }
+
+            ++it;
+        }
+
+        return it;
+    }
+
+    template <typename FormatContext>
+    auto format(E value, FormatContext &ctx) const
+    {
+        using U = std::underlying_type_t<E>;
+        if (presentation == Presentation::Hex) {
+            return fmt::format_to(ctx.out(), "0x{:x}", static_cast<U>(value));
+        }
+
+        if (presentation == Presentation::Decimal) {
+            return fmt::format_to(ctx.out(), "{}", static_cast<U>(value));
+        }
+
+        constexpr auto table = get_enum_table(static_cast<E *>(nullptr));
+        return table.format_to(ctx.out(), value);
+    }
+};

--- a/src/linyaps_box/utils/enum_traits.h
+++ b/src/linyaps_box/utils/enum_traits.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <fmt/format.h>
-
 #include <array>
 #include <cstddef>
 #include <optional>
@@ -159,70 +157,14 @@ struct enum_table
     }
 
     template <typename OutputIt>
-    OutputIt format_to(OutputIt out, E value) const
-    {
-        if constexpr (is_bitmask_enum_v<E>) {
-            return format_flags_to(out, value);
-        } else {
-            return format_single_to(out, value);
-        }
-    }
+    OutputIt format_to(OutputIt out, E value) const;
 
 private:
     template <typename OutputIt>
-    OutputIt format_single_to(OutputIt out, E value) const
-    {
-        if (auto name = to_name(value)) {
-            return std::copy(name->begin(), name->end(), out);
-        }
-
-        using U = std::underlying_type_t<E>;
-        return fmt::format_to(out, "{}", static_cast<U>(value));
-    }
+    OutputIt format_single_to(OutputIt out, E value) const;
 
     template <typename OutputIt>
-    OutputIt format_flags_to(OutputIt out, E flags) const
-    {
-        using U = std::underlying_type_t<E>;
-        auto val = static_cast<U>(flags);
-
-        if (val == 0) {
-            if (auto name = to_name(flags)) {
-                return std::copy(name->begin(), name->end(), out);
-            }
-
-            static constexpr std::string_view none_sv = "none";
-            return std::copy(none_sv.begin(), none_sv.end(), out);
-        }
-
-        bool first = true;
-        for (const auto &entry : entries) {
-            const auto mask = static_cast<U>(entry.value);
-            if (mask != 0 && (val & mask) == mask) {
-                if (!first) {
-                    *out++ = '|';
-                }
-
-                out = std::copy(entry.name.begin(), entry.name.end(), out);
-                first = false;
-                val &= ~mask;
-
-                if (val == 0) {
-                    break;
-                }
-            }
-        }
-
-        if (val != 0) {
-            if (!first) {
-                *out++ = '|';
-            }
-
-            out = fmt::format_to(out, "0x{:x}", val);
-        }
-
-        return out;
-    }
+    OutputIt format_flags_to(OutputIt out, E flags) const;
 };
 
 template <typename E, typename... Rest>
@@ -364,45 +306,3 @@ constexpr E &operator^=(E &lhs, E rhs) noexcept
                       ": duplicate name or value detected!");                             \
         return table;                                                                     \
     }
-
-template <typename E>
-struct fmt::formatter<E, std::enable_if_t<linyaps_box::utils::has_enum_table_v<E>, char>>
-{
-    enum class Presentation : uint8_t { Default, Hex, Decimal };
-    Presentation presentation{ Presentation::Default };
-
-    constexpr auto parse(fmt::format_parse_context &ctx)
-    {
-        const auto *it = ctx.begin();
-        const auto *end = ctx.end();
-        if (it != end && *it != '}') {
-            if (*it == 'x') {
-                presentation = Presentation::Hex;
-            } else if (*it == 'd') {
-                presentation = Presentation::Decimal;
-            } else {
-                throw fmt::format_error("invalid format specifier for enum");
-            }
-
-            ++it;
-        }
-
-        return it;
-    }
-
-    template <typename FormatContext>
-    auto format(E value, FormatContext &ctx) const
-    {
-        using U = std::underlying_type_t<E>;
-        if (presentation == Presentation::Hex) {
-            return fmt::format_to(ctx.out(), "0x{:x}", static_cast<U>(value));
-        }
-
-        if (presentation == Presentation::Decimal) {
-            return fmt::format_to(ctx.out(), "{}", static_cast<U>(value));
-        }
-
-        constexpr auto table = get_enum_table(static_cast<E *>(nullptr));
-        return table.format_to(ctx.out(), value);
-    }
-};

--- a/src/linyaps_box/utils/file_describer.cpp
+++ b/src/linyaps_box/utils/file_describer.cpp
@@ -8,6 +8,8 @@
 #include "linyaps_box/os/fs.h"
 #include "linyaps_box/utils/utils.h"
 
+#include <fmt/std.h>
+
 #include <algorithm>
 #include <array>
 #include <climits> // IWYU pragma: keep


### PR DESCRIPTION
- use json_fwd.hpp and move json formatting to .cpp helper
- drop unused <fmt/format.h>
- move <fmt/std.h> to the .cpp files that actually format std types
- split fmt-dependent formatter into enum_formatter.h so config.h no longer pulls fmt

Frontend parse time: 162.9s → 142.3s (-12.6%)