### PR TITLE
fix(os): use int underlying type for optional_action enum

### DIFF
--- a/src/linyaps_box/os/termios.h
+++ b/src/linyaps_box/os/termios.h
@@ -14,7 +14,7 @@ auto isatty(utils::file_descriptor_ref fd) noexcept -> bool;
 
 auto tcgetattr(utils::file_descriptor_ref fd) noexcept -> Result<struct termios>;
 
-enum class optional_action : uint8_t {
+enum class optional_action : int {
     now = TCSANOW,
     drain = TCSADRAIN,
     flush = TCSAFLUSH,


### PR DESCRIPTION
- Change optional_action underlying type from uint8_t to int so MIPS TCSANOW/TCSADRAIN/TCSAFLUSH values (21518/21519/21520) fit the range

Log: Fix the MIPS build failure caused by termios enum values exceeding the uint8_t range