### PR TITLE
feat(container): apply hostname and domainname from OCI config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ set(linyaps-box_LIBRARY_SOURCE
     src/linyaps_box/os/net.cpp
     src/linyaps_box/os/process.cpp
     src/linyaps_box/os/pty.cpp
+    src/linyaps_box/os/system.cpp
     src/linyaps_box/os/termios.cpp
     src/linyaps_box/protocol/message_channel.cpp
     src/linyaps_box/protocol/message.cpp

--- a/src/linyaps_box/container.cpp
+++ b/src/linyaps_box/container.cpp
@@ -14,6 +14,7 @@
 #include "linyaps_box/log/macro.h"
 #include "linyaps_box/os/fs.h"
 #include "linyaps_box/os/process.h"
+#include "linyaps_box/os/system.h"
 #include "linyaps_box/protocol/message_channel.h"
 #include "linyaps_box/protocol/sync_socket_forwarder.h"
 #include "linyaps_box/security/privilege.h"
@@ -244,6 +245,32 @@ void initialize_container(const oci_config &oci_config, child_message_channel &s
     sync.expect_stage(stage::type::namespace_done);
 
     LINYAPS_BOX_LOG_DEBUG("Container namespaces configured from runtime namespace");
+
+    const auto &linux = oci_config.linux;
+    const auto has_uts_namespace = linux && linux->namespaces
+      && std::any_of(linux->namespaces->cbegin(),
+                     linux->namespaces->cend(),
+                     [](const oci_config::linux_t::namespace_t &ns) {
+                         return ns.type_ == oci_config::linux_t::namespace_t::type::UTS;
+                     });
+
+    if (oci_config.hostname) {
+        if (UNLIKELY(!has_uts_namespace)) {
+            throw std::runtime_error("hostname requires the UTS namespace");
+        }
+
+        LINYAPS_BOX_LOG_DEBUG("Set container hostname to {}", oci_config.hostname.value());
+        os::throw_if_error(os::sethostname(oci_config.hostname.value()));
+    }
+
+    if (oci_config.domainname) {
+        if (UNLIKELY(!has_uts_namespace)) {
+            throw std::runtime_error("domainname requires the UTS namespace");
+        }
+
+        LINYAPS_BOX_LOG_DEBUG("Set container domainname to {}", oci_config.domainname.value());
+        os::throw_if_error(os::setdomainname(oci_config.domainname.value()));
+    }
 
     if (oci_config.process->oom_score_adj) {
         auto score = std::to_string(oci_config.process->oom_score_adj.value());

--- a/src/linyaps_box/os/system.cpp
+++ b/src/linyaps_box/os/system.cpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/os/system.h"
+
+#include "linyaps_box/utils/utils.h"
+
+namespace linyaps_box::os {
+
+auto sethostname(std::string_view name) noexcept -> os::Result<void>
+{
+    if (UNLIKELY(::sethostname(name.data(), name.size()) == -1)) {
+        return unexpected{ make_error_code(errno) };
+    }
+
+    return { };
+}
+
+auto setdomainname(std::string_view name) noexcept -> os::Result<void>
+{
+    if (UNLIKELY(::setdomainname(name.data(), name.size()) == -1)) {
+        return unexpected{ make_error_code(errno) };
+    }
+
+    return { };
+}
+
+} // namespace linyaps_box::os

--- a/src/linyaps_box/os/system.h
+++ b/src/linyaps_box/os/system.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/os/result.h"
+
+namespace linyaps_box::os {
+
+auto sethostname(std::string_view name) noexcept -> os::Result<void>;
+
+auto setdomainname(std::string_view name) noexcept -> os::Result<void>;
+
+} // namespace linyaps_box::os


### PR DESCRIPTION
sethostname/setdomainname only take effect inside a UTS namespace, so reject the config early when one isn't requested instead of silently mutating the host's UTS namespace.