### PR TITLE
fix(os): keep socket_flag bitmask sentinel as the largest flag

### DIFF
--- a/src/linyaps_box/os/net.h
+++ b/src/linyaps_box/os/net.h
@@ -99,7 +99,10 @@ enum class socket_flag : uint32_t {
     none = 0,
     nonblock = SOCK_NONBLOCK,
     cloexec = SOCK_CLOEXEC,
-    LINYAPS_MARK_AS_BITMASK_ENUM(cloexec),
+    // SOCK_NONBLOCK may be higher than SOCK_CLOEXEC (e.g. sw_64), so the
+    // sentinel must track the larger flag to keep the bitmask mask correct.
+    LINYAPS_MARK_AS_BITMASK_ENUM((SOCK_NONBLOCK) > (SOCK_CLOEXEC) ? (SOCK_NONBLOCK)
+                                                                  : (SOCK_CLOEXEC)),
 };
 LINYAPS_REGISTER_ENUM(socket_flag,
                       { socket_flag::none, "NONE" },

--- a/tests/ll-box-ut/CMakeLists.txt
+++ b/tests/ll-box-ut/CMakeLists.txt
@@ -2,6 +2,7 @@ set(linyaps-box_UNIT_TESTS ll-box-ut)
 set(linyaps-box_UNIT_TESTS_SOURCE
     ./src/main.cpp
     ./src/test.cpp
+    ./src/enum_traits_test.cpp
     ./src/semver_test.cpp
     ./src/span_test.cpp
     ./src/message_channel_test.cpp

--- a/tests/ll-box-ut/src/enum_traits_test.cpp
+++ b/tests/ll-box-ut/src/enum_traits_test.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "linyaps_box/os/net.h"
+#include "linyaps_box/utils/enum_traits.h"
+
+#include <cstdint>
+
+namespace os = linyaps_box::os;
+
+namespace {
+
+// The bitmask sentinel must stay the largest flag bit on every Linux
+// architecture. On sw_64 SOCK_NONBLOCK is higher than SOCK_CLOEXEC, so pinning
+// the sentinel to SOCK_CLOEXEC would reject the enum table at compile time.
+TEST(EnumTraits, SocketFlagBitmaskCoversAllFlags)
+{
+    using flag = os::sys::socket_flag;
+    constexpr auto mask = linyaps_box::utils::bitmask_mask<flag>();
+
+    EXPECT_EQ(mask & static_cast<std::uint32_t>(flag::none), 0U);
+    EXPECT_NE(mask & static_cast<std::uint32_t>(flag::nonblock), 0U);
+    EXPECT_NE(mask & static_cast<std::uint32_t>(flag::cloexec), 0U);
+
+    const auto all = ~flag::none;
+    EXPECT_NE(all & flag::nonblock, flag::none);
+    EXPECT_NE(all & flag::cloexec, flag::none);
+}
+
+TEST(EnumTraits, SocketFlagTableRoundTrip)
+{
+    using flag = os::sys::socket_flag;
+    const auto table = os::sys::get_enum_table(static_cast<flag *>(nullptr));
+
+    const auto nonblock = table.to_name(flag::nonblock);
+    ASSERT_TRUE(nonblock.has_value());
+    EXPECT_EQ(*nonblock, "SOCK_NONBLOCK");
+
+    const auto cloexec = table.to_name(flag::cloexec);
+    ASSERT_TRUE(cloexec.has_value());
+    EXPECT_EQ(*cloexec, "SOCK_CLOEXEC");
+
+    const auto parsed = table.from_name("SOCK_NONBLOCK");
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(*parsed, flag::nonblock);
+}
+
+} // namespace


### PR DESCRIPTION
On sw_64 SOCK_NONBLOCK (0x40000000) is higher than SOCK_CLOEXEC (0x200000), so pinning the bitmask sentinel to SOCK_CLOEXEC made verify_enum_table reject the socket_flag table at compile time.

Track the larger of the two flags so the mask covers every registered flag on all Linux architectures, and add a regression test that pins the socket_flag bitmask invariant and enum table round-trip.