### PR TITLE
fix(status): tolerate legacy 2.2.x status files

### DIFF
--- a/src/linyaps_box/container_ref.cpp
+++ b/src/linyaps_box/container_ref.cpp
@@ -415,7 +415,17 @@ auto verify_container_process(const infra::process_handle &handle,
                                 fmt::format("container process {} is not running", st.pid));
     }
 
-    if (UNLIKELY(stat->start_time != st.process_start_time)) {
+    if (UNLIKELY(!st.process_start_time)) {
+        // Legacy status files have no recorded start time, so the pinned process
+        // identity cannot be verified. Refuse rather than signal an unknown PID.
+        throw std::system_error(std::make_error_code(std::errc::no_such_process),
+                                fmt::format("cannot verify container process {} (no recorded "
+                                            "start time); refusing to {}",
+                                            st.pid,
+                                            action));
+    }
+
+    if (UNLIKELY(stat->start_time != *st.process_start_time)) {
         throw std::system_error(std::make_error_code(std::errc::no_such_process),
                                 fmt::format("container PID {} was reused by another process; "
                                             "refusing to {}",

--- a/src/linyaps_box/container_status.cpp
+++ b/src/linyaps_box/container_status.cpp
@@ -20,7 +20,7 @@ auto to_json(nlohmann::json &j, const container_status &s) -> void
       linyaps_box::utils::to_created_time(linyaps_box::utils::span{ created_buf }, s.created);
     j = nlohmann::json::object({ { "id", s.id },
                                  { "pid", s.pid },
-                                 { "process-start-time", s.process_start_time },
+                                 { "process-start-time", s.process_start_time.value_or(0) },
                                  { "bundle", s.bundle.string() },
                                  { "created", std::string_view{ created_buf.data(), len } },
                                  { "owner", s.owner },
@@ -32,7 +32,12 @@ auto from_json(const nlohmann::json &j, container_status &s) -> void
 {
     j.at("id").get_to(s.id);
     j.at("pid").get_to(s.pid);
-    j.at("process-start-time").get_to(s.process_start_time);
+    if (auto it = j.find("process-start-time"); it != j.end()) {
+        s.process_start_time = it->get<std::uint64_t>();
+    } else {
+        // Legacy status files (2.2.x) predate the start-time field.
+        s.process_start_time.reset();
+    }
     s.bundle = j.at("bundle").get<std::string>();
     s.created = utils::from_created_time(j.at("created").get_ref<const std::string &>());
     j.at("owner").get_to(s.owner);
@@ -87,7 +92,7 @@ auto derive_status(const container_status &s) -> runtime_status
         return runtime_status::STOPPED;
     }
 
-    if (stat->start_time != s.process_start_time) {
+    if (s.process_start_time && stat->start_time != *s.process_start_time) {
         // PID was recycled: the original container process is gone.
         return runtime_status::STOPPED;
     }

--- a/src/linyaps_box/container_status.h
+++ b/src/linyaps_box/container_status.h
@@ -11,6 +11,7 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -24,7 +25,8 @@ struct container_status
     std::string id;
     std::string oci_version;
     std::string owner; // extension field
-    std::uint64_t process_start_time;
+    // std::nullopt when the status file predates the start-time field (legacy 2.2.x state).
+    std::optional<std::uint64_t> process_start_time;
     std::chrono::system_clock::time_point created; // extension field
     pid_t pid;
 };
@@ -97,7 +99,7 @@ struct fmt::formatter<linyaps_box::container_status>
               status.pid,
               status.annotations,
               status.owner,
-              status.process_start_time,
+              status.process_start_time.value_or(0),
               std::string_view{ time_buf.data(), len });
         }
 

--- a/src/linyaps_box/utils/time.cpp
+++ b/src/linyaps_box/utils/time.cpp
@@ -10,6 +10,7 @@
 
 #include <cassert>
 #include <charconv>
+#include <cstdint>
 #include <stdexcept>
 
 namespace linyaps_box::utils {
@@ -51,6 +52,15 @@ auto to_created_time(span<char> buf,
 
 auto from_created_time(const std::string &str) -> std::chrono::system_clock::time_point
 {
+    // Legacy 2.2.x status files stored "created" as nanoseconds since epoch.
+    if (!str.empty() && str.find_first_not_of("0123456789") == std::string::npos) {
+        std::uint64_t ns{ 0 };
+        const auto [ptr, ec] = std::from_chars(str.data(), str.data() + str.size(), ns);
+        if (ec == std::errc{ } && ptr == str.data() + str.size()) {
+            return std::chrono::system_clock::time_point{ std::chrono::nanoseconds{ ns } };
+        }
+    }
+
     std::tm tm{ };
 
     auto *end = ::strptime(str.c_str(), "%Y-%m-%dT%H:%M:%S", &tm);

--- a/tests/ll-box-ut/CMakeLists.txt
+++ b/tests/ll-box-ut/CMakeLists.txt
@@ -7,7 +7,8 @@ set(linyaps-box_UNIT_TESTS_SOURCE
     ./src/message_channel_test.cpp
     ./src/log_test.cpp
     ./src/vfs_test.cpp
-    ./src/parse_proc_stat_test.cpp)
+    ./src/parse_proc_stat_test.cpp
+    ./src/container_status_test.cpp)
 set(linyaps-box_UNIT_TESTS_LINK_LIBRARIES PRIVATE "${linyaps-box_LIBRARY}")
 set(linyaps-box_UNIT_TESTS_SOURCE_INCLUDE_DIRS
     PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")

--- a/tests/ll-box-ut/src/container_status_test.cpp
+++ b/tests/ll-box-ut/src/container_status_test.cpp
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "linyaps_box/container_status.h"
+#include "linyaps_box/status_directory.h"
+#include "linyaps_box/utils/time.h"
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <string>
+
+#include <unistd.h>
+
+namespace {
+
+using linyaps_box::container_status;
+using linyaps_box::runtime_status;
+
+class TempDir
+{
+public:
+    TempDir(const TempDir &) = delete;
+    TempDir(TempDir &&) noexcept = default;
+    TempDir &operator=(const TempDir &) = delete;
+    TempDir &operator=(TempDir &&) noexcept = default;
+
+    TempDir()
+    {
+        auto tmpl = std::filesystem::temp_directory_path().string();
+        tmpl.append("/linyaps-box-status-test-XXXXXX");
+
+        auto *p = ::mkdtemp(tmpl.data());
+        if (p == nullptr) {
+            throw std::runtime_error(fmt::format("failed to create test dir: {}", errno));
+        }
+        path_ = p;
+    }
+
+    ~TempDir()
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(path_, ec);
+    }
+
+    [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & { return path_; }
+
+private:
+    std::filesystem::path path_;
+};
+
+// Mirrors the status.json written by the 2.2.x ll-box: it has a "status" field
+// but no "process-start-time" key.
+auto make_legacy_status_json(std::uint64_t pid, std::string_view id) -> nlohmann::json
+{
+    return nlohmann::json::object({ { "id", id },
+                                    { "pid", pid },
+                                    { "status", "running" },
+                                    { "bundle", "/tmp/bundle" },
+                                    { "created", "1787901642171875663" },
+                                    { "owner", "dengbo" },
+                                    { "annotations", nlohmann::json::object() },
+                                    { "ociVersion", "1.2.1" } });
+}
+
+} // namespace
+
+TEST(ContainerStatusJson, ParsesLegacyFormatWithoutStartTime)
+{
+    const auto j = make_legacy_status_json(1234, "legacy-id");
+
+    container_status s;
+    EXPECT_NO_THROW(s = j.get<container_status>());
+    EXPECT_EQ(s.id, "legacy-id");
+    EXPECT_EQ(s.pid, 1234);
+    EXPECT_FALSE(s.process_start_time.has_value());
+    EXPECT_EQ(s.oci_version, "1.2.1");
+}
+
+TEST(ContainerStatusJson, RoundTripPreservesStartTime)
+{
+    container_status s;
+    s.id = "roundtrip";
+    s.pid = 42;
+    s.process_start_time = 987654;
+    s.bundle = "/tmp/bundle";
+    s.created = std::chrono::system_clock::now();
+    s.owner = "dengbo";
+    s.oci_version = "1.2.1";
+
+    const auto j = nlohmann::json(s);
+    const auto back = j.get<container_status>();
+
+    ASSERT_TRUE(back.process_start_time.has_value());
+    EXPECT_EQ(*back.process_start_time, 987654);
+    EXPECT_EQ(back.pid, 42);
+    EXPECT_EQ(back.owner, "dengbo");
+}
+
+TEST(CreatedTime, ParsesLegacyNanosecondsAndCurrentFormat)
+{
+    // Same instant: 2026-08-28T07:20:42.171875663Z.
+    const auto legacy = linyaps_box::utils::from_created_time("1787901642171875663");
+    const auto iso = linyaps_box::utils::from_created_time("2026-08-28T07:20:42.171875663Z");
+
+    EXPECT_EQ(legacy, iso);
+}
+
+TEST(ContainerStatusDirectory, ReadsLegacyStatusFile)
+{
+    TempDir dir;
+    std::ofstream out(dir.path() / "status.json");
+    out << make_legacy_status_json(1234, "legacy-id").dump();
+    out.close();
+
+    const auto s = linyaps_box::status_directory(dir.path()).read();
+
+    EXPECT_EQ(s.id, "legacy-id");
+    EXPECT_FALSE(s.process_start_time.has_value());
+}
+
+TEST(DeriveStatus, UnknownStartTimeLiveProcessIsRunning)
+{
+    container_status s;
+    s.pid = getpid();
+    // process_start_time intentionally left nullopt, as with a legacy status file.
+
+    EXPECT_EQ(linyaps_box::derive_status(s), runtime_status::RUNNING);
+}
+
+TEST(DeriveStatus, KnownStartTimeMismatchIsStopped)
+{
+    container_status s;
+    s.pid = getpid();
+    s.process_start_time = 0; // known but certainly wrong for any live process
+
+    EXPECT_EQ(linyaps_box::derive_status(s), runtime_status::STOPPED);
+}
+
+TEST(DeriveStatus, DeadPidIsStopped)
+{
+    container_status s;
+    s.pid = std::numeric_limits<pid_t>::max();
+    s.process_start_time.reset();
+
+    EXPECT_EQ(linyaps_box::derive_status(s), runtime_status::STOPPED);
+}


### PR DESCRIPTION
ll-box list and ll-cli ps crashed with "key 'process-start-time' not found" when parsing status.json written by ll-box 2.2.x, which has no process-start-time field and stores created as nanoseconds since epoch.

Make process_start_time optional (unknown for legacy files), keep the PID-recycling check when the start time is known, and refuse kill/exec when identity cannot be verified. Accept both created time formats.

Add regression tests for legacy parsing, round-trip, created formats, and derive_status behavior.