### PR TITLE
refactor(enum): replace sentinel bitmask with table-driven bitflags

### DIFF
--- a/src/linyaps_box/config.cpp
+++ b/src/linyaps_box/config.cpp
@@ -331,7 +331,7 @@ auto parse_mount_options(const std::vector<std::string> &options)
         }
 
         if (auto ev = extra_flags_table.from_name(opt)) {
-            extension_flags = extension_flags | *ev;
+            extension_flags |= *ev;
             continue;
         }
 
@@ -480,7 +480,7 @@ void from_json(const nlohmann::json &j, oci_config::process_t::scheduler_t &v)
             if (UNLIKELY(!flag_opt)) {
                 throw std::runtime_error("unknown value: " + std::string(flag_str));
             }
-            flags = flags | *flag_opt;
+            flags |= *flag_opt;
         }
 
         v.flags = flags;
@@ -921,7 +921,7 @@ void from_json(const nlohmann::json &j, oci_config::linux_t::memory_policy_t &v)
             if (UNLIKELY(!flag_opt)) {
                 throw std::runtime_error("unknown value: " + std::string(flag_str));
             }
-            flags = flags | *flag_opt;
+            flags |= *flag_opt;
         }
 
         v.flags = flags;
@@ -1019,7 +1019,7 @@ void from_json(const nlohmann::json &j, oci_config::linux_t::seccomp_t &v)
                 throw std::runtime_error("unknown value: " + std::string(flag_str));
             }
 
-            flags = flags | *flag_opt;
+            flags |= *flag_opt;
         }
 
         v.flags = flags;

--- a/src/linyaps_box/config.h
+++ b/src/linyaps_box/config.h
@@ -98,7 +98,6 @@ struct oci_config
                 KEEP_PARAMS,
                 UTIL_CLAMP_MIN,
                 UTIL_CLAMP_MAX,
-                LINYAPS_MARK_AS_BITMASK_ENUM(UTIL_CLAMP_MAX),
             };
 
             std::optional<flag_t> flags;
@@ -163,7 +162,6 @@ struct oci_config
             NONE = 0,
             COPY_SYMLINK = (1U << 0),
             TMPCOPYUP = (1U << 1),
-            LINYAPS_MARK_AS_BITMASK_ENUM(TMPCOPYUP),
         };
 
         enum class idmap_type : std::uint8_t { IDMAP, RIDMAP };
@@ -217,7 +215,6 @@ struct oci_config
                 USER = (1U << 5),
                 CGROUP = (1U << 6),
                 TIME = (1U << 7),
-                LINYAPS_MARK_AS_BITMASK_ENUM(TIME),
             };
 
             type type_;
@@ -405,7 +402,6 @@ struct oci_config
                 NUMA_BALANCING = 1,
                 RELATIVE_NODES = 2,
                 STATIC_NODES = 4,
-                LINYAPS_MARK_AS_BITMASK_ENUM(STATIC_NODES),
             };
             std::optional<flag_t> flags;
         };
@@ -466,7 +462,6 @@ struct oci_config
                 LOG = 2,
                 SPEC_ALLOW = 4,
                 WAIT_KILLABLE_RECV = 8,
-                LINYAPS_MARK_AS_BITMASK_ENUM(WAIT_KILLABLE_RECV),
             };
             std::optional<flag_t> flags;
 
@@ -555,6 +550,12 @@ struct oci_config
 
     std::optional<std::unordered_map<std::string, std::string>> annotations;
 };
+
+LINYAPS_ENABLE_BITMASK_ENUM(oci_config::process_t::scheduler_t::flag_t);
+LINYAPS_ENABLE_BITMASK_ENUM(oci_config::mount_t::extension);
+LINYAPS_ENABLE_BITMASK_ENUM(oci_config::linux_t::namespace_t::type);
+LINYAPS_ENABLE_BITMASK_ENUM(oci_config::linux_t::memory_policy_t::flag_t);
+LINYAPS_ENABLE_BITMASK_ENUM(oci_config::linux_t::seccomp_t::flag_t);
 
 auto to_string_view(oci_config::linux_t::namespace_t::type type) noexcept -> std::string_view;
 

--- a/src/linyaps_box/config/enum_tables.h
+++ b/src/linyaps_box/config/enum_tables.h
@@ -8,8 +8,9 @@
 #include "linyaps_box/utils/enum_traits.h"
 
 // rlimit types
-LINYAPS_REGISTER_ENUM(
+LINYAPS_REGISTER_ENUM_TABLE(
   linyaps_box::oci_config::process_t::rlimit_t::type_t,
+  16,
   { linyaps_box::oci_config::process_t::rlimit_t::type_t::AS, "RLIMIT_AS" },
   { linyaps_box::oci_config::process_t::rlimit_t::type_t::CORE, "RLIMIT_CORE" },
   { linyaps_box::oci_config::process_t::rlimit_t::type_t::CPU, "RLIMIT_CPU" },
@@ -28,8 +29,9 @@ LINYAPS_REGISTER_ENUM(
   { linyaps_box::oci_config::process_t::rlimit_t::type_t::STACK, "RLIMIT_STACK" })
 
 // scheduler policies
-LINYAPS_REGISTER_ENUM(
+LINYAPS_REGISTER_ENUM_TABLE(
   linyaps_box::oci_config::process_t::scheduler_t::policy_t,
+  7,
   { linyaps_box::oci_config::process_t::scheduler_t::policy_t::OTHER, "SCHED_OTHER" },
   { linyaps_box::oci_config::process_t::scheduler_t::policy_t::FIFO, "SCHED_FIFO" },
   { linyaps_box::oci_config::process_t::scheduler_t::policy_t::RR, "SCHED_RR" },
@@ -39,38 +41,42 @@ LINYAPS_REGISTER_ENUM(
   { linyaps_box::oci_config::process_t::scheduler_t::policy_t::DEADLINE, "SCHED_DEADLINE" })
 
 // scheduler flags
-LINYAPS_REGISTER_ENUM(linyaps_box::oci_config::process_t::scheduler_t::flag_t,
-                      { linyaps_box::oci_config::process_t::scheduler_t::flag_t::RESET_ON_FORK,
-                        "SCHED_FLAG_RESET_ON_FORK" },
-                      { linyaps_box::oci_config::process_t::scheduler_t::flag_t::RECLAIM,
-                        "SCHED_FLAG_RECLAIM" },
-                      { linyaps_box::oci_config::process_t::scheduler_t::flag_t::DL_OVERRUN,
-                        "SCHED_FLAG_DL_OVERRUN" },
-                      { linyaps_box::oci_config::process_t::scheduler_t::flag_t::KEEP_POLICY,
-                        "SCHED_FLAG_KEEP_POLICY" },
-                      { linyaps_box::oci_config::process_t::scheduler_t::flag_t::KEEP_PARAMS,
-                        "SCHED_FLAG_KEEP_PARAMS" },
-                      { linyaps_box::oci_config::process_t::scheduler_t::flag_t::UTIL_CLAMP_MIN,
-                        "SCHED_FLAG_UTIL_CLAMP_MIN" },
-                      { linyaps_box::oci_config::process_t::scheduler_t::flag_t::UTIL_CLAMP_MAX,
-                        "SCHED_FLAG_UTIL_CLAMP_MAX" })
+LINYAPS_REGISTER_ENUM_TABLE(
+  linyaps_box::oci_config::process_t::scheduler_t::flag_t,
+  7,
+  { linyaps_box::oci_config::process_t::scheduler_t::flag_t::RESET_ON_FORK,
+    "SCHED_FLAG_RESET_ON_FORK" },
+  { linyaps_box::oci_config::process_t::scheduler_t::flag_t::RECLAIM, "SCHED_FLAG_RECLAIM" },
+  { linyaps_box::oci_config::process_t::scheduler_t::flag_t::DL_OVERRUN, "SCHED_FLAG_DL_OVERRUN" },
+  { linyaps_box::oci_config::process_t::scheduler_t::flag_t::KEEP_POLICY,
+    "SCHED_FLAG_KEEP_POLICY" },
+  { linyaps_box::oci_config::process_t::scheduler_t::flag_t::KEEP_PARAMS,
+    "SCHED_FLAG_KEEP_PARAMS" },
+  { linyaps_box::oci_config::process_t::scheduler_t::flag_t::UTIL_CLAMP_MIN,
+    "SCHED_FLAG_UTIL_CLAMP_MIN" },
+  { linyaps_box::oci_config::process_t::scheduler_t::flag_t::UTIL_CLAMP_MAX,
+    "SCHED_FLAG_UTIL_CLAMP_MAX" })
 
 // IO priority classes
-LINYAPS_REGISTER_ENUM(
+LINYAPS_REGISTER_ENUM_TABLE(
   linyaps_box::oci_config::process_t::io_priority_t::class_t,
+  3,
   { linyaps_box::oci_config::process_t::io_priority_t::class_t::RT, "IOPRIO_CLASS_RT" },
   { linyaps_box::oci_config::process_t::io_priority_t::class_t::BEST_EFFORT, "IOPRIO_CLASS_BE" },
   { linyaps_box::oci_config::process_t::io_priority_t::class_t::IDLE, "IOPRIO_CLASS_IDLE" })
 
 // personality domains
-LINYAPS_REGISTER_ENUM(linyaps_box::oci_config::linux_t::personality_t::domain_t,
-                      { linyaps_box::oci_config::linux_t::personality_t::domain_t::LINUX, "LINUX" },
-                      { linyaps_box::oci_config::linux_t::personality_t::domain_t::LINUX32,
-                        "LINUX32" })
+LINYAPS_REGISTER_ENUM_TABLE(linyaps_box::oci_config::linux_t::personality_t::domain_t,
+                            2,
+                            { linyaps_box::oci_config::linux_t::personality_t::domain_t::LINUX,
+                              "LINUX" },
+                            { linyaps_box::oci_config::linux_t::personality_t::domain_t::LINUX32,
+                              "LINUX32" })
 
 // memory policy modes
-LINYAPS_REGISTER_ENUM(
+LINYAPS_REGISTER_ENUM_TABLE(
   linyaps_box::oci_config::linux_t::memory_policy_t::mode_t,
+  7,
   { linyaps_box::oci_config::linux_t::memory_policy_t::mode_t::DEFAULT, "MPOL_DEFAULT" },
   { linyaps_box::oci_config::linux_t::memory_policy_t::mode_t::BIND, "MPOL_BIND" },
   { linyaps_box::oci_config::linux_t::memory_policy_t::mode_t::INTERLEAVE, "MPOL_INTERLEAVE" },
@@ -82,17 +88,20 @@ LINYAPS_REGISTER_ENUM(
   { linyaps_box::oci_config::linux_t::memory_policy_t::mode_t::LOCAL, "MPOL_LOCAL" })
 
 // memory policy flags
-LINYAPS_REGISTER_ENUM(linyaps_box::oci_config::linux_t::memory_policy_t::flag_t,
-                      { linyaps_box::oci_config::linux_t::memory_policy_t::flag_t::NUMA_BALANCING,
-                        "MPOL_F_NUMA_BALANCING" },
-                      { linyaps_box::oci_config::linux_t::memory_policy_t::flag_t::RELATIVE_NODES,
-                        "MPOL_F_RELATIVE_NODES" },
-                      { linyaps_box::oci_config::linux_t::memory_policy_t::flag_t::STATIC_NODES,
-                        "MPOL_F_STATIC_NODES" })
+LINYAPS_REGISTER_ENUM_TABLE(
+  linyaps_box::oci_config::linux_t::memory_policy_t::flag_t,
+  3,
+  { linyaps_box::oci_config::linux_t::memory_policy_t::flag_t::NUMA_BALANCING,
+    "MPOL_F_NUMA_BALANCING" },
+  { linyaps_box::oci_config::linux_t::memory_policy_t::flag_t::RELATIVE_NODES,
+    "MPOL_F_RELATIVE_NODES" },
+  { linyaps_box::oci_config::linux_t::memory_policy_t::flag_t::STATIC_NODES,
+    "MPOL_F_STATIC_NODES" })
 
 // seccomp operators
-LINYAPS_REGISTER_ENUM(
+LINYAPS_REGISTER_ENUM_TABLE(
   linyaps_box::oci_config::linux_t::seccomp_t::syscall_t::arg_t::op_t,
+  7,
   { linyaps_box::oci_config::linux_t::seccomp_t::syscall_t::arg_t::op_t::EQ, "SCMP_CMP_EQ" },
   { linyaps_box::oci_config::linux_t::seccomp_t::syscall_t::arg_t::op_t::NE, "SCMP_CMP_NE" },
   { linyaps_box::oci_config::linux_t::seccomp_t::syscall_t::arg_t::op_t::LT, "SCMP_CMP_LT" },
@@ -103,8 +112,9 @@ LINYAPS_REGISTER_ENUM(
     "SCMP_CMP_MASKED_EQ" })
 
 // seccomp actions
-LINYAPS_REGISTER_ENUM(
+LINYAPS_REGISTER_ENUM_TABLE(
   linyaps_box::oci_config::linux_t::seccomp_t::action_t,
+  9,
   { linyaps_box::oci_config::linux_t::seccomp_t::action_t::ALLOW, "SCMP_ACT_ALLOW" },
   { linyaps_box::oci_config::linux_t::seccomp_t::action_t::ERRNO, "SCMP_ACT_ERRNO" },
   { linyaps_box::oci_config::linux_t::seccomp_t::action_t::KILL, "SCMP_ACT_KILL" },
@@ -116,40 +126,46 @@ LINYAPS_REGISTER_ENUM(
   { linyaps_box::oci_config::linux_t::seccomp_t::action_t::TRAP, "SCMP_ACT_TRAP" })
 
 // seccomp flags
-LINYAPS_REGISTER_ENUM(linyaps_box::oci_config::linux_t::seccomp_t::flag_t,
-                      { linyaps_box::oci_config::linux_t::seccomp_t::flag_t::TSYNC,
-                        "SECCOMP_FILTER_FLAG_TSYNC" },
-                      { linyaps_box::oci_config::linux_t::seccomp_t::flag_t::LOG,
-                        "SECCOMP_FILTER_FLAG_LOG" },
-                      { linyaps_box::oci_config::linux_t::seccomp_t::flag_t::SPEC_ALLOW,
-                        "SECCOMP_FILTER_FLAG_SPEC_ALLOW" },
-                      { linyaps_box::oci_config::linux_t::seccomp_t::flag_t::WAIT_KILLABLE_RECV,
-                        "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV" })
+LINYAPS_REGISTER_ENUM_TABLE(
+  linyaps_box::oci_config::linux_t::seccomp_t::flag_t,
+  4,
+  { linyaps_box::oci_config::linux_t::seccomp_t::flag_t::TSYNC, "SECCOMP_FILTER_FLAG_TSYNC" },
+  { linyaps_box::oci_config::linux_t::seccomp_t::flag_t::LOG, "SECCOMP_FILTER_FLAG_LOG" },
+  { linyaps_box::oci_config::linux_t::seccomp_t::flag_t::SPEC_ALLOW,
+    "SECCOMP_FILTER_FLAG_SPEC_ALLOW" },
+  { linyaps_box::oci_config::linux_t::seccomp_t::flag_t::WAIT_KILLABLE_RECV,
+    "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV" })
 
 // mount extensions
-LINYAPS_REGISTER_ENUM(linyaps_box::oci_config::mount_t::extension,
-                      { linyaps_box::oci_config::mount_t::extension::COPY_SYMLINK, "copy-symlink" },
-                      { linyaps_box::oci_config::mount_t::extension::TMPCOPYUP, "tmpcopyup" })
+LINYAPS_REGISTER_ENUM_TABLE(linyaps_box::oci_config::mount_t::extension,
+                            2,
+                            { linyaps_box::oci_config::mount_t::extension::COPY_SYMLINK,
+                              "copy-symlink" },
+                            { linyaps_box::oci_config::mount_t::extension::TMPCOPYUP, "tmpcopyup" })
 
 // mount idmap types
-LINYAPS_REGISTER_ENUM(linyaps_box::oci_config::mount_t::idmap_type,
-                      { linyaps_box::oci_config::mount_t::idmap_type::IDMAP, "idmap" },
-                      { linyaps_box::oci_config::mount_t::idmap_type::RIDMAP, "ridmap" })
+LINYAPS_REGISTER_ENUM_TABLE(linyaps_box::oci_config::mount_t::idmap_type,
+                            2,
+                            { linyaps_box::oci_config::mount_t::idmap_type::IDMAP, "idmap" },
+                            { linyaps_box::oci_config::mount_t::idmap_type::RIDMAP, "ridmap" })
 
 // namespace types
-LINYAPS_REGISTER_ENUM(linyaps_box::oci_config::linux_t::namespace_t::type,
-                      { linyaps_box::oci_config::linux_t::namespace_t::type::IPC, "ipc" },
-                      { linyaps_box::oci_config::linux_t::namespace_t::type::UTS, "uts" },
-                      { linyaps_box::oci_config::linux_t::namespace_t::type::MOUNT, "mount" },
-                      { linyaps_box::oci_config::linux_t::namespace_t::type::PID, "pid" },
-                      { linyaps_box::oci_config::linux_t::namespace_t::type::NET, "network" },
-                      { linyaps_box::oci_config::linux_t::namespace_t::type::USER, "user" },
-                      { linyaps_box::oci_config::linux_t::namespace_t::type::CGROUP, "cgroup" },
-                      { linyaps_box::oci_config::linux_t::namespace_t::type::TIME, "time" })
+LINYAPS_REGISTER_ENUM_TABLE(linyaps_box::oci_config::linux_t::namespace_t::type,
+                            8,
+                            { linyaps_box::oci_config::linux_t::namespace_t::type::IPC, "ipc" },
+                            { linyaps_box::oci_config::linux_t::namespace_t::type::UTS, "uts" },
+                            { linyaps_box::oci_config::linux_t::namespace_t::type::MOUNT, "mount" },
+                            { linyaps_box::oci_config::linux_t::namespace_t::type::PID, "pid" },
+                            { linyaps_box::oci_config::linux_t::namespace_t::type::NET, "network" },
+                            { linyaps_box::oci_config::linux_t::namespace_t::type::USER, "user" },
+                            { linyaps_box::oci_config::linux_t::namespace_t::type::CGROUP,
+                              "cgroup" },
+                            { linyaps_box::oci_config::linux_t::namespace_t::type::TIME, "time" })
 
 // seccomp architectures
-LINYAPS_REGISTER_ENUM(
+LINYAPS_REGISTER_ENUM_TABLE(
   linyaps_box::oci_config::linux_t::seccomp_t::arch_t,
+  23,
   { linyaps_box::oci_config::linux_t::seccomp_t::arch_t::X86, "SCMP_ARCH_X86" },
   { linyaps_box::oci_config::linux_t::seccomp_t::arch_t::X86_64, "SCMP_ARCH_X86_64" },
   { linyaps_box::oci_config::linux_t::seccomp_t::arch_t::X32, "SCMP_ARCH_X32" },

--- a/src/linyaps_box/infra/rootfs.cpp
+++ b/src/linyaps_box/infra/rootfs.cpp
@@ -878,7 +878,7 @@ auto Root::create_directories(const std::filesystem::path &path,
 }
 
 auto Root::create_file(const std::filesystem::path &path,
-                       open_flag flags,
+                       utils::bitflags<open_flag> flags,
                        std::filesystem::perms perm) const noexcept -> os::Result<file_descriptor>
 {
     if (has_trailing_slash(path) || has_trailing_dot_or_dotdot(path)) {

--- a/src/linyaps_box/infra/rootfs.h
+++ b/src/linyaps_box/infra/rootfs.h
@@ -84,7 +84,7 @@ public:
 
     [[nodiscard]] auto
     create_file(const std::filesystem::path &path,
-                os::sys::open_flag flags = os::sys::open_flag::none,
+                utils::bitflags<os::sys::open_flag> flags = os::sys::open_flag::none,
                 std::filesystem::perms perm = os::default_new_file_perm) const noexcept
       -> os::Result<utils::file_descriptor>;
 

--- a/src/linyaps_box/infra/unix_socket.cpp
+++ b/src/linyaps_box/infra/unix_socket.cpp
@@ -37,7 +37,7 @@ auto unix_socket::send(utils::span<const std::byte> data) const -> os::Result<st
     return os::send(fd_.ref(), data);
 }
 
-auto unix_socket::recv(utils::span<std::byte> buf, os::sys::recv_flag flags) const
+auto unix_socket::recv(utils::span<std::byte> buf, utils::bitflags<os::sys::recv_flag> flags) const
   -> os::Result<std::size_t>
 {
     return os::recv(fd_.ref(), buf, flags);

--- a/src/linyaps_box/infra/unix_socket.h
+++ b/src/linyaps_box/infra/unix_socket.h
@@ -43,8 +43,9 @@ public:
 
     [[nodiscard]] auto send(utils::span<const std::byte> data) const -> os::Result<std::size_t>;
 
-    [[nodiscard]] auto recv(utils::span<std::byte> buf,
-                            os::sys::recv_flag flags = os::sys::recv_flag::none) const
+    [[nodiscard]] auto
+    recv(utils::span<std::byte> buf,
+         utils::bitflags<os::sys::recv_flag> flags = os::sys::recv_flag::none) const
       -> os::Result<std::size_t>;
 
     [[nodiscard]] auto send_fd(utils::file_descriptor_ref fd) const -> os::Result<void>;

--- a/src/linyaps_box/os/fs.cpp
+++ b/src/linyaps_box/os/fs.cpp
@@ -101,7 +101,7 @@ auto openat2(utils::file_descriptor_ref dirfd,
         uint64_t resolve;
     } linux_open_how{ static_cast<uint64_t>(how.opt),
                       static_cast<uint64_t>(how.perms),
-                      static_cast<uint64_t>(how.resolve) };
+                      how.resolve.to_raw() };
 
     while (true) {
         const auto fd = static_cast<int>(
@@ -120,9 +120,9 @@ auto openat2(utils::file_descriptor_ref dirfd,
 
 auto unlinkat(utils::file_descriptor_ref dirfd,
               const std::filesystem::path &path,
-              sys::at_flag flags) noexcept -> Result<void>
+              utils::bitflags<sys::at_flag> flags) noexcept -> Result<void>
 {
-    if (UNLIKELY(::unlinkat(dirfd, path.c_str(), static_cast<int>(flags)) < 0)) {
+    if (UNLIKELY(::unlinkat(dirfd, path.c_str(), flags.to_raw()) < 0)) {
 
         return unexpected{ make_error_code(errno) };
     }
@@ -156,11 +156,10 @@ auto renameat2(utils::file_descriptor_ref olddirfd,
                const std::filesystem::path &oldpath,
                utils::file_descriptor_ref newdirfd,
                const std::filesystem::path &newpath,
-               sys::rename_flag flags) noexcept -> Result<void>
+               utils::bitflags<sys::rename_flag> flags) noexcept -> Result<void>
 {
-    if (UNLIKELY(
-          ::renameat2(olddirfd, oldpath.c_str(), newdirfd, newpath.c_str(), static_cast<int>(flags))
-          < 0)) {
+    if (UNLIKELY(::renameat2(olddirfd, oldpath.c_str(), newdirfd, newpath.c_str(), flags.to_raw())
+                 < 0)) {
 
         return unexpected{ make_error_code(errno) };
     }
@@ -181,10 +180,10 @@ auto fstat(utils::file_descriptor_ref fd) noexcept -> Result<struct stat>
 
 auto fstatat(utils::file_descriptor_ref dirfd,
              const std::filesystem::path &path,
-             sys::at_flag flags) noexcept -> Result<struct stat>
+             utils::bitflags<sys::at_flag> flags) noexcept -> Result<struct stat>
 {
     struct stat st{ };
-    if (UNLIKELY(::fstatat(dirfd, path.c_str(), &st, static_cast<int>(flags)) < 0)) {
+    if (UNLIKELY(::fstatat(dirfd, path.c_str(), &st, flags.to_raw()) < 0)) {
 
         return unexpected{ make_error_code(errno) };
     }
@@ -277,11 +276,10 @@ auto linkat(utils::file_descriptor_ref olddirfd,
             const std::filesystem::path &oldpath,
             utils::file_descriptor_ref newdirfd,
             const std::filesystem::path &newpath,
-            sys::at_flag flags) noexcept -> Result<void>
+            utils::bitflags<sys::at_flag> flags) noexcept -> Result<void>
 {
-    if (UNLIKELY(
-          ::linkat(olddirfd, oldpath.c_str(), newdirfd, newpath.c_str(), static_cast<int>(flags))
-          < 0)) {
+    if (UNLIKELY(::linkat(olddirfd, oldpath.c_str(), newdirfd, newpath.c_str(), flags.to_raw())
+                 < 0)) {
 
         return unexpected{ make_error_code(errno) };
     }
@@ -311,9 +309,10 @@ auto fcntl_dupfd_cloexec(utils::file_descriptor_ref fd, int newfd) noexcept
     return utils::file_descriptor{ ret };
 }
 
-auto fcntl_setfl(utils::file_descriptor_ref fd, sys::open_flag flag) noexcept -> Result<void>
+auto fcntl_setfl(utils::file_descriptor_ref fd, utils::bitflags<sys::open_flag> flag) noexcept
+  -> Result<void>
 {
-    if (UNLIKELY(::fcntl(fd, F_SETFL, fmt::underlying(flag)) < 0)) {
+    if (UNLIKELY(::fcntl(fd, F_SETFL, flag.to_raw()) < 0)) {
 
         return unexpected(make_error_code(errno));
     }
@@ -331,9 +330,10 @@ auto fcntl_getfl(utils::file_descriptor_ref fd) noexcept -> Result<sys::open_opt
     return sys::open_option::from_raw(ret);
 }
 
-auto fcntl_setfd(utils::file_descriptor_ref fd, sys::fd_flag flag) noexcept -> Result<void>
+auto fcntl_setfd(utils::file_descriptor_ref fd, utils::bitflags<sys::fd_flag> flag) noexcept
+  -> Result<void>
 {
-    if (UNLIKELY(::fcntl(fd, F_SETFD, fmt::underlying(flag)) < 0)) {
+    if (UNLIKELY(::fcntl(fd, F_SETFD, flag.to_raw()) < 0)) {
 
         return unexpected(make_error_code(errno));
     }
@@ -393,12 +393,11 @@ auto fchmod(utils::file_descriptor_ref fd, std::filesystem::perms perm) noexcept
 auto fchmodat(utils::file_descriptor_ref dirfd,
               const std::filesystem::path &path,
               std::filesystem::perms perm,
-              sys::at_flag flags) noexcept -> Result<void>
+              utils::bitflags<sys::at_flag> flags) noexcept -> Result<void>
 {
     while (true) {
-        if (UNLIKELY(
-              ::fchmodat(dirfd, path.c_str(), static_cast<mode_t>(perm), static_cast<int>(flags))
-              < 0)) {
+        if (UNLIKELY(::fchmodat(dirfd, path.c_str(), static_cast<mode_t>(perm), flags.to_raw())
+                     < 0)) {
             if (errno == EINTR) {
                 continue;
             }
@@ -430,10 +429,10 @@ auto fchmodat(utils::file_descriptor_ref dirfd,
                             const std::filesystem::path &path,
                             uid_t owner,
                             gid_t group,
-                            sys::at_flag flags) noexcept -> Result<void>
+                            utils::bitflags<sys::at_flag> flags) noexcept -> Result<void>
 {
     while (true) {
-        if (UNLIKELY(::fchownat(dirfd, path.c_str(), owner, group, static_cast<int>(flags)) < 0)) {
+        if (UNLIKELY(::fchownat(dirfd, path.c_str(), owner, group, flags.to_raw()) < 0)) {
             if (errno == EINTR) {
                 continue;
             }

--- a/src/linyaps_box/os/fs.h
+++ b/src/linyaps_box/os/fs.h
@@ -44,38 +44,46 @@ enum class open_flag : uint64_t { // NOLINT
     no_follow = O_NOFOLLOW,
     async = O_ASYNC,
     dsync = O_DSYNC,
+#if O_LARGEFILE
     largefile = O_LARGEFILE,
+#endif
     no_atime = O_NOATIME,
     no_ctty = O_NOCTTY,
     tmpfile = O_TMPFILE,
-    LINYAPS_MARK_AS_BITMASK_ENUM(tmpfile),
 };
 // O_TMPFILE contains O_DIRECTORY, so it must be placed at first.
 // O_LARGEFILE is 0 on 64-bit platforms (kernel always supports large files),
-// so only register it in the name table when it's a real non-zero flag.
+// so both the enumerator and its name-table entry only exist when it's a real
+// non-zero flag. The table count below must match the entries actually present.
 #if O_LARGEFILE
 #  define LINYAPS_BOX_OPEN_FLAG_LARGEFILE_ENTRY { open_flag::largefile, "O_LARGEFILE" },
+#  define LINYAPS_BOX_OPEN_FLAG_TABLE_COUNT 17
 #else
 #  define LINYAPS_BOX_OPEN_FLAG_LARGEFILE_ENTRY
+#  define LINYAPS_BOX_OPEN_FLAG_TABLE_COUNT 16
 #endif
-LINYAPS_REGISTER_ENUM(open_flag,
-                      { open_flag::none, "NONE" },
-                      { open_flag::tmpfile, "O_TMPFILE" },
-                      { open_flag::sync, "O_SYNC" },
-                      { open_flag::create, "O_CREAT" },
-                      { open_flag::exclusive, "O_EXCL" },
-                      { open_flag::cloexec, "O_CLOEXEC" },
-                      { open_flag::truncate, "O_TRUNC" },
-                      { open_flag::append, "O_APPEND" },
-                      { open_flag::non_block, "O_NONBLOCK" },
-                      { open_flag::directory, "O_DIRECTORY" },
-                      { open_flag::no_follow, "O_NOFOLLOW" },
-                      { open_flag::async, "O_ASYNC" },
-                      { open_flag::direct, "O_DIRECT" },
-                      { open_flag::dsync, "O_DSYNC" },
-                      LINYAPS_BOX_OPEN_FLAG_LARGEFILE_ENTRY{ open_flag::no_atime, "O_NOATIME" },
-                      { open_flag::no_ctty, "O_NOCTTY" })
+LINYAPS_ENABLE_BITMASK_ENUM(open_flag);
+LINYAPS_REGISTER_ENUM_TABLE(open_flag,
+                            LINYAPS_BOX_OPEN_FLAG_TABLE_COUNT,
+                            { open_flag::none, "NONE" },
+                            { open_flag::tmpfile, "O_TMPFILE" },
+                            { open_flag::sync, "O_SYNC" },
+                            { open_flag::create, "O_CREAT" },
+                            { open_flag::exclusive, "O_EXCL" },
+                            { open_flag::cloexec, "O_CLOEXEC" },
+                            { open_flag::truncate, "O_TRUNC" },
+                            { open_flag::append, "O_APPEND" },
+                            { open_flag::non_block, "O_NONBLOCK" },
+                            { open_flag::directory, "O_DIRECTORY" },
+                            { open_flag::no_follow, "O_NOFOLLOW" },
+                            { open_flag::async, "O_ASYNC" },
+                            { open_flag::direct, "O_DIRECT" },
+                            { open_flag::dsync, "O_DSYNC" },
+                            LINYAPS_BOX_OPEN_FLAG_LARGEFILE_ENTRY{ open_flag::no_atime,
+                                                                   "O_NOATIME" },
+                            { open_flag::no_ctty, "O_NOCTTY" })
 #undef LINYAPS_BOX_OPEN_FLAG_LARGEFILE_ENTRY
+#undef LINYAPS_BOX_OPEN_FLAG_TABLE_COUNT
 
 enum class access_mode : mode_t { // NOLINT
     unknown,
@@ -109,7 +117,7 @@ public:
 
     static auto from_raw(uint raw) noexcept -> Result<open_option>;
 
-    constexpr open_option(open_flag flags, access_mode acc_mode) noexcept
+    constexpr open_option(utils::bitflags<open_flag> flags, access_mode acc_mode) noexcept
         : flags_(flags)
         , access_mode_(acc_mode)
     {
@@ -145,7 +153,7 @@ public:
             mode |= 0U;
         }
 
-        return static_cast<uint>(flags_) | mode;
+        return flags_.to_raw() | mode;
     }
 
     [[nodiscard]] constexpr explicit operator int() const noexcept
@@ -159,42 +167,47 @@ public:
     }
 
 private:
-    open_flag flags_;
+    utils::bitflags<open_flag> flags_;
     access_mode access_mode_;
 };
 
 enum class fd_flag : uint8_t {
     none = 0,
     cloexec = FD_CLOEXEC,
-    LINYAPS_MARK_AS_BITMASK_ENUM(cloexec),
 };
-LINYAPS_REGISTER_ENUM(fd_flag, { fd_flag::none, "NONE" }, { fd_flag::cloexec, "FD_CLOEXEC" })
+LINYAPS_ENABLE_BITMASK_ENUM(fd_flag);
+LINYAPS_REGISTER_ENUM_TABLE(fd_flag,
+                            2,
+                            { fd_flag::none, "NONE" },
+                            { fd_flag::cloexec, "FD_CLOEXEC" })
 
 enum class at_flag : std::uint16_t {
     none = 0,
     empty_path = AT_EMPTY_PATH,
     symlink_nofollow = AT_SYMLINK_NOFOLLOW,
     remove_dir = AT_REMOVEDIR,
-    LINYAPS_MARK_AS_BITMASK_ENUM(empty_path),
 };
-LINYAPS_REGISTER_ENUM(at_flag,
-                      { at_flag::none, "NONE" },
-                      { at_flag::empty_path, "AT_EMPTY_PATH" },
-                      { at_flag::symlink_nofollow, "AT_SYMLINK_NOFOLLOW" },
-                      { at_flag::remove_dir, "AT_REMOVEDIR" })
+LINYAPS_ENABLE_BITMASK_ENUM(at_flag);
+LINYAPS_REGISTER_ENUM_TABLE(at_flag,
+                            4,
+                            { at_flag::none, "NONE" },
+                            { at_flag::empty_path, "AT_EMPTY_PATH" },
+                            { at_flag::symlink_nofollow, "AT_SYMLINK_NOFOLLOW" },
+                            { at_flag::remove_dir, "AT_REMOVEDIR" })
 
 enum class rename_flag : std::uint8_t {
     none = 0,
     exchange = RENAME_EXCHANGE,
     noreplace = RENAME_NOREPLACE,
     whiteout = RENAME_WHITEOUT,
-    LINYAPS_MARK_AS_BITMASK_ENUM(whiteout),
 };
-LINYAPS_REGISTER_ENUM(rename_flag,
-                      { rename_flag::none, "NONE" },
-                      { rename_flag::exchange, "RENAME_EXCHANGE" },
-                      { rename_flag::noreplace, "RENAME_NOREPLACE" },
-                      { rename_flag::whiteout, "RENAME_WHITEOUT" })
+LINYAPS_ENABLE_BITMASK_ENUM(rename_flag);
+LINYAPS_REGISTER_ENUM_TABLE(rename_flag,
+                            4,
+                            { rename_flag::none, "NONE" },
+                            { rename_flag::exchange, "RENAME_EXCHANGE" },
+                            { rename_flag::noreplace, "RENAME_NOREPLACE" },
+                            { rename_flag::whiteout, "RENAME_WHITEOUT" })
 
 enum class openat2_resolve : std::uint64_t { // NOLINT
     none = 0,
@@ -240,21 +253,21 @@ enum class openat2_resolve : std::uint64_t { // NOLINT
     ,
 
     // we couldn't stimulate RESOLVE_CACHED in userspace
-
-    LINYAPS_MARK_AS_BITMASK_ENUM(in_root),
 };
-LINYAPS_REGISTER_ENUM(openat2_resolve,
-                      { openat2_resolve::no_xdev, "RESOLVE_NO_XDEV" },
-                      { openat2_resolve::no_magic_links, "RESOLVE_NO_MAGICLINKS" },
-                      { openat2_resolve::no_symlinks, "RESOLVE_NO_SYMLINKS" },
-                      { openat2_resolve::beneath, "RESOLVE_BENEATH" },
-                      { openat2_resolve::in_root, "RESOLVE_IN_ROOT" })
+LINYAPS_ENABLE_BITMASK_ENUM(openat2_resolve);
+LINYAPS_REGISTER_ENUM_TABLE(openat2_resolve,
+                            5,
+                            { openat2_resolve::no_xdev, "RESOLVE_NO_XDEV" },
+                            { openat2_resolve::no_magic_links, "RESOLVE_NO_MAGICLINKS" },
+                            { openat2_resolve::no_symlinks, "RESOLVE_NO_SYMLINKS" },
+                            { openat2_resolve::beneath, "RESOLVE_BENEATH" },
+                            { openat2_resolve::in_root, "RESOLVE_IN_ROOT" })
 
 struct open_how
 {
     open_option opt;
     std::filesystem::perms perms;
-    openat2_resolve resolve;
+    utils::bitflags<openat2_resolve> resolve;
 };
 
 struct linux_dirent64
@@ -291,7 +304,8 @@ struct linux_dirent64
 
 [[nodiscard]] auto unlinkat(utils::file_descriptor_ref dirfd,
                             const std::filesystem::path &path,
-                            sys::at_flag flags = sys::at_flag::none) noexcept -> Result<void>;
+                            utils::bitflags<sys::at_flag> flags = sys::at_flag::none) noexcept
+  -> Result<void>;
 
 [[nodiscard]] auto mkdirat(utils::file_descriptor_ref dirfd,
                            const std::filesystem::path &path,
@@ -301,18 +315,19 @@ struct linux_dirent64
                              utils::file_descriptor_ref dirfd,
                              const std::filesystem::path &linkpath) noexcept -> Result<void>;
 
-[[nodiscard]] auto renameat2(utils::file_descriptor_ref olddirfd,
-                             const std::filesystem::path &oldpath,
-                             utils::file_descriptor_ref newdirfd,
-                             const std::filesystem::path &newpath,
-                             sys::rename_flag flags = sys::rename_flag::none) noexcept
-  -> Result<void>;
+[[nodiscard]] auto renameat2(
+  utils::file_descriptor_ref olddirfd,
+  const std::filesystem::path &oldpath,
+  utils::file_descriptor_ref newdirfd,
+  const std::filesystem::path &newpath,
+  utils::bitflags<sys::rename_flag> flags = sys::rename_flag::none) noexcept -> Result<void>;
 
 [[nodiscard]] auto fstat(utils::file_descriptor_ref fd) noexcept -> Result<struct stat>;
 
 [[nodiscard]] auto fstatat(utils::file_descriptor_ref dirfd,
                            const std::filesystem::path &path,
-                           sys::at_flag flags = sys::at_flag::none) noexcept -> Result<struct stat>;
+                           utils::bitflags<sys::at_flag> flags = sys::at_flag::none) noexcept
+  -> Result<struct stat>;
 
 [[nodiscard]] auto readlinkat(utils::file_descriptor_ref dirfd,
                               const std::filesystem::path &path,
@@ -328,7 +343,8 @@ struct linux_dirent64
                           const std::filesystem::path &oldpath,
                           utils::file_descriptor_ref newdirfd,
                           const std::filesystem::path &newpath,
-                          sys::at_flag flags = sys::at_flag::none) noexcept -> Result<void>;
+                          utils::bitflags<sys::at_flag> flags = sys::at_flag::none) noexcept
+  -> Result<void>;
 
 [[nodiscard]] auto fcntl_dupfd(utils::file_descriptor_ref fd, int newfd) noexcept
   -> Result<utils::file_descriptor>;
@@ -336,13 +352,13 @@ struct linux_dirent64
 [[nodiscard]] auto fcntl_dupfd_cloexec(utils::file_descriptor_ref fd, int newfd) noexcept
   -> Result<utils::file_descriptor>;
 
-[[nodiscard]] auto fcntl_setfl(utils::file_descriptor_ref fd, sys::open_flag flag) noexcept
-  -> Result<void>;
+[[nodiscard]] auto fcntl_setfl(utils::file_descriptor_ref fd,
+                               utils::bitflags<sys::open_flag> flag) noexcept -> Result<void>;
 
 [[nodiscard]] auto fcntl_getfl(utils::file_descriptor_ref fd) noexcept -> Result<sys::open_option>;
 
-[[nodiscard]] auto fcntl_setfd(utils::file_descriptor_ref fd, sys::fd_flag flag) noexcept
-  -> Result<void>;
+[[nodiscard]] auto fcntl_setfd(utils::file_descriptor_ref fd,
+                               utils::bitflags<sys::fd_flag> flag) noexcept -> Result<void>;
 
 [[nodiscard]] auto fcntl_getfd(utils::file_descriptor_ref fd) noexcept -> Result<sys::fd_flag>;
 
@@ -357,17 +373,18 @@ struct linux_dirent64
 [[nodiscard]] auto fchmodat(utils::file_descriptor_ref dirfd,
                             const std::filesystem::path &path,
                             std::filesystem::perms perm,
-                            sys::at_flag flags = sys::at_flag::none) noexcept -> Result<void>;
+                            utils::bitflags<sys::at_flag> flags = sys::at_flag::none) noexcept
+  -> Result<void>;
 
 [[nodiscard]] auto fchown(utils::file_descriptor_ref fd, uid_t owner, gid_t group) noexcept
   -> Result<void>;
 
-[[nodiscard]] auto fchownat(utils::file_descriptor_ref dirfd,
-                            const std::filesystem::path &path,
-                            uid_t owner,
-                            gid_t group,
-                            sys::at_flag flags = sys::at_flag::symlink_nofollow) noexcept
-  -> Result<void>;
+[[nodiscard]] auto fchownat(
+  utils::file_descriptor_ref dirfd,
+  const std::filesystem::path &path,
+  uid_t owner,
+  gid_t group,
+  utils::bitflags<sys::at_flag> flags = sys::at_flag::symlink_nofollow) noexcept -> Result<void>;
 
 auto to_fs_file_type(mode_t val) noexcept -> std::filesystem::file_type;
 

--- a/src/linyaps_box/os/net.cpp
+++ b/src/linyaps_box/os/net.cpp
@@ -61,10 +61,10 @@ auto endpoint::from_path(const std::filesystem::path &path) noexcept -> os::Resu
 
 auto send(utils::file_descriptor_ref fd,
           utils::span<const std::byte> buf,
-          sys::send_flag flags) noexcept -> Result<std::size_t>
+          utils::bitflags<sys::send_flag> flags) noexcept -> Result<std::size_t>
 {
     while (true) {
-        auto ret = ::send(fd, buf.data(), buf.size(), static_cast<int>(flags));
+        auto ret = ::send(fd, buf.data(), buf.size(), flags.to_raw());
         if (UNLIKELY(ret < 0)) {
             if (errno == EINTR) {
                 continue;
@@ -80,7 +80,7 @@ auto send(utils::file_descriptor_ref fd,
 auto sendmsg(utils::file_descriptor_ref fd,
              const io_slice &iov,
              ancillary_buffer_writer &control,
-             sys::send_flag flags) noexcept -> Result<std::size_t>
+             utils::bitflags<sys::send_flag> flags) noexcept -> Result<std::size_t>
 {
     struct msghdr msg{ };
 
@@ -94,7 +94,7 @@ auto sendmsg(utils::file_descriptor_ref fd,
     }
 
     while (true) {
-        auto ret = ::sendmsg(fd, &msg, static_cast<int>(flags));
+        auto ret = ::sendmsg(fd, &msg, flags.to_raw());
         if (UNLIKELY(ret < 0)) {
             if (errno == EINTR) {
                 continue;
@@ -107,11 +107,12 @@ auto sendmsg(utils::file_descriptor_ref fd,
     }
 }
 
-auto recv(utils::file_descriptor_ref fd, utils::span<std::byte> buf, sys::recv_flag flags) noexcept
-  -> Result<std::size_t>
+auto recv(utils::file_descriptor_ref fd,
+          utils::span<std::byte> buf,
+          utils::bitflags<sys::recv_flag> flags) noexcept -> Result<std::size_t>
 {
     while (true) {
-        auto ret = ::recv(fd, buf.data(), buf.size(), static_cast<int>(flags));
+        auto ret = ::recv(fd, buf.data(), buf.size(), flags.to_raw());
         if (UNLIKELY(ret < 0)) {
             if (errno == EINTR) {
                 continue;
@@ -127,7 +128,7 @@ auto recv(utils::file_descriptor_ref fd, utils::span<std::byte> buf, sys::recv_f
 auto recvmsg(utils::file_descriptor_ref fd,
              const mutable_io_slice &iov,
              ancillary_buffer &control,
-             sys::recv_flag flags) noexcept -> Result<RecvMsg>
+             utils::bitflags<sys::recv_flag> flags) noexcept -> Result<RecvMsg>
 {
     struct msghdr msg{ };
 
@@ -142,7 +143,7 @@ auto recvmsg(utils::file_descriptor_ref fd,
     msg.msg_namelen = linyaps_box::os::endpoint::capacity();
 
     while (true) {
-        auto ret = ::recvmsg(fd.get(), &msg, static_cast<int>(flags));
+        auto ret = ::recvmsg(fd.get(), &msg, flags.to_raw());
         if (UNLIKELY(ret < 0)) {
             if (errno == EINTR) {
                 continue;
@@ -153,7 +154,7 @@ auto recvmsg(utils::file_descriptor_ref fd,
 
         RecvMsg res{ };
         res.bytes = static_cast<std::size_t>(ret);
-        res.flags = static_cast<sys::return_flag>(msg.msg_flags);
+        res.flags = sys::return_flag(msg.msg_flags);
 
         if (msg.msg_namelen > 0) {
             res.address.emplace(peer_ep.data(), msg.msg_namelen);
@@ -223,11 +224,10 @@ auto ancillary_message_view::raw_data() const noexcept -> utils::span<const std:
 
 auto socket(sys::address_family domain,
             sys::socket_type type,
-            sys::socket_flag flag,
+            utils::bitflags<sys::socket_flag> flag,
             int protocol) noexcept -> Result<utils::file_descriptor>
 {
-    auto fd =
-      ::socket(static_cast<int>(domain), static_cast<int>(type) | static_cast<int>(flag), protocol);
+    auto fd = ::socket(static_cast<int>(domain), static_cast<int>(type) | flag.to_raw(), protocol);
     if (UNLIKELY(fd == -1)) {
         return unexpected{ make_error_code(errno) };
     }
@@ -237,13 +237,13 @@ auto socket(sys::address_family domain,
 
 auto socketpair(sys::address_family domain,
                 sys::socket_type type,
-                sys::socket_flag flag,
+                utils::bitflags<sys::socket_flag> flag,
                 int protocol) noexcept
   -> Result<std::pair<utils::file_descriptor, utils::file_descriptor>>
 {
     std::array<int, 2> fds{ };
     if (UNLIKELY(::socketpair(static_cast<int>(domain),
-                              static_cast<int>(type) | static_cast<int>(flag),
+                              static_cast<int>(type) | flag.to_raw(),
                               protocol,
                               fds.data())
                  == -1)) {

--- a/src/linyaps_box/os/net.h
+++ b/src/linyaps_box/os/net.h
@@ -24,17 +24,18 @@ enum class send_flag : uint16_t {
     more = MSG_MORE,
     nosignal = MSG_NOSIGNAL,
     oob = MSG_OOB,
-    LINYAPS_MARK_AS_BITMASK_ENUM(more),
 };
-LINYAPS_REGISTER_ENUM(send_flag,
-                      { send_flag::none, "NONE" },
-                      { send_flag::confirm, "MSG_CONFIRM" },
-                      { send_flag::dontroute, "MSG_DONTROUTE" },
-                      { send_flag::dontwait, "MSG_DONTWAIT" },
-                      { send_flag::eor, "MSG_EOR" },
-                      { send_flag::more, "MSG_MORE" },
-                      { send_flag::nosignal, "MSG_NOSIGNAL" },
-                      { send_flag::oob, "MSG_OOB" })
+LINYAPS_ENABLE_BITMASK_ENUM(send_flag);
+LINYAPS_REGISTER_ENUM_TABLE(send_flag,
+                            8,
+                            { send_flag::none, "NONE" },
+                            { send_flag::confirm, "MSG_CONFIRM" },
+                            { send_flag::dontroute, "MSG_DONTROUTE" },
+                            { send_flag::dontwait, "MSG_DONTWAIT" },
+                            { send_flag::eor, "MSG_EOR" },
+                            { send_flag::more, "MSG_MORE" },
+                            { send_flag::nosignal, "MSG_NOSIGNAL" },
+                            { send_flag::oob, "MSG_OOB" })
 
 enum class recv_flag : uint32_t {
     none = 0,
@@ -45,17 +46,18 @@ enum class recv_flag : uint32_t {
     peek = MSG_PEEK,
     trunc = MSG_TRUNC,
     waitall = MSG_WAITALL,
-    LINYAPS_MARK_AS_BITMASK_ENUM(cmsg_cloexec),
 };
-LINYAPS_REGISTER_ENUM(recv_flag,
-                      { recv_flag::none, "NONE" },
-                      { recv_flag::cmsg_cloexec, "MSG_CMSG_CLOEXEC" },
-                      { recv_flag::dontwait, "MSG_DONTWAIT" },
-                      { recv_flag::errqueue, "MSG_ERRQUEUE" },
-                      { recv_flag::oob, "MSG_OOB" },
-                      { recv_flag::peek, "MSG_PEEK" },
-                      { recv_flag::trunc, "MSG_TRUNC" },
-                      { recv_flag::waitall, "MSG_WAITALL" })
+LINYAPS_ENABLE_BITMASK_ENUM(recv_flag);
+LINYAPS_REGISTER_ENUM_TABLE(recv_flag,
+                            8,
+                            { recv_flag::none, "NONE" },
+                            { recv_flag::cmsg_cloexec, "MSG_CMSG_CLOEXEC" },
+                            { recv_flag::dontwait, "MSG_DONTWAIT" },
+                            { recv_flag::errqueue, "MSG_ERRQUEUE" },
+                            { recv_flag::oob, "MSG_OOB" },
+                            { recv_flag::peek, "MSG_PEEK" },
+                            { recv_flag::trunc, "MSG_TRUNC" },
+                            { recv_flag::waitall, "MSG_WAITALL" })
 
 enum class return_flag : uint32_t {
     none = 0,
@@ -65,21 +67,23 @@ enum class return_flag : uint32_t {
     ctrunc = MSG_CTRUNC,
     errqueue = MSG_ERRQUEUE,
     cmsg_cloexec = MSG_CMSG_CLOEXEC,
-    LINYAPS_MARK_AS_BITMASK_ENUM(cmsg_cloexec),
 };
-LINYAPS_REGISTER_ENUM(return_flag,
-                      { return_flag::none, "NONE" },
-                      { return_flag::oob, "MSG_OOB" },
-                      { return_flag::eor, "MSG_EOR" },
-                      { return_flag::trunc, "MSG_TRUNC" },
-                      { return_flag::ctrunc, "MSG_CTRUNC" },
-                      { return_flag::errqueue, "MSG_ERRQUEUE" },
-                      { return_flag::cmsg_cloexec, "MSG_CMSG_CLOEXEC" })
+LINYAPS_ENABLE_BITMASK_ENUM(return_flag);
+LINYAPS_REGISTER_ENUM_TABLE(return_flag,
+                            7,
+                            { return_flag::none, "NONE" },
+                            { return_flag::oob, "MSG_OOB" },
+                            { return_flag::eor, "MSG_EOR" },
+                            { return_flag::trunc, "MSG_TRUNC" },
+                            { return_flag::ctrunc, "MSG_CTRUNC" },
+                            { return_flag::errqueue, "MSG_ERRQUEUE" },
+                            { return_flag::cmsg_cloexec, "MSG_CMSG_CLOEXEC" })
 
 enum class address_family : uint8_t { unspecified = AF_UNSPEC, unix = AF_UNIX };
-LINYAPS_REGISTER_ENUM(address_family,
-                      { address_family::unspecified, "AF_UNSPEC" },
-                      { address_family::unix, "AF_UNIX" })
+LINYAPS_REGISTER_ENUM_TABLE(address_family,
+                            2,
+                            { address_family::unspecified, "AF_UNSPEC" },
+                            { address_family::unix, "AF_UNIX" })
 
 enum class socket_type : uint8_t {
     stream = SOCK_STREAM,
@@ -88,23 +92,25 @@ enum class socket_type : uint8_t {
     rdm = SOCK_RDM,
     seqpacket = SOCK_SEQPACKET
 };
-LINYAPS_REGISTER_ENUM(socket_type,
-                      { socket_type::stream, "SOCK_STREAM" },
-                      { socket_type::datagram, "SOCK_DGRAM" },
-                      { socket_type::raw, "SOCK_RAW" },
-                      { socket_type::rdm, "SOCK_RDM" },
-                      { socket_type::seqpacket, "SOCK_SEQPACKET" })
+LINYAPS_REGISTER_ENUM_TABLE(socket_type,
+                            5,
+                            { socket_type::stream, "SOCK_STREAM" },
+                            { socket_type::datagram, "SOCK_DGRAM" },
+                            { socket_type::raw, "SOCK_RAW" },
+                            { socket_type::rdm, "SOCK_RDM" },
+                            { socket_type::seqpacket, "SOCK_SEQPACKET" })
 
 enum class socket_flag : uint32_t {
     none = 0,
     nonblock = SOCK_NONBLOCK,
     cloexec = SOCK_CLOEXEC,
-    LINYAPS_MARK_AS_BITMASK_ENUM(cloexec),
 };
-LINYAPS_REGISTER_ENUM(socket_flag,
-                      { socket_flag::none, "NONE" },
-                      { socket_flag::nonblock, "SOCK_NONBLOCK" },
-                      { socket_flag::cloexec, "SOCK_CLOEXEC" })
+LINYAPS_ENABLE_BITMASK_ENUM(socket_flag);
+LINYAPS_REGISTER_ENUM_TABLE(socket_flag,
+                            3,
+                            { socket_flag::none, "NONE" },
+                            { socket_flag::nonblock, "SOCK_NONBLOCK" },
+                            { socket_flag::cloexec, "SOCK_CLOEXEC" })
 
 namespace cmsg {
 
@@ -484,30 +490,34 @@ private:
 struct RecvMsg
 {
     std::size_t bytes{ 0 };
-    sys::return_flag flags{ sys::return_flag::none };
+    utils::bitflags<sys::return_flag> flags{ sys::return_flag::none };
     std::optional<endpoint> address;
     ancillary_buffer_view control;
 };
 
 auto send(utils::file_descriptor_ref fd,
           utils::span<const std::byte> buf,
-          sys::send_flag flags = sys::send_flag::none) noexcept -> Result<std::size_t>;
+          utils::bitflags<sys::send_flag> flags = sys::send_flag::none) noexcept
+  -> Result<std::size_t>;
 
 // sendmsg/recvmsg deliberately take a single iovec rather than a span of them.
 // If that ever changes, add a span<io_slice> overload back rather than changing this one.
 auto sendmsg(utils::file_descriptor_ref fd,
              const io_slice &iov,
              ancillary_buffer_writer &control,
-             sys::send_flag flags = sys::send_flag::none) noexcept -> Result<std::size_t>;
+             utils::bitflags<sys::send_flag> flags = sys::send_flag::none) noexcept
+  -> Result<std::size_t>;
 
 auto recv(utils::file_descriptor_ref fd,
           utils::span<std::byte> buf,
-          sys::recv_flag flags = sys::recv_flag::none) noexcept -> Result<std::size_t>;
+          utils::bitflags<sys::recv_flag> flags = sys::recv_flag::none) noexcept
+  -> Result<std::size_t>;
 
 auto recvmsg(utils::file_descriptor_ref fd,
              const mutable_io_slice &iov,
              ancillary_buffer &control,
-             sys::recv_flag flags = sys::recv_flag::none) noexcept -> Result<RecvMsg>;
+             utils::bitflags<sys::recv_flag> flags = sys::recv_flag::none) noexcept
+  -> Result<RecvMsg>;
 
 auto connect(utils::file_descriptor_ref fd, const endpoint &ep) noexcept -> Result<void>;
 
@@ -516,12 +526,12 @@ auto connect(utils::file_descriptor_ref fd, const endpoint &ep) noexcept -> Resu
 // add a wrapper class for protocol.
 auto socket(sys::address_family domain,
             sys::socket_type type,
-            sys::socket_flag flag = sys::socket_flag::none,
+            utils::bitflags<sys::socket_flag> flag = sys::socket_flag::none,
             int protocol = 0) noexcept -> Result<utils::file_descriptor>;
 
 auto socketpair(sys::address_family domain,
                 sys::socket_type type,
-                sys::socket_flag flag = sys::socket_flag::none,
+                utils::bitflags<sys::socket_flag> flag = sys::socket_flag::none,
                 int protocol = 0) noexcept
   -> Result<std::pair<utils::file_descriptor, utils::file_descriptor>>;
 

--- a/src/linyaps_box/utils/enum_formatter.h
+++ b/src/linyaps_box/utils/enum_formatter.h
@@ -15,54 +15,68 @@
 // bitmask / enum-table infrastructure (e.g. config.h) do not pull in
 // <fmt/format.h>.
 
-template <typename E, std::size_t N>
-template <typename OutputIt>
-OutputIt linyaps_box::utils::enum_table<E, N>::format_to(OutputIt out, E value) const
+namespace linyaps_box::utils::detail {
+
+struct enum_entry_view
 {
-    if constexpr (is_bitmask_enum_v<E>) {
-        return format_flags_to(out, value);
-    } else {
-        return format_single_to(out, value);
+    std::string_view name;
+    uint64_t value;
+};
+
+template <typename T>
+struct enum_or_bitflags_traits
+{
+    using enum_type = T;
+    using underlying_type = enum_underlying_t<T>;
+
+    static constexpr auto to_raw(T val) noexcept -> underlying_type
+    {
+        return static_cast<underlying_type>(val);
     }
-}
+};
 
-template <typename E, std::size_t N>
-template <typename OutputIt>
-OutputIt linyaps_box::utils::enum_table<E, N>::format_single_to(OutputIt out, E value) const
+template <typename E>
+struct enum_or_bitflags_traits<bitflags<E>>
 {
-    if (auto name = to_name(value)) {
-        return std::copy(name->begin(), name->end(), out);
+    using enum_type = E;
+    using underlying_type = typename bitflags<E>::underlying_type;
+
+    static constexpr auto to_raw(bitflags<E> val) noexcept -> underlying_type
+    {
+        return val.to_raw();
     }
+};
 
-    using U = std::underlying_type_t<E>;
-    return fmt::format_to(out, "{}", static_cast<U>(value));
-}
-
-template <typename E, std::size_t N>
 template <typename OutputIt>
-OutputIt linyaps_box::utils::enum_table<E, N>::format_flags_to(OutputIt out, E flags) const
+OutputIt format_flags_impl(OutputIt out,
+                           uint64_t val,
+                           std::string_view type_name,
+                           const enum_entry_view *entries,
+                           std::size_t count)
 {
-    using U = std::underlying_type_t<E>;
-    auto val = static_cast<U>(flags);
-
     if (val == 0) {
-        if (auto name = to_name(flags)) {
-            return std::copy(name->begin(), name->end(), out);
+        for (std::size_t i = 0; i < count; ++i) {
+            if (entries[i].value == 0) {
+                return std::copy(entries[i].name.cbegin(), entries[i].name.cend(), out);
+            }
         }
 
         static constexpr std::string_view none_sv = "none";
-        return std::copy(none_sv.begin(), none_sv.end(), out);
+        return std::copy(none_sv.cbegin(), none_sv.cend(), out);
     }
 
-    bool first = true;
-    for (const auto &entry : entries) {
-        const auto mask = static_cast<U>(entry.value);
+    std::copy(type_name.cbegin(), type_name.cend(), out);
+    *out++ = '(';
+
+    bool first{ true };
+    for (std::size_t i = 0; i < count; ++i) {
+        const auto mask = entries[i].value;
         if (mask != 0 && (val & mask) == mask) {
             if (!first) {
                 *out++ = '|';
             }
 
-            out = std::copy(entry.name.begin(), entry.name.end(), out);
+            out = std::copy(entries[i].name.cbegin(), entries[i].name.cend(), out);
             first = false;
             val &= ~mask;
 
@@ -80,11 +94,14 @@ OutputIt linyaps_box::utils::enum_table<E, N>::format_flags_to(OutputIt out, E f
         out = fmt::format_to(out, "0x{:x}", val);
     }
 
+    *out++ = ')';
     return out;
 }
 
-template <typename E>
-struct fmt::formatter<E, std::enable_if_t<linyaps_box::utils::has_enum_table_v<E>, char>>
+} // namespace linyaps_box::utils::detail
+
+template <typename T>
+struct fmt::formatter<T, std::enable_if_t<linyaps_box::utils::has_enum_table_v<T>, char>>
 {
     enum class Presentation : uint8_t { Default, Hex, Decimal };
     Presentation presentation{ Presentation::Default };
@@ -105,22 +122,63 @@ struct fmt::formatter<E, std::enable_if_t<linyaps_box::utils::has_enum_table_v<E
             ++it;
         }
 
+        if (it != end && *it != '}') {
+            throw fmt::format_error("invalid format specifier for enum");
+        }
+
         return it;
     }
 
     template <typename FormatContext>
-    auto format(E value, FormatContext &ctx) const
+    auto format(const T &value, FormatContext &ctx) const
     {
-        using U = std::underlying_type_t<E>;
+        using Traits = linyaps_box::utils::detail::enum_or_bitflags_traits<T>;
+        using E = typename Traits::enum_type;
+        using U = typename Traits::underlying_type;
+
+        const U raw_val = Traits::to_raw(value);
+
         if (presentation == Presentation::Hex) {
-            return fmt::format_to(ctx.out(), "0x{:x}", static_cast<U>(value));
+            using UnsignedU = std::make_unsigned_t<U>;
+            return fmt::format_to(ctx.out(), "0x{:x}", static_cast<UnsignedU>(raw_val));
         }
 
         if (presentation == Presentation::Decimal) {
-            return fmt::format_to(ctx.out(), "{}", static_cast<U>(value));
+            return fmt::format_to(ctx.out(), "{}", raw_val);
         }
 
-        constexpr auto table = get_enum_table(static_cast<E *>(nullptr));
-        return table.format_to(ctx.out(), value);
+        if constexpr (linyaps_box::utils::is_bitmask_enum_v<E>) {
+            static constexpr auto enum_data = [] {
+                constexpr auto table = get_enum_table(static_cast<E *>(nullptr));
+
+                struct packed_view
+                {
+                    std::string_view type_name;
+                    std::array<linyaps_box::utils::detail::enum_entry_view, table.entries().size()>
+                      views;
+                };
+
+                packed_view result{ table.type_name(), { } };
+                for (std::size_t i = 0; i < table.entries().size(); ++i) {
+                    result.views[i] = { table.entries()[i].name,
+                                        static_cast<uint64_t>(table.entries()[i].value) };
+                }
+
+                return result;
+            }();
+
+            return linyaps_box::utils::detail::format_flags_impl(ctx.out(),
+                                                                 static_cast<uint64_t>(raw_val),
+                                                                 enum_data.type_name,
+                                                                 enum_data.views.data(),
+                                                                 enum_data.views.size());
+        } else {
+            constexpr auto table = get_enum_table(static_cast<E *>(nullptr));
+            if (auto name = table.to_name(static_cast<E>(raw_val))) {
+                return std::copy(name->cbegin(), name->cend(), ctx.out());
+            }
+
+            return fmt::format_to(ctx.out(), "{}", raw_val);
+        }
     }
 };

--- a/src/linyaps_box/utils/enum_traits.h
+++ b/src/linyaps_box/utils/enum_traits.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include "linyaps_box/utils/span.h"
+#include "linyaps_box/utils/utils.h"
+
 #include <array>
 #include <cstddef>
 #include <optional>
@@ -12,109 +15,84 @@
 
 namespace linyaps_box::utils {
 
-// Enum traits are built around two opt-in mechanisms:
-//
-// 1. Bitmask support is an intrinsic property of the enum, so the marker is
-//    written inside the enum body:
-//
-//        enum class some_flag : uint64_t {
-//            ...
-//            max = SOME_VALUE,
-//            LINYAPS_MARK_AS_BITMASK_ENUM(max),   // sentinel enumerator
-//        };
-//
-//    The macro injects a sentinel enumerator named
-//    `LINYAPS_BITMASK_LARGEST_ENUMERATOR` holding the highest flag bit.
-//    `is_bitmask_enum<E>` detects it by a plain member lookup, so no ADL free
-//    function is needed for detection. The operators (`| & ^ ~` and the
-//    compound forms) are defined once, at global scope, as templates
-//    SFINAE-constrained on `is_bitmask_enum_v<E>`; ADL finds them for a marked
-//    enum no matter which namespace it lives in, so they are usable anywhere in
-//    the project without per-enum macro expansion.
-//
-//    The sentinel's value (the largest flag bit) bounds `operator~` to the
-//    defined flag range via `bitmask_mask()`, so `~x` yields "all defined flags
-//    except x" instead of a value with unrelated high bits set.
-//
-//    The macro argument must be an *enumerator*, not a literal: its value is
-//    bound to the platform macro at the enum definition site, so it tracks the
-//    platform automatically. The one invariant to uphold is that the declared
-//    enumerator really is the maximum flag on every platform this code compiles
-//    on. For table-registered enums `verify_enum_table()` enforces this at
-//    compile time by requiring every entry's bits to fall within
-//    `bitmask_mask()`; an enum without a table has no such check, so its
-//    declared maximum must be verified by hand (all current ones are stable
-//    across Linux architectures).
-//
-// 2. The name table is extrinsic metadata: entries are `{value, name}` pairs
-//    that cannot be enumerators, so they cannot live inside the enum body. The
-//    table is registered right after the enum instead:
-//
-//        LINYAPS_REGISTER_ENUM(some_flag, { some_flag::none, "NONE" }, ...);
-//
-//    which generates a `get_enum_table(E*)` free function in the enum's
-//    namespace. `has_enum_table<E>` and the `fmt::formatter` specialization
-//    below look it up via ADL, giving table-driven `to_name`/`from_name` and
-//    automatic fmt formatting (splitting bitmask values into `A|B`).
-//
-// Limitation: `LINYAPS_MARK_AS_BITMASK_ENUM` injects a real enumerator. For an
-// unscoped enum that enumerator leaks into the enclosing scope, so two
-// unscoped bitmask enums in the same scope would collide on the sentinel name
-// (scoped `enum class` enums are unaffected). A non-intrusive variant (explicit specialization) can
-// be added later if that becomes a problem.
+namespace detail {
 
-template <typename E>
-using enum_underlying_t = std::underlying_type_t<E>;
-
-template <typename E, typename = void>
-struct is_bitmask_enum : std::false_type
+template <typename T, std::size_t N, typename Compare>
+constexpr void shell_sort(span<T, N> entries, Compare comp) noexcept
 {
-};
+    for (const std::size_t gap : { 123, 54, 23, 10, 4, 1 }) {
+        if (gap >= N) {
+            continue;
+        }
 
-template <typename E>
-struct is_bitmask_enum<E, std::void_t<decltype(E::LINYAPS_BITMASK_LARGEST_ENUMERATOR)>>
-    : std::true_type
-{
-};
+        for (auto i = gap; i < N; ++i) {
+            auto temp = entries[i];
+            auto j = i;
 
-template <typename E>
-inline constexpr bool is_bitmask_enum_v = is_bitmask_enum<E>::value;
+            while (j >= gap && comp(temp, entries[j - gap])) {
+                entries[j] = entries[j - gap];
+                j -= gap;
+            }
 
-template <typename E, typename = void>
-struct largest_bitmask_enum_bit
-{
-};
-
-template <typename E>
-struct largest_bitmask_enum_bit<E, std::void_t<decltype(E::LINYAPS_BITMASK_LARGEST_ENUMERATOR)>>
-{
-    using underlying_t = enum_underlying_t<E>;
-    static constexpr underlying_t value =
-      static_cast<underlying_t>(E::LINYAPS_BITMASK_LARGEST_ENUMERATOR);
-};
-
-// Smallest power of two strictly greater than `value`. On overflow (top bit
-// set) the propagation fills the whole width and `+ 1` wraps to 0
-template <typename T>
-constexpr auto next_power_of_2(T value) noexcept -> T
-{
-    for (std::size_t shift = 1; shift < sizeof(T) * 8; shift <<= 1) {
-        value |= static_cast<T>(value >> shift);
+            entries[j] = temp;
+        }
     }
-
-    return static_cast<T>(value + 1);
 }
+
+template <typename E, bool = std::is_enum_v<E>>
+struct safe_underlying
+{
+    using type = E;
+};
 
 template <typename E>
-constexpr auto bitmask_mask() noexcept -> enum_underlying_t<E>
+struct safe_underlying<E, true>
 {
-    using U = enum_underlying_t<E>;
-    const auto largest = static_cast<U>(largest_bitmask_enum_bit<E>::value);
-    // Every bit up to (but not including) the next power of two above the
-    // largest flag: a contiguous 1-range covering every bit the enum can
-    // express.
-    return static_cast<U>(next_power_of_2(largest) - 1);
+    using type = std::underlying_type_t<E>;
+};
+
+template <typename E>
+using enum_underlying_t = typename safe_underlying<E>::type;
+
+template <typename T>
+constexpr auto popcount(T val) noexcept -> int
+{
+    if constexpr (std::is_enum_v<T>) {
+        using U = std::make_unsigned_t<enum_underlying_t<T>>;
+        return detail::popcount(static_cast<U>(val));
+    } else {
+        static_assert(std::is_integral_v<T> && !std::is_same_v<T, bool>,
+                      "popcount requires an integral or enum type (excluding bool)");
+
+        using U = std::make_unsigned_t<T>;
+        const auto uval = static_cast<U>(val);
+
+        if constexpr (sizeof(U) <= sizeof(unsigned int)) {
+            return __builtin_popcount(static_cast<unsigned int>(uval));
+        } else if constexpr (sizeof(U) <= sizeof(unsigned long long)) {
+            return __builtin_popcountll(static_cast<unsigned long long>(uval));
+        } else {
+            static_assert(sizeof(U) <= 16, "Types larger than 128-bit are not supported");
+            const auto low = static_cast<unsigned long long>(uval);
+            const auto high = static_cast<unsigned long long>(uval >> 64);
+            return __builtin_popcountll(low) + __builtin_popcountll(high);
+        }
+    }
 }
+
+template <typename T>
+constexpr auto enable_bitmask_enum_tag(T *) noexcept -> std::false_type;
+
+template <typename E>
+constexpr auto check_is_bitmask_enum() noexcept
+{
+    return decltype(enable_bitmask_enum_tag(static_cast<E *>(nullptr)))::value;
+}
+
+} // namespace detail
+
+template <typename E>
+inline constexpr bool is_bitmask_enum_v = detail::check_is_bitmask_enum<E>();
 
 template <typename E>
 struct enum_entry
@@ -130,13 +108,28 @@ template <typename E>
 enum_entry(E, std::string_view) -> enum_entry<E>;
 
 template <typename E, std::size_t N>
-struct enum_table
+class enum_table;
+
+template <typename E, std::size_t N>
+constexpr auto make_enum_table(std::string_view type_name, const enum_entry<E> (&arr)[N]) noexcept
+  -> enum_table<E, N>;
+
+template <typename E, std::size_t N>
+constexpr auto verify_enum_table(const enum_table<E, N> &entries) noexcept -> bool;
+
+template <typename E, std::size_t N>
+class enum_table
 {
-    std::array<enum_entry<E>, N> entries;
+public:
+    constexpr enum_table(std::string_view name, const enum_entry<E> (&arr)[N]) noexcept
+        : type_name_(name)
+        , entries_(utils::to_array(arr))
+    {
+    }
 
     [[nodiscard]] constexpr auto to_name(E value) const noexcept -> std::optional<std::string_view>
     {
-        for (const auto &entry : entries) {
+        for (const auto &entry : entries_) {
             if (entry.value == value) {
                 return entry.name;
             }
@@ -147,7 +140,7 @@ struct enum_table
 
     [[nodiscard]] constexpr auto from_name(std::string_view name) const noexcept -> std::optional<E>
     {
-        for (const auto &entry : entries) {
+        for (const auto &entry : entries_) {
             if (entry.name == name) {
                 return entry.value;
             }
@@ -156,153 +149,331 @@ struct enum_table
         return std::nullopt;
     }
 
-    template <typename OutputIt>
-    OutputIt format_to(OutputIt out, E value) const;
+    friend constexpr auto make_enum_table<>(std::string_view, const enum_entry<E> (&)[N]) noexcept
+      -> enum_table<E, N>;
+
+    friend constexpr auto verify_enum_table<>(const enum_table<E, N> &) noexcept -> bool;
+
+    [[nodiscard]] constexpr auto type_name() const noexcept -> std::string_view
+    {
+        return type_name_;
+    }
+
+    [[nodiscard]] constexpr auto entries() const noexcept -> const std::array<enum_entry<E>, N> &
+    {
+        return entries_;
+    }
 
 private:
-    template <typename OutputIt>
-    OutputIt format_single_to(OutputIt out, E value) const;
-
-    template <typename OutputIt>
-    OutputIt format_flags_to(OutputIt out, E flags) const;
+    std::string_view type_name_;
+    std::array<enum_entry<E>, N> entries_;
 };
-
-template <typename E, typename... Rest>
-enum_table(enum_entry<E>, Rest...) -> enum_table<E, 1 + sizeof...(Rest)>;
 
 template <typename E, typename = void>
-struct has_enum_table : std::false_type
-{
-};
+inline constexpr bool has_enum_table_v = false;
 
 template <typename E>
-struct has_enum_table<E, std::void_t<decltype(get_enum_table(static_cast<E *>(nullptr)))>>
-    : std::true_type
-{
-};
+inline constexpr bool
+  has_enum_table_v<E, std::void_t<decltype(get_enum_table(static_cast<E *>(nullptr)))>> = true;
 
+namespace detail {
+
+// The bitwise union of all declared (non-zero) flag values
 template <typename E>
-inline constexpr bool has_enum_table_v = has_enum_table<E>::value;
+constexpr auto known_mask() noexcept -> enum_underlying_t<E>
+{
+    using U = enum_underlying_t<E>;
+
+    if constexpr (has_enum_table_v<E>) {
+        constexpr auto table = get_enum_table(static_cast<E *>(nullptr));
+        U mask{ 0 };
+        for (const auto &entry : table.entries()) {
+            mask |= static_cast<U>(entry.value);
+        }
+
+        return mask;
+    } else {
+        // A bitmask enum must register a table for its known bits to be
+        // well-defined; otherwise truncate/all would silently no-op.
+        static_assert(
+          has_enum_table_v<E>,
+          "bitmask enum requires a registered enum table (LINYAPS_REGISTER_ENUM_TABLE)");
+    }
+}
+
+} // namespace detail
 
 template <typename E, std::size_t N>
-constexpr auto make_enum_table(const enum_entry<E> (&entries)[N]) noexcept -> enum_table<E, N>
+constexpr auto make_enum_table(std::string_view type_name,
+                               const enum_entry<E> (&entries)[N]) noexcept -> enum_table<E, N>
 {
-    enum_table<E, N> table{ };
-    for (std::size_t i = 0; i < N; ++i) {
-        table.entries[i] = entries[i];
+    enum_table table(type_name, entries);
+
+    // generate an ordered table at compile time
+    if constexpr (is_bitmask_enum_v<E>) {
+        using U = std::make_unsigned_t<detail::enum_underlying_t<E>>;
+
+        detail::shell_sort(span(table.entries_),
+                           [](const enum_entry<E> &a, const enum_entry<E> &b) {
+                               const auto a_u = static_cast<U>(a.value);
+                               const auto b_u = static_cast<U>(b.value);
+                               const auto a_pop = detail::popcount(a_u);
+                               const auto b_pop = detail::popcount(b_u);
+                               return a_pop > b_pop || (a_pop == b_pop && a_u < b_u);
+                           });
     }
+
     return table;
 }
 
 template <typename E, std::size_t N>
 constexpr auto verify_enum_table(const enum_table<E, N> &table) noexcept -> bool
 {
-    for (std::size_t i = 0; i < N; ++i) {
-        for (std::size_t j = i + 1; j < N; ++j) {
-            if (table.entries[i].name == table.entries[j].name
-                || table.entries[i].value == table.entries[j].value) {
+    // value duplicates: leverage existing sort order for bitmask enums
+    if constexpr (is_bitmask_enum_v<E>) {
+        for (std::size_t i = 1; i < N; ++i) {
+            if (table.entries_[i].value == table.entries_[i - 1].value) {
                 return false;
+            }
+        }
+    } else {
+        for (std::size_t i = 0; i < N; ++i) {
+            for (std::size_t j = i + 1; j < N; ++j) {
+                if (table.entries_[i].value == table.entries_[j].value) {
+                    return false;
+                }
             }
         }
     }
 
-    if constexpr (is_bitmask_enum_v<E>) {
-        using U = enum_underlying_t<E>;
-        constexpr auto mask = bitmask_mask<E>();
-        for (std::size_t i = 0; i < N; ++i) {
-            const auto value = static_cast<U>(table.entries[i].value);
-            if ((value & ~mask) != 0) {
-                return false;
-            }
+    // name duplicates: shell sort by name then check adjacent
+    std::array<enum_entry<E>, N> sorted;
+    for (std::size_t i = 0; i < N; ++i) {
+        sorted[i] = table.entries_[i];
+    }
+
+    detail::shell_sort(span(sorted), [](const enum_entry<E> &a, const enum_entry<E> &b) {
+        return a.name < b.name;
+    });
+
+    for (std::size_t i = 1; i < N; ++i) {
+        if (sorted[i].name == sorted[i - 1].name) {
+            return false;
         }
     }
 
     return true;
 }
 
-template <typename E, std::size_t N, typename Pred>
-constexpr auto verify_enum_table(const enum_table<E, N> &table, Pred is_valid) -> bool
+template <typename E, std::enable_if_t<is_bitmask_enum_v<E>, int> = 0>
+class bitflags
 {
-    for (std::size_t i = 0; i < N; ++i) {
-        for (std::size_t j = i + 1; j < N; ++j) {
-            if (!is_valid(table.entries[i], table.entries[j])) {
-                return false;
-            }
-        }
+public:
+    using underlying_type = detail::enum_underlying_t<E>;
+
+    static_assert(!std::is_signed_v<underlying_type>,
+                  "bitflags<E> requires an unsigned underlying type");
+
+    constexpr bitflags() noexcept = default;
+
+    constexpr bitflags(E flag) noexcept
+        : bits_(static_cast<underlying_type>(flag))
+    {
     }
 
-    return true;
+    [[nodiscard]] constexpr static auto from_raw(underlying_type bits) noexcept
+      -> std::optional<bitflags>
+    {
+        if ((bits & ~detail::known_mask<E>()) != 0) {
+            return std::nullopt;
+        }
+
+        return bitflags(bits);
+    }
+
+    // Drops unknown bits, keeping only the declared flags
+    constexpr static auto from_raw_truncate(underlying_type bits) noexcept -> bitflags
+    {
+        return bitflags(bits & detail::known_mask<E>());
+    }
+
+    constexpr static auto all() noexcept -> bitflags { return bitflags(detail::known_mask<E>()); }
+
+    [[nodiscard]] constexpr auto is_all() const noexcept -> bool
+    {
+        return bits_ == detail::known_mask<E>();
+    }
+
+    [[nodiscard]] constexpr auto to_raw() const noexcept -> underlying_type { return bits_; }
+
+    [[nodiscard]] constexpr auto empty() const noexcept -> bool { return bits_ == 0; }
+
+    [[nodiscard]] constexpr explicit operator bool() const noexcept { return !empty(); }
+
+    [[nodiscard]] constexpr auto contains(E flag) const noexcept -> bool
+    {
+        const auto f = static_cast<underlying_type>(flag);
+        return (bits_ & f) == f;
+    }
+
+    [[nodiscard]] constexpr auto contains(bitflags flags) const noexcept -> bool
+    {
+        return (bits_ & flags.bits_) == flags.bits_;
+    }
+
+    [[nodiscard]] constexpr auto intersects(bitflags flags) const noexcept -> bool
+    {
+        return (bits_ & flags.bits_) != 0;
+    }
+
+    constexpr auto set(E flag, bool value = true) noexcept -> bitflags &
+    {
+        if (value) {
+            bits_ |= static_cast<underlying_type>(flag);
+        } else {
+            bits_ &= ~static_cast<underlying_type>(flag);
+        }
+
+        return *this;
+    }
+
+    constexpr auto unset(E flag) noexcept -> bitflags & { return set(flag, false); }
+
+    constexpr auto toggle(E flag) noexcept -> bitflags &
+    {
+        bits_ ^= static_cast<underlying_type>(flag);
+        return *this;
+    }
+
+    constexpr auto clear() noexcept -> void { bits_ = 0; }
+
+    constexpr auto operator|=(bitflags rhs) noexcept -> bitflags &
+    {
+        bits_ |= rhs.bits_;
+        return *this;
+    }
+
+    constexpr auto operator&=(bitflags rhs) noexcept -> bitflags &
+    {
+        bits_ &= rhs.bits_;
+        return *this;
+    }
+
+    constexpr auto operator^=(bitflags rhs) noexcept -> bitflags &
+    {
+        bits_ ^= rhs.bits_;
+        return *this;
+    }
+
+    [[nodiscard]] friend constexpr auto operator|(bitflags lhs, bitflags rhs) noexcept -> bitflags
+    {
+        return bitflags{ static_cast<underlying_type>(lhs.bits_ | rhs.bits_) };
+    }
+
+    [[nodiscard]] friend constexpr auto operator&(bitflags lhs, bitflags rhs) noexcept -> bitflags
+    {
+        return bitflags{ static_cast<underlying_type>(lhs.bits_ & rhs.bits_) };
+    }
+
+    [[nodiscard]] friend constexpr auto operator^(bitflags lhs, bitflags rhs) noexcept -> bitflags
+    {
+        return bitflags{ static_cast<underlying_type>(lhs.bits_ ^ rhs.bits_) };
+    }
+
+    [[nodiscard]] friend constexpr auto operator~(bitflags rhs) noexcept -> bitflags
+    {
+        return bitflags{ static_cast<underlying_type>(~rhs.bits_)
+                         & static_cast<underlying_type>(detail::known_mask<E>()) };
+    }
+
+    [[nodiscard]] friend constexpr auto operator==(bitflags lhs, bitflags rhs) noexcept -> bool
+    {
+        return lhs.bits_ == rhs.bits_;
+    }
+
+    [[nodiscard]] friend constexpr auto operator!=(bitflags lhs, bitflags rhs) noexcept -> bool
+    {
+        return lhs.bits_ != rhs.bits_;
+    }
+
+private:
+    explicit constexpr bitflags(underlying_type bits) noexcept
+        : bits_(bits)
+    {
+    }
+
+    underlying_type bits_{ 0 };
+};
+
+template <typename E, std::enable_if_t<is_bitmask_enum_v<E>, int> = 0>
+constexpr auto get_enum_table([[maybe_unused]] bitflags<E> *ptr) noexcept
+{
+    return get_enum_table(static_cast<E *>(nullptr));
 }
 
 } // namespace linyaps_box::utils
 
-template <typename E, typename = std::enable_if_t<linyaps_box::utils::is_bitmask_enum_v<E>>>
-[[nodiscard]] constexpr E operator|(E lhs, E rhs) noexcept
+template <typename E, std::enable_if_t<linyaps_box::utils::is_bitmask_enum_v<E>, int> = 0>
+[[nodiscard]] constexpr auto operator|(E lhs, E rhs) noexcept -> linyaps_box::utils::bitflags<E>
 {
-    using U = linyaps_box::utils::enum_underlying_t<E>;
-    return static_cast<E>(static_cast<U>(lhs) | static_cast<U>(rhs));
+    return linyaps_box::utils::bitflags<E>(lhs) | linyaps_box::utils::bitflags<E>(rhs);
 }
 
-template <typename E, typename = std::enable_if_t<linyaps_box::utils::is_bitmask_enum_v<E>>>
-[[nodiscard]] constexpr E operator&(E lhs, E rhs) noexcept
+template <typename E, std::enable_if_t<linyaps_box::utils::is_bitmask_enum_v<E>, int> = 0>
+[[nodiscard]] constexpr auto operator&(E lhs, E rhs) noexcept -> linyaps_box::utils::bitflags<E>
 {
-    using U = linyaps_box::utils::enum_underlying_t<E>;
-    return static_cast<E>(static_cast<U>(lhs) & static_cast<U>(rhs));
+    return linyaps_box::utils::bitflags<E>(lhs) & linyaps_box::utils::bitflags<E>(rhs);
 }
 
-template <typename E, typename = std::enable_if_t<linyaps_box::utils::is_bitmask_enum_v<E>>>
-[[nodiscard]] constexpr E operator^(E lhs, E rhs) noexcept
+template <typename E, std::enable_if_t<linyaps_box::utils::is_bitmask_enum_v<E>, int> = 0>
+[[nodiscard]] constexpr auto operator^(E lhs, E rhs) noexcept -> linyaps_box::utils::bitflags<E>
 {
-    using U = linyaps_box::utils::enum_underlying_t<E>;
-    return static_cast<E>(static_cast<U>(lhs) ^ static_cast<U>(rhs));
+    return linyaps_box::utils::bitflags<E>(lhs) ^ linyaps_box::utils::bitflags<E>(rhs);
 }
 
-template <typename E, typename = std::enable_if_t<linyaps_box::utils::is_bitmask_enum_v<E>>>
-[[nodiscard]] constexpr E operator~(E rhs) noexcept
+template <typename E, std::enable_if_t<linyaps_box::utils::is_bitmask_enum_v<E>, int> = 0>
+[[nodiscard]] constexpr auto operator~(E rhs) noexcept -> linyaps_box::utils::bitflags<E>
 {
-    using U = linyaps_box::utils::enum_underlying_t<E>;
-    return static_cast<E>(~static_cast<U>(rhs) & linyaps_box::utils::bitmask_mask<E>());
+    return ~linyaps_box::utils::bitflags<E>(rhs);
 }
 
-template <typename E, typename = std::enable_if_t<linyaps_box::utils::is_bitmask_enum_v<E>>>
+template <typename E, std::enable_if_t<linyaps_box::utils::is_bitmask_enum_v<E>, int> = 0>
 constexpr E &operator|=(E &lhs, E rhs) noexcept
 {
-    return lhs = lhs | rhs;
+    using U = linyaps_box::utils::detail::enum_underlying_t<E>;
+    return lhs = static_cast<E>(static_cast<U>(lhs) | static_cast<U>(rhs));
 }
 
-template <typename E, typename = std::enable_if_t<linyaps_box::utils::is_bitmask_enum_v<E>>>
+template <typename E, std::enable_if_t<linyaps_box::utils::is_bitmask_enum_v<E>, int> = 0>
 constexpr E &operator&=(E &lhs, E rhs) noexcept
 {
-    return lhs = lhs & rhs;
+    using U = linyaps_box::utils::detail::enum_underlying_t<E>;
+    return lhs = static_cast<E>(static_cast<U>(lhs) & static_cast<U>(rhs));
 }
 
-template <typename E, typename = std::enable_if_t<linyaps_box::utils::is_bitmask_enum_v<E>>>
+template <typename E, std::enable_if_t<linyaps_box::utils::is_bitmask_enum_v<E>, int> = 0>
 constexpr E &operator^=(E &lhs, E rhs) noexcept
 {
-    return lhs = lhs ^ rhs;
+    using U = linyaps_box::utils::detail::enum_underlying_t<E>;
+    return lhs = static_cast<E>(static_cast<U>(lhs) ^ static_cast<U>(rhs));
 }
 
-// Opts an enum into bitmask operators. Write it inside the enum body; it
-// injects the sentinel enumerator LINYAPS_BITMASK_LARGEST_ENUMERATOR holding the
-// highest flag bit, which bounds operator~ to the defined flag range.
-//
-// The argument must be the *enumerator* with the highest flag bit, NOT a
-// literal: its value is bound to the platform macro at the enum definition site
-// (e.g. `tmpfile = O_TMPFILE`), so it tracks the platform automatically. It must
-// stay the true maximum on every platform this code compiles on; for
-// table-registered enums verify_enum_table() enforces that at compile time.
-#define LINYAPS_MARK_AS_BITMASK_ENUM(LargestValue) LINYAPS_BITMASK_LARGEST_ENUMERATOR = LargestValue
+#define LINYAPS_ENABLE_BITMASK_ENUM(E)                                           \
+    [[maybe_unused]] constexpr ::std::true_type enable_bitmask_enum_tag(         \
+      [[maybe_unused]] E *ptr) noexcept /* NOLINT(bugprone-macro-parentheses) */ \
+    {                                                                            \
+        return { };                                                              \
+    }
 
-// GCC 8's constexpr evaluator may default-construct + copy the table
-// when binding a reference inside a direct static_assert(verify(table)).
-// Assigning to a constexpr variable first avoids that path.
-#define LINYAPS_REGISTER_ENUM(E, ...)                                                     \
-    constexpr auto get_enum_table(E *) noexcept                                           \
-    {                                                                                     \
-        constexpr auto table = ::linyaps_box::utils::make_enum_table<E>({ __VA_ARGS__ }); \
-        constexpr auto valid = ::linyaps_box::utils::verify_enum_table(table);            \
-        static_assert(valid,                                                              \
-                      "enum_table validation failed for " #E                              \
-                      ": duplicate name or value detected!");                             \
-        return table;                                                                     \
+#define LINYAPS_REGISTER_ENUM_TABLE(E, COUNT, ...)                                                \
+    constexpr auto get_enum_table([[maybe_unused]] E *ptr) noexcept                               \
+    {                                                                                             \
+        constexpr auto table = ::linyaps_box::utils::make_enum_table<E>(#E, { __VA_ARGS__ });     \
+        constexpr auto valid = ::linyaps_box::utils::verify_enum_table(table);                    \
+        static_assert(valid,                                                                      \
+                      "enum_table validation failed for " #E                                      \
+                      ": duplicate name or value detected!");                                     \
+        static_assert(table.entries().size() == static_cast<std::size_t>(COUNT),                  \
+                      "enum_table entry count mismatch for " #E ": expected " #COUNT " entries"); \
+        return table;                                                                             \
     }

--- a/src/linyaps_box/utils/file_describer.cpp
+++ b/src/linyaps_box/utils/file_describer.cpp
@@ -217,7 +217,7 @@ auto linyaps_box::utils::file_descriptor::flags() const -> unsigned int
         throw std::system_error(res.error());
     }
 
-    return static_cast<int>(res->flags());
+    return res->flags().to_raw();
 }
 
 auto linyaps_box::utils::file_descriptor::set_flags(unsigned int flags) const & -> void

--- a/src/linyaps_box/utils/utils.h
+++ b/src/linyaps_box/utils/utils.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <chrono>
 #include <random>
 #include <string>
@@ -19,6 +20,21 @@
 #endif
 
 namespace linyaps_box::utils {
+
+namespace detail {
+template <typename T, std::size_t N, std::size_t... I>
+constexpr std::array<std::remove_cv_t<T>, N> to_array_impl(T (&arr)[N], std::index_sequence<I...>)
+{
+    return { { arr[I]... } };
+}
+
+template <typename T, std::size_t N, std::size_t... I>
+constexpr std::array<std::remove_cv_t<T>, N> to_array_impl(T (&&arr)[N], std::index_sequence<I...>)
+{
+    return { { std::move(arr[I])... } };
+}
+
+} // namespace detail
 
 template <typename... T>
 struct Overload : T...
@@ -94,5 +110,18 @@ struct uninit_allocator
 
 template <typename T>
 using uninit_vector = std::vector<T, uninit_allocator<T>>;
+
+// c++ 20 to_array
+template <typename T, std::size_t N>
+constexpr auto to_array(T (&arr)[N]) noexcept
+{
+    return detail::to_array_impl(arr, std::make_index_sequence<N>{ });
+}
+
+template <typename T, std::size_t N>
+constexpr auto to_array(T (&&arr)[N]) noexcept
+{
+    return detail::to_array_impl(std::move(arr), std::make_index_sequence<N>{ });
+}
 
 } // namespace linyaps_box::utils


### PR DESCRIPTION
Old LINYAPS_MARK_AS_BITMASK_ENUM injected a largest-flag sentinel into the enum body to detect bitmask support and bound operator~. The sentinel leaked into enclosing scope for unscoped enums, and its hand-maintained "max flag" invariant broke for flags whose values vary across platforms (e.g. SOCK_CLOEXEC), making the hardcoded bound unsafe.

Introduce non-intrusive LINYAPS_ENABLE_BITMASK_ENUM + bitflags<E> value type. known_mask derives from the registered enum table, which is the source of truth, so platform-varying flag values track automatically. LINYAPS_REGISTER_ENUM_TABLE now takes an explicit entry count, and operator~ is bounded to known_mask.

Migrates fs, net, config, rootfs, and unix_socket call sites.