### PR TITLE
feat(config): add scoped OCI config module

### DIFF
--- a/src/linyaps_box/config/block_io.cpp
+++ b/src/linyaps_box/config/block_io.cpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/block_io.h"
+
+#include "linyaps_box/config/utils.h"
+#include "linyaps_box/utils/utils.h"
+
+#include <nlohmann/json.hpp>
+
+#include <string_view>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, block_io::weight_device &v)
+{
+    j.at("major").get_to(v.major);
+    j.at("minor").get_to(v.minor);
+
+    if (auto it = j.find("weight"); it != j.end() && !it->is_null()) {
+        it->get_to(v.weight.emplace());
+    }
+
+    if (auto it = j.find("leafWeight"); it != j.end() && !it->is_null()) {
+        it->get_to(v.leaf_weight.emplace());
+    }
+}
+
+void from_json(const nlohmann::json &j, block_io::throttle_device &v)
+{
+    j.at("major").get_to(v.major);
+    j.at("minor").get_to(v.minor);
+    j.at("rate").get_to(v.rate);
+}
+
+void from_json(const nlohmann::json &j, block_io &v)
+{
+    for (const auto &[key, val] : j.items()) {
+        const auto k = std::string_view{ key };
+        if (key_matches(k, "weight")) {
+            if (!val.is_null()) {
+                val.get_to(v.weight.emplace());
+            }
+        } else if (key_matches(k, "leafWeight")) {
+            if (!val.is_null()) {
+                val.get_to(v.leaf_weight.emplace());
+            }
+        } else if (key_matches(k, "weightDevice")) {
+            if (!val.is_null()) {
+                val.get_to(v.weight_devices.emplace());
+            }
+        } else if (key_matches(k, "throttleReadBpsDevice")) {
+            if (!val.is_null()) {
+                val.get_to(v.throttle_read_bps_device.emplace());
+            }
+        } else if (key_matches(k, "throttleWriteBpsDevice")) {
+            if (!val.is_null()) {
+                val.get_to(v.throttle_write_bps_device.emplace());
+            }
+        } else if (key_matches(k, "throttleReadIOPSDevice")) {
+            if (!val.is_null()) {
+                val.get_to(v.throttle_read_iops_device.emplace());
+            }
+        } else if (key_matches(k, "throttleWriteIOPSDevice")) {
+            if (!val.is_null()) {
+                val.get_to(v.throttle_write_iops_device.emplace());
+            }
+        }
+    }
+}
+
+void validate(const block_io::weight_device &v)
+{
+    if (UNLIKELY(!v.weight && !v.leaf_weight)) {
+        throw std::runtime_error("block_io weightDevice requires weight or leafWeight");
+    }
+}
+
+void validate(const block_io &v)
+{
+    if (!v.weight_devices) {
+        return;
+    }
+
+    std::for_each(v.weight_devices->cbegin(), v.weight_devices->cend(), [](const auto &d) {
+        validate(d);
+    });
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/block_io.h
+++ b/src/linyaps_box/config/block_io.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace linyaps_box::config {
+
+struct block_io
+{
+    struct weight_device
+    {
+        int64_t major;
+        int64_t minor;
+        std::optional<uint16_t> weight;
+        std::optional<uint16_t> leaf_weight;
+    };
+
+    struct throttle_device
+    {
+        int64_t major;
+        int64_t minor;
+        uint64_t rate;
+    };
+
+    std::optional<uint16_t> weight;
+    std::optional<uint16_t> leaf_weight;
+    std::optional<std::vector<weight_device>> weight_devices;
+    std::optional<std::vector<throttle_device>> throttle_read_bps_device;
+    std::optional<std::vector<throttle_device>> throttle_write_bps_device;
+    std::optional<std::vector<throttle_device>> throttle_read_iops_device;
+    std::optional<std::vector<throttle_device>> throttle_write_iops_device;
+};
+
+void from_json(const nlohmann::json &j, block_io::weight_device &v);
+
+void validate(const block_io::weight_device &v);
+
+void from_json(const nlohmann::json &j, block_io::throttle_device &v);
+
+void from_json(const nlohmann::json &j, block_io &v);
+
+void validate(const block_io &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/capabilities.cpp
+++ b/src/linyaps_box/config/capabilities.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/capabilities.h"
+
+#include "linyaps_box/config/utils.h"
+
+#include <nlohmann/json.hpp>
+
+#include <string_view>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, capabilities &v)
+{
+    auto parse_set = [](const nlohmann::json &j, std::vector<std::string> &set) {
+        set.reserve(j.size());
+        for (const auto &elem : j) {
+            set.push_back(elem.get<std::string>());
+        }
+    };
+
+    for (const auto &[key, val] : j.items()) {
+        const auto k = std::string_view{ key };
+        if (key_matches(k, "effective")) {
+            if (!val.is_null()) {
+                parse_set(val, v.effective.emplace());
+            }
+        } else if (key_matches(k, "ambient")) {
+            if (!val.is_null()) {
+                parse_set(val, v.ambient.emplace());
+            }
+        } else if (key_matches(k, "bounding")) {
+            if (!val.is_null()) {
+                parse_set(val, v.bounding.emplace());
+            }
+        } else if (key_matches(k, "inheritable")) {
+            if (!val.is_null()) {
+                parse_set(val, v.inheritable.emplace());
+            }
+        } else if (key_matches(k, "permitted")) {
+            if (!val.is_null()) {
+                parse_set(val, v.permitted.emplace());
+            }
+        }
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/capabilities.h
+++ b/src/linyaps_box/config/capabilities.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace linyaps_box::config {
+
+struct capabilities
+{
+    std::optional<std::vector<std::string>> effective;
+    std::optional<std::vector<std::string>> bounding;
+    std::optional<std::vector<std::string>> inheritable;
+    std::optional<std::vector<std::string>> permitted;
+    std::optional<std::vector<std::string>> ambient;
+};
+
+void from_json(const nlohmann::json &j, capabilities &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/console_size.cpp
+++ b/src/linyaps_box/config/console_size.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/console_size.h"
+
+#include <nlohmann/json.hpp>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, console_size &v)
+{
+    j.at("height").get_to(v.height);
+    j.at("width").get_to(v.width);
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/console_size.h
+++ b/src/linyaps_box/config/console_size.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+namespace linyaps_box::config {
+
+struct console_size
+{
+    unsigned short height;
+    unsigned short width;
+};
+
+void from_json(const nlohmann::json &j, console_size &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/cpu.cpp
+++ b/src/linyaps_box/config/cpu.cpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/cpu.h"
+
+#include "linyaps_box/config/utils.h"
+#include "linyaps_box/utils/utils.h"
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, cpu &v)
+{
+    for (const auto &[key, val] : j.items()) {
+        const auto k = std::string_view{ key };
+        if (key_matches(k, "shares")) {
+            if (!val.is_null()) {
+                val.get_to(v.shares.emplace());
+            }
+        } else if (key_matches(k, "quota")) {
+            if (!val.is_null()) {
+                val.get_to(v.quota.emplace());
+            }
+        } else if (key_matches(k, "burst")) {
+            if (!val.is_null()) {
+                val.get_to(v.burst.emplace());
+            }
+        } else if (key_matches(k, "period")) {
+            if (!val.is_null()) {
+                val.get_to(v.period.emplace());
+            }
+        } else if (key_matches(k, "realtimeRuntime")) {
+            if (!val.is_null()) {
+                val.get_to(v.realtime_runtime.emplace());
+            }
+        } else if (key_matches(k, "realtimePeriod")) {
+            if (!val.is_null()) {
+                val.get_to(v.realtime_period.emplace());
+            }
+        } else if (key_matches(k, "cpus")) {
+            if (!val.is_null()) {
+                v.cpus = parse_range_list(val.get_ref<const std::string &>());
+            }
+        } else if (key_matches(k, "mems")) {
+            if (!val.is_null()) {
+                v.mems = parse_range_list(val.get_ref<const std::string &>());
+            }
+        } else if (key_matches(k, "idle")) {
+            if (!val.is_null()) {
+                auto idle_val = val.get<int64_t>();
+                if (UNLIKELY(idle_val != 0 && idle_val != 1)) {
+                    throw std::runtime_error(fmt::format("cpu.idle must be 0 or 1: {}", idle_val));
+                }
+
+                v.idle_.emplace((idle_val == 1) ? cpu::idle::idle : cpu::idle::none);
+            }
+        }
+    }
+}
+
+void validate(const cpu &v)
+{
+    if (UNLIKELY(v.quota && *v.quota > 0 && v.burst
+                 && *v.burst > static_cast<uint64_t>(*v.quota))) {
+        throw std::runtime_error("cpu.quota must be no smaller than cpu.burst");
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/cpu.h
+++ b/src/linyaps_box/config/cpu.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace linyaps_box::config {
+
+struct cpu
+{
+    enum class idle : uint8_t { none, idle };
+
+    std::optional<uint64_t> shares;
+    std::optional<int64_t> quota;
+    std::optional<uint64_t> burst;
+    std::optional<uint64_t> period;
+    std::optional<int64_t> realtime_runtime;
+    std::optional<uint64_t> realtime_period;
+    std::optional<std::vector<unsigned int>> cpus;
+    std::optional<std::vector<unsigned int>> mems;
+    std::optional<idle> idle_;
+};
+
+void from_json(const nlohmann::json &j, cpu &v);
+
+void validate(const cpu &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/device.cpp
+++ b/src/linyaps_box/config/device.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/device.h"
+
+#include "linyaps_box/config/utils.h"
+#include "linyaps_box/utils/utils.h"
+
+#include <fmt/std.h>
+#include <nlohmann/json.hpp>
+
+#include <stdexcept>
+#include <string_view>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, device &v)
+{
+    constexpr auto device_type_table = get_enum_table_from<device::type>();
+    bool have_type{ false };
+    bool have_path{ false };
+    for (const auto &[key, val] : j.items()) {
+        const auto k = std::string_view{ key };
+        if (key_matches(k, "type")) {
+            auto type_str = val.get<std::string_view>();
+            auto type_opt = device_type_table.from_name(type_str);
+            if (UNLIKELY(!type_opt)) {
+                throw std::runtime_error(
+                  fmt::format("device.type must be one of c/b/u/p: {}", type_str));
+            }
+
+            v.type_ = *type_opt;
+            have_type = true;
+        } else if (key_matches(k, "path")) {
+            val.get_to(v.path);
+            have_path = true;
+        } else if (key_matches(k, "fileMode")) {
+            if (!val.is_null()) {
+                val.get_to(v.mode.emplace());
+            }
+        } else if (key_matches(k, "major")) {
+            if (!val.is_null()) {
+                val.get_to(v.major.emplace());
+            }
+        } else if (key_matches(k, "minor")) {
+            if (!val.is_null()) {
+                val.get_to(v.minor.emplace());
+            }
+        } else if (key_matches(k, "uid")) {
+            if (!val.is_null()) {
+                val.get_to(v.uid.emplace());
+            }
+        } else if (key_matches(k, "gid")) {
+            if (!val.is_null()) {
+                val.get_to(v.gid.emplace());
+            }
+        }
+    }
+
+    if (UNLIKELY(!have_type)) {
+        throw std::runtime_error("device.type is required");
+    }
+    if (UNLIKELY(!have_path)) {
+        throw std::runtime_error("device.path is required");
+    }
+}
+
+void validate(const device &v)
+{
+    if (UNLIKELY(!v.path.is_absolute())) {
+        throw std::runtime_error(fmt::format("device.path must be an absolute path: {}", v.path));
+    }
+
+    if (UNLIKELY(v.type_ != device::type::fifo && (!v.major || !v.minor))) {
+        throw std::runtime_error("device.major and device.minor are required unless type is p");
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/device.h
+++ b/src/linyaps_box/config/device.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/utils/enum_traits.h"
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+
+namespace linyaps_box::config {
+
+struct device
+{
+    enum class type : std::uint8_t { character, unbuffered_character, block, fifo };
+
+    type type_{ type::character };
+    std::filesystem::path path;
+    std::optional<uint32_t> major;
+    std::optional<uint32_t> minor;
+    std::optional<uint32_t> mode;
+    std::optional<uint32_t> uid;
+    std::optional<uint32_t> gid;
+};
+
+LINYAPS_REGISTER_ENUM_TABLE(device::type,
+                            4,
+                            { device::type::character, "c" },
+                            { device::type::block, "b" },
+                            { device::type::unbuffered_character, "u" },
+                            { device::type::fifo, "p" })
+
+void from_json(const nlohmann::json &j, device &v);
+
+void validate(const device &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/device_rule.cpp
+++ b/src/linyaps_box/config/device_rule.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/device_rule.h"
+
+#include "linyaps_box/config/utils.h"
+#include "linyaps_box/utils/utils.h"
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <string_view>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, device_rule &v)
+{
+    bool have_allow{ false };
+    for (const auto &[key, val] : j.items()) {
+        const auto k = std::string_view{ key };
+        if (key_matches(k, "allow")) {
+            val.get_to(v.allow);
+            have_allow = true;
+        } else if (key_matches(k, "type")) {
+            if (!val.is_null()) {
+                auto type_name = val.get<std::string_view>();
+                auto type_opt = get_enum_table_from<device_rule::type>().from_name(type_name);
+                if (UNLIKELY(!type_opt)) {
+                    throw std::runtime_error(
+                      fmt::format("device_rule.type must be one of a/c/b: {}", type_name));
+                }
+
+                v.type_ = *type_opt;
+            }
+        } else if (key_matches(k, "major")) {
+            if (!val.is_null()) {
+                val.get_to(v.major.emplace());
+            }
+        } else if (key_matches(k, "minor")) {
+            if (!val.is_null()) {
+                val.get_to(v.minor.emplace());
+            }
+        } else if (key_matches(k, "access")) {
+            if (!val.is_null()) {
+                auto access_str = val.get_ref<const std::string &>();
+                auto access_flags{ device_rule::access_flag::none };
+                for (const auto c : access_str) {
+                    auto flag_opt = get_enum_table_from<device_rule::access_flag>().from_name(
+                      std::string_view(&c, 1));
+                    if (UNLIKELY(!flag_opt)) {
+                        throw std::runtime_error(
+                          fmt::format("device_rule.access must be a composition of r/w/m: {}", c));
+                    }
+
+                    access_flags |= *flag_opt;
+                }
+
+                v.access = access_flags;
+            }
+        }
+    }
+
+    if (UNLIKELY(!have_allow)) {
+        throw std::runtime_error("device_rule.allow is required");
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/device_rule.h
+++ b/src/linyaps_box/config/device_rule.h
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/utils/enum_traits.h"
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <optional>
+
+namespace linyaps_box::config {
+
+struct device_rule
+{
+    enum class type : std::uint8_t { all, character, block };
+
+    enum class access_flag : std::uint8_t {
+        none = 0U,
+        read = (1U << 0),
+        write = (1U << 1),
+        mknod = (1U << 2),
+    };
+
+    bool allow;
+    std::optional<type> type_;
+    std::optional<int64_t> major;
+    std::optional<int64_t> minor;
+    std::optional<access_flag> access;
+};
+
+LINYAPS_ENABLE_BITMASK_ENUM(device_rule::access_flag);
+
+LINYAPS_REGISTER_ENUM_TABLE(device_rule::type,
+                            3,
+                            { device_rule::type::all, "a" },
+                            { device_rule::type::character, "c" },
+                            { device_rule::type::block, "b" })
+
+LINYAPS_REGISTER_ENUM_TABLE(device_rule::access_flag,
+                            3,
+                            { device_rule::access_flag::read, "r" },
+                            { device_rule::access_flag::write, "w" },
+                            { device_rule::access_flag::mknod, "m" })
+
+void from_json(const nlohmann::json &j, device_rule &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/exec_cpu_affinity.cpp
+++ b/src/linyaps_box/config/exec_cpu_affinity.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/exec_cpu_affinity.h"
+
+#include <nlohmann/json.hpp>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, exec_cpu_affinity &v)
+{
+    if (auto it = j.find("initial"); it != j.end() && !it->is_null()) {
+        it->get_to(v.initial.emplace());
+    }
+
+    if (auto it = j.find("final"); it != j.end() && !it->is_null()) {
+        it->get_to(v.final.emplace());
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/exec_cpu_affinity.h
+++ b/src/linyaps_box/config/exec_cpu_affinity.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <optional>
+#include <string>
+
+namespace linyaps_box::config {
+
+struct exec_cpu_affinity
+{
+    std::optional<std::string> initial;
+    std::optional<std::string> final;
+};
+
+void from_json(const nlohmann::json &j, exec_cpu_affinity &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/hook.cpp
+++ b/src/linyaps_box/config/hook.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/hook.h"
+
+#include "linyaps_box/utils/environ.h"
+#include "linyaps_box/utils/utils.h"
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, hook &v)
+{
+    j.at("path").get_to(v.path);
+
+    if (auto it = j.find("args"); it != j.end() && !it->is_null()) {
+        it->get_to(v.args.emplace());
+    }
+
+    if (auto it = j.find("env"); it != j.end() && !it->is_null()) {
+        it->get_to(v.env.emplace());
+    }
+
+    if (auto it = j.find("timeout"); it != j.end() && !it->is_null()) {
+        it->get_to(v.timeout.emplace());
+    }
+}
+
+void validate(std::string_view label, const hook &v)
+{
+    if (UNLIKELY(!v.path.is_absolute())) {
+        throw std::runtime_error(fmt::format("{} hook path must be absolute", label));
+    }
+
+    if (v.env) {
+        auto invalid = std::find_if(v.env->cbegin(), v.env->cend(), utils::is_invalid_env);
+        if (UNLIKELY(invalid != v.env->cend())) {
+            throw std::runtime_error(
+              fmt::format("{} hook.env contains a invalid env: {}", label, *invalid));
+        }
+    }
+
+    if (UNLIKELY(v.timeout && *v.timeout <= 0)) {
+        throw std::runtime_error(fmt::format("{} hook timeout must be greater than zero", label));
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/hook.h
+++ b/src/linyaps_box/config/hook.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace linyaps_box::config {
+
+struct hook
+{
+    std::filesystem::path path;
+    std::optional<std::vector<std::string>> args;
+    std::optional<std::vector<std::string>> env;
+    std::optional<int> timeout;
+};
+
+void from_json(const nlohmann::json &j, hook &v);
+
+void validate(std::string_view label, const hook &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/hooks.cpp
+++ b/src/linyaps_box/config/hooks.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/hooks.h"
+
+#include "linyaps_box/config/utils.h"
+
+#include <nlohmann/json.hpp>
+
+#include <string_view>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, hooks &v)
+{
+    for (const auto &[key, val] : j.items()) {
+        const auto k = std::string_view{ key };
+        if (key_matches(k, "prestart")) {
+            if (!val.is_null()) {
+                val.get_to(v.prestart.emplace());
+            }
+        } else if (key_matches(k, "createRuntime")) {
+            if (!val.is_null()) {
+                val.get_to(v.create_runtime.emplace());
+            }
+        } else if (key_matches(k, "createContainer")) {
+            if (!val.is_null()) {
+                val.get_to(v.create_container.emplace());
+            }
+        } else if (key_matches(k, "startContainer")) {
+            if (!val.is_null()) {
+                val.get_to(v.start_container.emplace());
+            }
+        } else if (key_matches(k, "poststart")) {
+            if (!val.is_null()) {
+                val.get_to(v.poststart.emplace());
+            }
+        } else if (key_matches(k, "poststop")) {
+            if (!val.is_null()) {
+                val.get_to(v.poststop.emplace());
+            }
+        }
+    }
+}
+
+void validate(const hooks &v)
+{
+    auto validate_hooks = [](std::string_view label, const auto &hooks) {
+        for (const auto &h : hooks) {
+            validate(label, h);
+        }
+    };
+
+    if (v.prestart) {
+        validate_hooks("prestart", *v.prestart);
+    }
+
+    if (v.create_runtime) {
+        validate_hooks("create_runtime", *v.create_runtime);
+    }
+
+    if (v.create_container) {
+        validate_hooks("create_container", *v.create_container);
+    }
+
+    if (v.start_container) {
+        validate_hooks("start_container", *v.start_container);
+    }
+
+    if (v.poststart) {
+        validate_hooks("poststart", *v.poststart);
+    }
+
+    if (v.poststop) {
+        validate_hooks("poststop", *v.poststop);
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/hooks.h
+++ b/src/linyaps_box/config/hooks.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/config/hook.h"
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <optional>
+#include <vector>
+
+namespace linyaps_box::config {
+
+struct hooks
+{
+    std::optional<std::vector<hook>> prestart;
+    std::optional<std::vector<hook>> create_runtime;
+    std::optional<std::vector<hook>> create_container;
+    std::optional<std::vector<hook>> start_container;
+    std::optional<std::vector<hook>> poststart;
+    std::optional<std::vector<hook>> poststop;
+};
+
+void from_json(const nlohmann::json &j, hooks &v);
+
+void validate(const hooks &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/hugepage.cpp
+++ b/src/linyaps_box/config/hugepage.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/hugepage.h"
+
+#include <nlohmann/json.hpp>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, hugepage_limit &v)
+{
+    j.at("pageSize").get_to(v.page_size);
+    j.at("limit").get_to(v.limit);
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/hugepage.h
+++ b/src/linyaps_box/config/hugepage.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <string>
+
+namespace linyaps_box::config {
+
+struct hugepage_limit
+{
+    std::string page_size;
+    uint64_t limit;
+};
+
+void from_json(const nlohmann::json &j, hugepage_limit &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/id_mapping.cpp
+++ b/src/linyaps_box/config/id_mapping.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/id_mapping.h"
+
+#include <nlohmann/json.hpp>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, id_mapping &v)
+{
+    j.at("hostID").get_to(v.host_id);
+    j.at("containerID").get_to(v.container_id);
+    j.at("size").get_to(v.size);
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/id_mapping.h
+++ b/src/linyaps_box/config/id_mapping.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+
+#include <sys/types.h>
+
+namespace linyaps_box::config {
+
+struct id_mapping
+{
+    uid_t host_id;
+    uid_t container_id;
+    uint32_t size;
+};
+
+void from_json(const nlohmann::json &j, id_mapping &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/intel_rdt.cpp
+++ b/src/linyaps_box/config/intel_rdt.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/intel_rdt.h"
+
+#include "linyaps_box/config/utils.h"
+
+#include <nlohmann/json.hpp>
+
+#include <string_view>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, intel_rdt &v)
+{
+    for (const auto &[key, val] : j.items()) {
+        const auto k = std::string_view{ key };
+        if (key_matches(k, "closID")) {
+            if (!val.is_null()) {
+                val.get_to(v.clos_id.emplace());
+            }
+        } else if (key_matches(k, "l3CacheSchema")) {
+            if (!val.is_null()) {
+                val.get_to(v.l3_cache_schema.emplace());
+            }
+        } else if (key_matches(k, "memBwSchema")) {
+            if (!val.is_null()) {
+                val.get_to(v.memory_bandwidth_schema.emplace());
+            }
+        } else if (key_matches(k, "schemata")) {
+            if (!val.is_null()) {
+                val.get_to(v.schemata.emplace());
+            }
+        } else if (key_matches(k, "enableMonitoring")) {
+            if (!val.is_null()) {
+                val.get_to(v.enable_monitoring.emplace());
+            }
+        }
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/intel_rdt.h
+++ b/src/linyaps_box/config/intel_rdt.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace linyaps_box::config {
+
+struct intel_rdt
+{
+    std::optional<std::string> clos_id;
+    std::optional<std::string> l3_cache_schema;
+    std::optional<std::string> memory_bandwidth_schema;
+    std::optional<std::vector<std::string>> schemata;
+    std::optional<bool> enable_monitoring;
+};
+
+void from_json(const nlohmann::json &j, intel_rdt &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/io_priority.cpp
+++ b/src/linyaps_box/config/io_priority.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/io_priority.h"
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <stdexcept>
+#include <string_view>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, io_priority &v)
+{
+    auto name = j.at("class").get<std::string_view>();
+    auto opt = get_enum_table_from<io_priority::class_t>().from_name(name);
+    if (UNLIKELY(!opt)) {
+        throw std::runtime_error(fmt::format("unknown I/O priority class: {}", name));
+    }
+
+    v.class_ = *opt;
+    v.priority = j.value("priority", 0);
+}
+
+void validate(const io_priority &v)
+{
+    if (UNLIKELY(v.priority < 0 || v.priority > 7)) {
+        throw std::runtime_error(
+          fmt::format("io priority must be in range [0, 7], got: {}", v.priority));
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/io_priority.h
+++ b/src/linyaps_box/config/io_priority.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/utils/enum_traits.h"
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+
+namespace linyaps_box::config {
+
+struct io_priority
+{
+    enum class class_t : uint8_t { rt, best_effort, idle };
+
+    class_t class_;
+    int priority;
+};
+
+LINYAPS_REGISTER_ENUM_TABLE(io_priority::class_t,
+                            3,
+                            { io_priority::class_t::rt, "IOPRIO_CLASS_RT" },
+                            { io_priority::class_t::best_effort, "IOPRIO_CLASS_BE" },
+                            { io_priority::class_t::idle, "IOPRIO_CLASS_IDLE" })
+
+void from_json(const nlohmann::json &j, io_priority &v);
+
+void validate(const io_priority &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/linux.cpp
+++ b/src/linyaps_box/config/linux.cpp
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/linux.h"
+
+#include "linyaps_box/config/utils.h"
+
+#include <fmt/std.h>
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+#include <string_view>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, linux &v)
+{
+    for (const auto &[key, val] : j.items()) {
+        const auto k = std::string_view{ key };
+        if (key_matches(k, "uidMappings")) {
+            if (!val.is_null()) {
+                val.get_to(v.uid_mappings.emplace());
+            }
+        } else if (key_matches(k, "gidMappings")) {
+            if (!val.is_null()) {
+                val.get_to(v.gid_mappings.emplace());
+            }
+        } else if (key_matches(k, "namespaces")) {
+            if (!val.is_null()) {
+                val.get_to(v.namespaces.emplace());
+            }
+        } else if (key_matches(k, "devices")) {
+            if (!val.is_null()) {
+                val.get_to(v.devices.emplace());
+            }
+        } else if (key_matches(k, "netDevices")) {
+            if (!val.is_null()) {
+                val.get_to(v.network_devices.emplace());
+            }
+        } else if (key_matches(k, "cgroupsPath")) {
+            if (!val.is_null()) {
+                val.get_to(v.cgroups_path.emplace());
+            }
+        } else if (key_matches(k, "maskedPaths")) {
+            if (!val.is_null()) {
+                val.get_to(v.masked_paths.emplace());
+            }
+        } else if (key_matches(k, "readonlyPaths")) {
+            if (!val.is_null()) {
+                val.get_to(v.readonly_paths.emplace());
+            }
+        } else if (key_matches(k, "mountLabel")) {
+            if (!val.is_null()) {
+                val.get_to(v.mount_label.emplace());
+            }
+        } else if (key_matches(k, "rootfsPropagation")) {
+            if (!val.is_null()) {
+                auto prop_name = val.get<std::string_view>();
+                auto prop_opt = get_enum_table_from<rootfs_propagation>().from_name(prop_name);
+                if (UNLIKELY(!prop_opt)) {
+                    throw std::runtime_error(
+                      fmt::format("unknown rootfsPropagation value: {}", prop_name));
+                }
+
+                v.rootfs_propagation_.emplace(*prop_opt);
+            }
+        } else if (key_matches(k, "sysctl")) {
+            if (!val.is_null()) {
+                val.get_to(v.sysctl.emplace());
+            }
+        } else if (key_matches(k, "timeOffsets")) {
+            if (!val.is_null()) {
+                auto &offsets = v.time_offsets.emplace();
+                for (const auto &[clock_name, offset_json] : val.items()) {
+                    offsets.emplace(clock_name, offset_json.get<time_offset>());
+                }
+            }
+        } else if (key_matches(k, "personality")) {
+            if (!val.is_null()) {
+                val.get_to(v.personality_.emplace());
+            }
+        } else if (key_matches(k, "memoryPolicy")) {
+            if (!val.is_null()) {
+                val.get_to(v.memory_policy_.emplace());
+            }
+        } else if (key_matches(k, "intelRdt")) {
+            if (!val.is_null()) {
+                val.get_to(v.intel_rdt_.emplace());
+            }
+        } else if (key_matches(k, "resources")) {
+            if (!val.is_null()) {
+                val.get_to(v.resources_.emplace());
+            }
+        } else if (key_matches(k, "seccomp")) {
+            if (!val.is_null()) {
+                val.get_to(v.seccomp_.emplace());
+            }
+        }
+    }
+}
+
+void validate(const linux &v)
+{
+    if (v.namespaces) {
+        validate(*v.namespaces);
+    }
+
+    if ((v.uid_mappings || v.gid_mappings) && v.namespaces) {
+        const auto userns_joined =
+          std::any_of(v.namespaces->cbegin(), v.namespaces->cend(), [](const ns &entry) {
+              return entry.type_ == ns::type::user && entry.path.has_value();
+          });
+
+        if (UNLIKELY(userns_joined)) {
+            throw std::runtime_error(
+              "linux.uidMappings/gidMappings cannot be used when the user namespace is "
+              "joined via path");
+        }
+    }
+
+    if (v.seccomp_) {
+#ifdef LINYAPS_BOX_ENABLE_SECCOMP
+        validate(*v.seccomp_);
+#else
+        throw std::runtime_error("seccomp support is not compiled in");
+#endif
+    }
+
+    if (v.devices) {
+        std::for_each(v.devices->cbegin(), v.devices->cend(), [](const auto &device) {
+            validate(device);
+        });
+    }
+
+    if (v.masked_paths) {
+        std::for_each(v.masked_paths->cbegin(), v.masked_paths->cend(), [](const auto &p) {
+            if (UNLIKELY(!p.is_absolute())) {
+                throw std::runtime_error(
+                  fmt::format("maskedPaths must be absolute paths, got: {}", p));
+            }
+        });
+    }
+
+    if (v.readonly_paths) {
+        std::for_each(v.readonly_paths->cbegin(), v.readonly_paths->cend(), [](const auto &p) {
+            if (UNLIKELY(!p.is_absolute())) {
+                throw std::runtime_error(
+                  fmt::format("readonlyPaths must be absolute paths, got: {}", p));
+            }
+        });
+    }
+
+    if (v.resources_) {
+        validate(*v.resources_);
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/linux.h
+++ b/src/linyaps_box/config/linux.h
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/config/device.h"
+#include "linyaps_box/config/id_mapping.h"
+#include "linyaps_box/config/intel_rdt.h"
+#include "linyaps_box/config/memory_policy.h"
+#include "linyaps_box/config/network_device.h"
+#include "linyaps_box/config/ns.h"
+#include "linyaps_box/config/personality.h"
+#include "linyaps_box/config/resources.h"
+#include "linyaps_box/config/seccomp.h"
+#include "linyaps_box/config/time_offset.h"
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace linyaps_box::config {
+
+enum class rootfs_propagation : std::uint8_t { private_, shared, slave, unbindable };
+
+LINYAPS_REGISTER_ENUM_TABLE(rootfs_propagation,
+                            4,
+                            { rootfs_propagation::private_, "private" },
+                            { rootfs_propagation::shared, "shared" },
+                            { rootfs_propagation::slave, "slave" },
+                            { rootfs_propagation::unbindable, "unbindable" })
+
+struct linux
+{
+    std::optional<std::vector<ns>> namespaces;
+    std::optional<std::vector<id_mapping>> uid_mappings;
+    std::optional<std::vector<id_mapping>> gid_mappings;
+    std::optional<std::unordered_map<std::string, time_offset>> time_offsets;
+    std::optional<std::vector<device>> devices;
+    std::optional<std::unordered_map<std::string, network_device>> network_devices;
+    std::optional<std::string> cgroups_path;
+    std::optional<resources> resources_;
+    std::optional<intel_rdt> intel_rdt_;
+    std::optional<memory_policy> memory_policy_;
+    std::optional<std::unordered_map<std::string, std::string>> sysctl;
+    std::optional<seccomp> seccomp_;
+    std::optional<std::vector<std::filesystem::path>> masked_paths;
+    std::optional<std::vector<std::filesystem::path>> readonly_paths;
+    std::optional<std::string> mount_label;
+    std::optional<personality> personality_;
+    std::optional<rootfs_propagation> rootfs_propagation_;
+};
+
+void from_json(const nlohmann::json &j, linux &v);
+
+void validate(const linux &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/memory.cpp
+++ b/src/linyaps_box/config/memory.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/memory.h"
+
+#include "linyaps_box/config/utils.h"
+#include "linyaps_box/utils/utils.h"
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <string_view>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, memory &v)
+{
+    // Single-pass traversal for perf
+    for (const auto &[key, val] : j.items()) {
+        const auto k = std::string_view{ key };
+        if (key_matches(k, "limit")) {
+            if (!val.is_null()) {
+                val.get_to(v.limit.emplace());
+            }
+        } else if (key_matches(k, "reservation")) {
+            if (!val.is_null()) {
+                val.get_to(v.reservation.emplace());
+            }
+        } else if (key_matches(k, "swap")) {
+            if (!val.is_null()) {
+                val.get_to(v.swap.emplace());
+            }
+        } else if (key_matches(k, "kernel")) {
+            if (!val.is_null()) {
+                val.get_to(v.kernel.emplace());
+            }
+        } else if (key_matches(k, "kernelTCP")) {
+            if (!val.is_null()) {
+                val.get_to(v.kernel_tcp.emplace());
+            }
+        } else if (key_matches(k, "swappiness")) {
+            if (!val.is_null()) {
+                val.get_to(v.swappiness.emplace());
+            }
+        } else if (key_matches(k, "disableOOMKiller")) {
+            if (!val.is_null()) {
+                val.get_to(v.disable_OOM_killer.emplace());
+            }
+        } else if (key_matches(k, "useHierarchy")) {
+            if (!val.is_null()) {
+                val.get_to(v.use_hierarchy.emplace());
+            }
+        } else if (key_matches(k, "checkBeforeUpdate")) {
+            if (!val.is_null()) {
+                val.get_to(v.check_before_update.emplace());
+            }
+        }
+    }
+}
+
+void validate(const memory &v)
+{
+    if (UNLIKELY(v.swappiness && *v.swappiness > 100)) {
+        throw std::runtime_error(
+          fmt::format("memory.swappiness must be in range [0, 100], got: {}", *v.swappiness));
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/memory.h
+++ b/src/linyaps_box/config/memory.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <optional>
+
+namespace linyaps_box::config {
+
+struct memory
+{
+    std::optional<int64_t> limit;
+    std::optional<int64_t> reservation;
+    std::optional<int64_t> swap;
+    std::optional<int64_t> kernel;
+    std::optional<int64_t> kernel_tcp;
+    std::optional<uint64_t> swappiness;
+    std::optional<bool> disable_OOM_killer;
+    std::optional<bool> use_hierarchy;
+    std::optional<bool> check_before_update;
+};
+
+void from_json(const nlohmann::json &j, memory &v);
+
+void validate(const memory &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/memory_policy.cpp
+++ b/src/linyaps_box/config/memory_policy.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/memory_policy.h"
+
+#include "linyaps_box/config/utils.h"
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <stdexcept>
+#include <string>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, memory_policy &v)
+{
+    auto mode_name = j.at("mode").get<std::string_view>();
+    auto mode_opt = get_enum_table_from<memory_policy::mode>().from_name(mode_name);
+    if (UNLIKELY(!mode_opt)) {
+        throw std::runtime_error(fmt::format("unknown memory policy mode: {}", mode_name));
+    }
+    v.mode_ = *mode_opt;
+
+    if (auto nodes_it = j.find("nodes"); nodes_it != j.end() && !nodes_it->is_null()) {
+        v.nodes = parse_range_list(nodes_it->get<std::string_view>());
+    }
+
+    if (auto flags_it = j.find("flags"); flags_it != j.end() && !flags_it->is_null()) {
+        auto flags{ memory_policy::flag::none };
+        for (const auto &f : *flags_it) {
+            const auto &flag_str = f.get_ref<const std::string &>();
+            auto flag_opt = get_enum_table_from<memory_policy::flag>().from_name(flag_str);
+            if (UNLIKELY(!flag_opt)) {
+                throw std::runtime_error(fmt::format("unknown memory policy flag: {}", flag_str));
+            }
+
+            flags |= *flag_opt;
+        }
+
+        v.flags = flags;
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/memory_policy.h
+++ b/src/linyaps_box/config/memory_policy.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/utils/enum_traits.h"
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace linyaps_box::config {
+
+struct memory_policy
+{
+    enum class mode : uint8_t {
+        default_,
+        bind,
+        interleave,
+        weighted_interleave,
+        preferred,
+        preferred_many,
+        local,
+    };
+
+    enum class flag : std::uint8_t {
+        none = 0U,
+        numa_balancing = (1U << 0),
+        relative_nodes = (1U << 1),
+        static_nodes = (1U << 2),
+    };
+
+    std::optional<std::vector<unsigned int>> nodes;
+    std::optional<flag> flags;
+    mode mode_;
+};
+
+LINYAPS_REGISTER_ENUM_TABLE(memory_policy::mode,
+                            7,
+                            { memory_policy::mode::default_, "MPOL_DEFAULT" },
+                            { memory_policy::mode::bind, "MPOL_BIND" },
+                            { memory_policy::mode::interleave, "MPOL_INTERLEAVE" },
+                            { memory_policy::mode::weighted_interleave,
+                              "MPOL_WEIGHTED_INTERLEAVE" },
+                            { memory_policy::mode::preferred, "MPOL_PREFERRED" },
+                            { memory_policy::mode::preferred_many, "MPOL_PREFERRED_MANY" },
+                            { memory_policy::mode::local, "MPOL_LOCAL" })
+
+LINYAPS_ENABLE_BITMASK_ENUM(memory_policy::flag);
+
+LINYAPS_REGISTER_ENUM_TABLE(memory_policy::flag,
+                            3,
+                            { memory_policy::flag::numa_balancing, "MPOL_F_NUMA_BALANCING" },
+                            { memory_policy::flag::relative_nodes, "MPOL_F_RELATIVE_NODES" },
+                            { memory_policy::flag::static_nodes, "MPOL_F_STATIC_NODES" })
+
+void from_json(const nlohmann::json &j, memory_policy &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/mount.cpp
+++ b/src/linyaps_box/config/mount.cpp
@@ -1,0 +1,407 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/mount.h"
+
+#include "linyaps_box/config/utils.h"
+#include "linyaps_box/log/macro.h"
+#include "linyaps_box/os/kernel_constants.h"
+
+#include <fmt/std.h>
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace linyaps_box::config {
+
+namespace {
+
+constexpr auto extra_flags_table = get_enum_table_from<mount::extension>();
+constexpr auto idmap_options_table = get_enum_table_from<mount::idmap_type>();
+
+struct vfs_option_entry
+{
+    std::string_view name;
+    utils::bitflags<vfs_flag> flag;
+    bool clear;
+};
+
+constexpr std::array<vfs_option_entry, 33> vfs_options{ {
+  { "bind", vfs_flag::bind, false },
+  { "dirsync", vfs_flag::dirsync, false },
+  { "defaults", vfs_flag::defaults, false },
+  { "iversion", vfs_flag::iversion, false },
+  { "lazytime", vfs_flag::lazytime, false },
+  { "mand", vfs_flag::mand, false },
+  { "noatime", vfs_flag::noatime, false },
+  { "nodev", vfs_flag::nodev, false },
+  { "nodiratime", vfs_flag::nodiratime, false },
+  { "noexec", vfs_flag::noexec, false },
+  { "nosuid", vfs_flag::nosuid, false },
+  { "nosymfollow", vfs_flag::nosymfollow, false },
+  { "rbind", vfs_flag::bind | vfs_flag::rec, false },
+  { "relatime", vfs_flag::relatime, false },
+  { "remount", vfs_flag::remount, false },
+  { "ro", vfs_flag::ro, false },
+  { "silent", vfs_flag::silent, false },
+  { "strictatime", vfs_flag::strictatime, false },
+  { "sync", vfs_flag::sync, false },
+  { "async", vfs_flag::sync, true },
+  { "atime", vfs_flag::noatime, true },
+  { "dev", vfs_flag::nodev, true },
+  { "diratime", vfs_flag::nodiratime, true },
+  { "exec", vfs_flag::noexec, true },
+  { "loud", vfs_flag::silent, true },
+  { "noiversion", vfs_flag::iversion, true },
+  { "nolazytime", vfs_flag::lazytime, true },
+  { "nomand", vfs_flag::mand, true },
+  { "norelatime", vfs_flag::relatime, true },
+  { "nostrictatime", vfs_flag::strictatime, true },
+  { "rw", vfs_flag::ro, true },
+  { "suid", vfs_flag::nosuid, true },
+  { "symfollow", vfs_flag::nosymfollow, true },
+} };
+
+struct propagation_option_entry
+{
+    std::string_view name;
+    utils::bitflags<propagation_flag> flag;
+};
+
+constexpr std::array<propagation_option_entry, 8> propagation_options{ {
+  { "private", propagation_flag::private_ },
+  { "rprivate", propagation_flag::private_ | propagation_flag::rec },
+  { "slave", propagation_flag::slave },
+  { "rslave", propagation_flag::slave | propagation_flag::rec },
+  { "shared", propagation_flag::shared },
+  { "rshared", propagation_flag::shared | propagation_flag::rec },
+  { "unbindable", propagation_flag::unbindable },
+  { "runbindable", propagation_flag::unbindable | propagation_flag::rec },
+} };
+
+// Recursive mount_setattr options. these carry raw
+// MOUNT_ATTR_* UAPI values (mount::recursive_attr is a passthrough ABI bitmask;
+// mount_setattr(2) is not implemented yet).
+// TODO: Revisit when it lands.
+struct rec_attr_option_entry
+{
+    std::string_view name;
+    uint64_t value;
+};
+
+constexpr std::array<rec_attr_option_entry, 9> recursive_attr_set{ {
+  { "rro", os::sys::mount_attr_rdonly },
+  { "rnosuid", os::sys::mount_attr_nosuid },
+  { "rnodev", os::sys::mount_attr_nodev },
+  { "rnoexec", os::sys::mount_attr_noexec },
+  { "rnodiratime", os::sys::mount_attr_nodiratime },
+  { "rnoatime", os::sys::mount_attr_noatime },
+  { "rstrictatime", os::sys::mount_attr_strictatime },
+  { "rnosymfollow", os::sys::mount_attr_nosymfollow },
+  { "rrelatime", 0 },
+} };
+
+constexpr std::array<rec_attr_option_entry, 9> recursive_attr_clr{ {
+  { "rrw", os::sys::mount_attr_rdonly },
+  { "rsuid", os::sys::mount_attr_nosuid },
+  { "rdev", os::sys::mount_attr_nodev },
+  { "rexec", os::sys::mount_attr_noexec },
+  { "rdiratime", os::sys::mount_attr_nodiratime },
+  { "ratime", os::sys::mount_attr_noatime },
+  { "rnostrictatime", os::sys::mount_attr_strictatime },
+  { "rsymfollow", os::sys::mount_attr_nosymfollow },
+  { "rnorelatime", 0 },
+} };
+
+template <typename Entry, std::size_t N>
+constexpr const Entry *find_option(const std::array<Entry, N> &table, std::string_view key) noexcept
+{
+    for (const auto &entry : table) {
+        if (entry.name == key) {
+            return &entry;
+        }
+    }
+
+    return nullptr;
+}
+
+auto parse_id_mapping_chunk(std::string_view chunk) -> id_mapping
+{
+    // format: "containerID:hostID:size"
+    auto first_colon = chunk.find(':');
+    if (UNLIKELY(first_colon == std::string_view::npos)) {
+        throw std::runtime_error(fmt::format("invalid id mapping: {}", chunk));
+    }
+
+    auto second_colon = chunk.find(':', first_colon + 1);
+    if (UNLIKELY(second_colon == std::string_view::npos)) {
+        throw std::runtime_error(fmt::format("invalid id mapping: {}", chunk));
+    }
+
+    id_mapping mapping{ };
+    const char *const base = chunk.data();
+    auto [p1, ec1] = std::from_chars(base, base + first_colon, mapping.container_id);
+    // from_chars may stop early on trailing garbage; the whole field must be consumed.
+    if (UNLIKELY(ec1 != std::errc{ } || p1 != base + first_colon)) {
+        throw std::runtime_error(fmt::format("invalid container id in mapping: {}", chunk));
+    }
+
+    auto [p2, ec2] = std::from_chars(base + first_colon + 1, base + second_colon, mapping.host_id);
+    if (UNLIKELY(ec2 != std::errc{ } || p2 != base + second_colon)) {
+        throw std::runtime_error(fmt::format("invalid host id in mapping: {}", chunk));
+    }
+
+    auto [p3, ec3] = std::from_chars(base + second_colon + 1, base + chunk.size(), mapping.size);
+    if (UNLIKELY(ec3 != std::errc{ } || p3 != base + chunk.size())) {
+        throw std::runtime_error(fmt::format("invalid size in mapping: {}", chunk));
+    }
+
+    return mapping;
+}
+
+auto parse_mappings(std::string_view value) -> std::optional<std::vector<id_mapping>>
+{
+    std::vector<id_mapping> result;
+    // Estimate capacity from comma count to avoid realloc during push_back
+    auto commas = std::count(value.begin(), value.end(), ',');
+    result.reserve(static_cast<std::size_t>(commas) + 1);
+
+    while (!value.empty()) {
+        auto comma_pos = value.find(',');
+        auto chunk = value.substr(0, comma_pos);
+        result.push_back(parse_id_mapping_chunk(chunk));
+
+        if (comma_pos == std::string_view::npos) {
+            break;
+        }
+
+        value = value.substr(comma_pos + 1);
+    }
+
+    return result;
+}
+
+struct inline_idmap_result
+{
+    mount::idmap_type type;
+    std::optional<std::vector<id_mapping>> uid_mappings;
+    std::optional<std::vector<id_mapping>> gid_mappings;
+};
+
+auto parse_inline_idmap_option(std::string_view opt) -> inline_idmap_result
+{
+    auto eq_pos = opt.find('=');
+    auto prefix = opt.substr(0, eq_pos);
+    auto iv = idmap_options_table.from_name(prefix);
+    if (UNLIKELY(!iv)) {
+        throw std::runtime_error(fmt::format("unknown idmap option: {}", opt));
+    }
+
+    inline_idmap_result result;
+    result.type = *iv;
+    auto rest = opt.substr(eq_pos + 1);
+
+    while (!rest.empty()) {
+        auto comma_pos = rest.find(',');
+        auto part = rest.substr(0, comma_pos);
+
+        auto eq2_pos = part.find('=');
+        if (eq2_pos == std::string_view::npos) {
+            throw std::runtime_error(fmt::format("invalid id mapping option: {}", opt));
+        }
+
+        auto key = part.substr(0, eq2_pos);
+        auto value = part.substr(eq2_pos + 1);
+
+        if (key == "uids") {
+            result.uid_mappings = parse_mappings(value);
+        } else if (key == "gids") {
+            result.gid_mappings = parse_mappings(value);
+        } else {
+            throw std::runtime_error(fmt::format("unknown id mapping key: {}", key));
+        }
+
+        if (comma_pos == std::string_view::npos) {
+            break;
+        }
+
+        rest = rest.substr(comma_pos + 1);
+    }
+
+    return result;
+}
+
+auto parse_mount_options(const std::vector<std::string> &options) -> parsed_mount_options
+{
+    parsed_mount_options result;
+
+    auto ensure_idmap_compatible = [&result](mount::idmap_type candidate) {
+        if (UNLIKELY(result.idmap.has_value() && *result.idmap != candidate)) {
+            throw std::runtime_error("idmap and ridmap options are mutually exclusive");
+        }
+    };
+
+    for (const auto &opt : options) {
+        if (const auto *entry = find_option(vfs_options, opt)) {
+            if (entry->clear) {
+                result.vfs_flags &= ~entry->flag;
+            } else {
+                result.vfs_flags |= entry->flag;
+            }
+
+            continue;
+        }
+
+        if (const auto *entry = find_option(propagation_options, opt)) {
+            result.propagation_flags |= entry->flag;
+            continue;
+        }
+
+        if (const auto *entry = find_option(recursive_attr_set, opt)) {
+            if (!result.rec_attr) {
+                result.rec_attr.emplace();
+            }
+
+            result.rec_attr->set |= entry->value;
+            continue;
+        }
+
+        if (const auto *entry = find_option(recursive_attr_clr, opt)) {
+            if (!result.rec_attr) {
+                result.rec_attr.emplace();
+            }
+
+            result.rec_attr->clr |= entry->value;
+            continue;
+        }
+
+        if (auto ev = extra_flags_table.from_name(opt)) {
+            result.extension_flags |= *ev;
+            continue;
+        }
+
+        // Handle simple "idmap" or "ridmap" flags
+        if (auto iv = idmap_options_table.from_name(opt)) {
+            ensure_idmap_compatible(*iv);
+
+            result.idmap.emplace(std::move(iv).value());
+            continue;
+        }
+
+        // Handle inline mapping strings like "idmap=uids=0:1000:1,gids=0:1000:1"
+        if (auto eq_pos = opt.find('='); UNLIKELY(eq_pos != std::string_view::npos)) {
+            auto prefix = std::string_view{ opt }.substr(0, eq_pos);
+            if (auto iv = idmap_options_table.from_name(prefix)) {
+                ensure_idmap_compatible(*iv);
+
+                auto inline_result = parse_inline_idmap_option(opt);
+                result.idmap.emplace(inline_result.type);
+                result.uid_mappings = std::move(inline_result.uid_mappings);
+                result.gid_mappings = std::move(inline_result.gid_mappings);
+
+                continue;
+            }
+        }
+
+        if (!result.data.empty()) {
+            result.data.push_back(',');
+        }
+
+        result.data.append(opt);
+    }
+
+    return result;
+}
+
+} // namespace
+
+void from_json(const nlohmann::json &j, mount &v)
+{
+    std::optional<std::vector<id_mapping>> inline_uid_mappings;
+    std::optional<std::vector<id_mapping>> inline_gid_mappings;
+    bool have_destination{ false };
+
+    for (const auto &[key, val] : j.items()) {
+        const auto k = std::string_view{ key };
+        if (key_matches(k, "destination")) {
+            val.get_to(v.destination);
+            have_destination = true;
+        } else if (key_matches(k, "source")) {
+            if (!val.is_null()) {
+                val.get_to(v.source.emplace());
+            }
+        } else if (key_matches(k, "type")) {
+            if (!val.is_null()) {
+                val.get_to(v.type.emplace());
+            }
+        } else if (key_matches(k, "uidMappings")) {
+            if (!val.is_null()) {
+                val.get_to(v.uid_mappings.emplace());
+            }
+        } else if (key_matches(k, "gidMappings")) {
+            if (!val.is_null()) {
+                val.get_to(v.gid_mappings.emplace());
+            }
+        } else if (key_matches(k, "options")) {
+            if (!val.is_null()) {
+                auto options = val.get<std::vector<std::string>>();
+                auto parsed = parse_mount_options(options);
+
+                v.vfs_flags = parsed.vfs_flags;
+                v.propagation_flags = parsed.propagation_flags;
+                v.rec_attr = parsed.rec_attr;
+                v.extension_flags = parsed.extension_flags;
+                v.idmap = parsed.idmap;
+                v.data = std::move(parsed.data);
+
+                inline_uid_mappings = std::move(parsed.uid_mappings);
+                inline_gid_mappings = std::move(parsed.gid_mappings);
+            }
+        }
+    }
+
+    if (inline_uid_mappings) {
+        if (v.uid_mappings) {
+            LINYAPS_BOX_LOG_WARN(
+              "mount {}: inline idmap uid mapping ignored because uidMappings is specified",
+              v.destination);
+        } else {
+            v.uid_mappings = std::move(inline_uid_mappings);
+        }
+    }
+
+    if (inline_gid_mappings) {
+        if (v.gid_mappings) {
+            LINYAPS_BOX_LOG_WARN(
+              "mount {}: inline idmap gid mapping ignored because gidMappings is specified",
+              v.destination);
+        } else {
+            v.gid_mappings = std::move(inline_gid_mappings);
+        }
+    }
+
+    if (UNLIKELY(!have_destination)) {
+        throw std::runtime_error("mount.destination is required");
+    }
+}
+
+void validate(const mount &v)
+{
+    if (UNLIKELY(!v.destination.is_absolute())) {
+        LINYAPS_BOX_LOG_WARN("mount destination is not an absolute path: {}", v.destination);
+    }
+
+    if (UNLIKELY(v.uid_mappings.has_value() != v.gid_mappings.has_value())) {
+        throw std::runtime_error(
+          "uidMappings and gidMappings on mounts must be specified together");
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/mount.h
+++ b/src/linyaps_box/config/mount.h
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/config/id_mapping.h"
+#include "linyaps_box/utils/enum_traits.h"
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace linyaps_box::config {
+
+enum class vfs_flag : uint32_t {
+    defaults = 0,
+    bind = 1U << 0,
+    rec = 1U << 1,
+    ro = 1U << 2,
+    nosuid = 1U << 3,
+    nodev = 1U << 4,
+    noexec = 1U << 5,
+    noatime = 1U << 6,
+    nodiratime = 1U << 7,
+    relatime = 1U << 8,
+    strictatime = 1U << 9,
+    sync = 1U << 10,
+    dirsync = 1U << 11,
+    iversion = 1U << 12,
+    lazytime = 1U << 13,
+    mand = 1U << 14,
+    silent = 1U << 15,
+    nosymfollow = 1U << 16,
+    remount = 1U << 17,
+};
+
+LINYAPS_ENABLE_BITMASK_ENUM(vfs_flag);
+
+LINYAPS_REGISTER_ENUM_TABLE(vfs_flag,
+                            19,
+                            { vfs_flag::defaults, "defaults" },
+                            { vfs_flag::bind, "bind" },
+                            { vfs_flag::rec, "rec" },
+                            { vfs_flag::ro, "ro" },
+                            { vfs_flag::nosuid, "nosuid" },
+                            { vfs_flag::nodev, "nodev" },
+                            { vfs_flag::noexec, "noexec" },
+                            { vfs_flag::noatime, "noatime" },
+                            { vfs_flag::nodiratime, "nodiratime" },
+                            { vfs_flag::relatime, "relatime" },
+                            { vfs_flag::strictatime, "strictatime" },
+                            { vfs_flag::sync, "sync" },
+                            { vfs_flag::dirsync, "dirsync" },
+                            { vfs_flag::iversion, "iversion" },
+                            { vfs_flag::lazytime, "lazytime" },
+                            { vfs_flag::mand, "mand" },
+                            { vfs_flag::silent, "silent" },
+                            { vfs_flag::nosymfollow, "nosymfollow" },
+                            { vfs_flag::remount, "remount" })
+
+enum class propagation_flag : uint8_t {
+    none = 0,
+    private_ = 1U << 0,
+    slave = 1U << 1,
+    shared = 1U << 2,
+    unbindable = 1U << 3,
+    rec = 1U << 4,
+};
+
+LINYAPS_ENABLE_BITMASK_ENUM(propagation_flag);
+
+LINYAPS_REGISTER_ENUM_TABLE(propagation_flag,
+                            6,
+                            { propagation_flag::none, "none" },
+                            { propagation_flag::private_, "private" },
+                            { propagation_flag::slave, "slave" },
+                            { propagation_flag::shared, "shared" },
+                            { propagation_flag::unbindable, "unbindable" },
+                            { propagation_flag::rec, "rec" })
+
+struct mount
+{
+    enum class extension : std::uint8_t {
+        none = 0,
+        copy_symlink = (1U << 0),
+        tmpcopyup = (1U << 1),
+    };
+
+    enum class idmap_type : std::uint8_t { idmap, ridmap };
+
+    struct recursive_attr
+    {
+        uint64_t set{ 0 };
+        uint64_t clr{ 0 };
+    };
+
+    utils::bitflags<vfs_flag> vfs_flags;
+    utils::bitflags<propagation_flag> propagation_flags;
+    std::optional<recursive_attr> rec_attr;
+    extension extension_flags{ extension::none };
+    std::optional<idmap_type> idmap;
+
+    std::optional<std::string> source;
+    std::filesystem::path destination;
+    std::optional<std::string> type;
+    std::string data;
+
+    std::optional<std::vector<id_mapping>> uid_mappings;
+    std::optional<std::vector<id_mapping>> gid_mappings;
+};
+
+LINYAPS_ENABLE_BITMASK_ENUM(mount::extension);
+
+LINYAPS_REGISTER_ENUM_TABLE(mount::extension,
+                            3,
+                            { mount::extension::none, "none" },
+                            { mount::extension::copy_symlink, "copy-symlink" },
+                            { mount::extension::tmpcopyup, "tmpcopyup" })
+
+LINYAPS_REGISTER_ENUM_TABLE(mount::idmap_type,
+                            2,
+                            { mount::idmap_type::idmap, "idmap" },
+                            { mount::idmap_type::ridmap, "ridmap" })
+
+struct parsed_mount_options
+{
+    utils::bitflags<vfs_flag> vfs_flags{ vfs_flag::defaults };
+    utils::bitflags<propagation_flag> propagation_flags{ propagation_flag::none };
+    std::optional<mount::recursive_attr> rec_attr;
+    mount::extension extension_flags{ mount::extension::none };
+    std::optional<mount::idmap_type> idmap;
+    std::optional<std::vector<id_mapping>> uid_mappings;
+    std::optional<std::vector<id_mapping>> gid_mappings;
+    std::string data;
+};
+
+void from_json(const nlohmann::json &j, mount &v);
+
+void validate(const mount &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/network.cpp
+++ b/src/linyaps_box/config/network.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/network.h"
+
+#include "linyaps_box/utils/utils.h"
+
+#include <nlohmann/json.hpp>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, network::priority &v)
+{
+    j.at("name").get_to(v.name);
+    j.at("priority").get_to(v.priority);
+}
+
+void from_json(const nlohmann::json &j, network &v)
+{
+    if (auto it = j.find("classID"); it != j.end() && !it->is_null()) {
+        it->get_to(v.class_id.emplace());
+    }
+
+    if (auto it = j.find("priorities"); it != j.end() && !it->is_null()) {
+        it->get_to(v.priorities.emplace());
+    }
+}
+
+void validate(const network &v)
+{
+    if (!v.priorities) {
+        return;
+    }
+
+    std::for_each(v.priorities->cbegin(), v.priorities->cend(), [](const auto &p) {
+        if (UNLIKELY(p.name.empty())) {
+            throw std::runtime_error("network.priorities name must not be empty");
+        }
+    });
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/network.h
+++ b/src/linyaps_box/config/network.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace linyaps_box::config {
+
+struct network
+{
+    struct priority
+    {
+        std::string name;
+        uint32_t priority;
+    };
+
+    std::optional<uint32_t> class_id;
+    std::optional<std::vector<priority>> priorities;
+};
+
+void from_json(const nlohmann::json &j, network::priority &v);
+
+void from_json(const nlohmann::json &j, network &v);
+
+void validate(const network &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/network_device.cpp
+++ b/src/linyaps_box/config/network_device.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/network_device.h"
+
+#include <nlohmann/json.hpp>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, network_device &v)
+{
+    if (auto it = j.find("name"); it != j.end() && !it->is_null()) {
+        it->get_to(v.name.emplace());
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/network_device.h
+++ b/src/linyaps_box/config/network_device.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <optional>
+#include <string>
+
+namespace linyaps_box::config {
+
+struct network_device
+{
+    std::optional<std::string> name;
+};
+
+void from_json(const nlohmann::json &j, network_device &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/ns.cpp
+++ b/src/linyaps_box/config/ns.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/ns.h"
+
+#include "linyaps_box/utils/enum_formatter.h" // IWYU pragma: keep
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <array>
+#include <filesystem>
+#include <stdexcept>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, ns &v)
+{
+    auto type_str = j.at("type").get<std::string_view>();
+    auto opt = get_enum_table_from<ns::type>().from_name(type_str);
+    if (UNLIKELY(!opt)) {
+        throw std::runtime_error(fmt::format("unknown namespace type: {}", type_str));
+    }
+    v.type_ = *opt;
+
+    if (auto path_it = j.find("path"); path_it != j.end() && !path_it->is_null()) {
+        auto path = path_it->get<std::string_view>();
+        if (UNLIKELY(path.empty())) {
+            throw std::runtime_error(
+              fmt::format("namespace path must not be empty for type: {}", type_str));
+        }
+
+        auto &fs_path = v.path.emplace(path);
+        if (UNLIKELY(!fs_path.is_absolute())) {
+            throw std::runtime_error(
+              fmt::format("namespace path must be absolute for type: {}, got: {}", type_str, path));
+        }
+    }
+}
+
+void validate(const std::vector<ns> &v)
+{
+    std::array<bool, 8> seen{ };
+    for (const auto &entry : v) {
+        const auto index = static_cast<std::size_t>(entry.type_);
+        if (UNLIKELY(seen[index])) {
+            throw std::runtime_error(fmt::format("duplicate namespace type: {}", entry.type_));
+        }
+
+        seen[index] = true;
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/ns.h
+++ b/src/linyaps_box/config/ns.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/utils/enum_traits.h"
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+namespace linyaps_box::config {
+
+struct ns
+{
+    enum class type : std::uint8_t {
+        ipc,
+        uts,
+        mount,
+        pid,
+        net,
+        user,
+        cgroup,
+        time,
+    };
+
+    type type_;
+    std::optional<std::filesystem::path> path;
+};
+
+LINYAPS_REGISTER_ENUM_TABLE(ns::type,
+                            8,
+                            { ns::type::ipc, "ipc" },
+                            { ns::type::uts, "uts" },
+                            { ns::type::mount, "mount" },
+                            { ns::type::pid, "pid" },
+                            { ns::type::net, "network" },
+                            { ns::type::user, "user" },
+                            { ns::type::cgroup, "cgroup" },
+                            { ns::type::time, "time" })
+
+void from_json(const nlohmann::json &j, ns &v);
+
+void validate(const std::vector<ns> &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/oci_config.cpp
+++ b/src/linyaps_box/config/oci_config.cpp
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/oci_config.h"
+
+#include "linyaps_box/config/utils.h"
+#include "linyaps_box/utils/semver.h"
+#include "linyaps_box/utils/utils.h"
+
+#include <nlohmann/json.hpp>
+
+#include <filesystem>
+#include <stdexcept>
+#include <string_view>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, oci_config &v)
+{
+    bool have_oci_version{ false };
+    for (const auto &[key, val] : j.items()) {
+        const auto k = std::string_view{ key };
+        if (key_matches(k, "ociVersion")) {
+            auto semver = linyaps_box::utils::semver(val.get_ref<const std::string &>());
+            if (UNLIKELY(
+                  !linyaps_box::utils::semver(oci_config::version).is_compatible_with(semver))) {
+                throw std::runtime_error("unsupported OCI version: " + semver.to_string());
+            }
+
+            have_oci_version = true;
+        } else if (key_matches(k, "process")) {
+            if (!val.is_null()) {
+                val.get_to(v.process_.emplace());
+            }
+        } else if (key_matches(k, "hostname")) {
+            if (!val.is_null()) {
+                val.get_to(v.hostname.emplace());
+            }
+        } else if (key_matches(k, "domainname")) {
+            if (!val.is_null()) {
+                val.get_to(v.domainname.emplace());
+            }
+        } else if (key_matches(k, "linux")) {
+            if (!val.is_null()) {
+                val.get_to(v.linux_.emplace());
+            }
+        } else if (key_matches(k, "hooks")) {
+            if (!val.is_null()) {
+                val.get_to(v.hooks_.emplace());
+            }
+        } else if (key_matches(k, "mounts")) {
+            if (!val.is_null()) {
+                val.get_to(v.mounts);
+            }
+        } else if (key_matches(k, "root")) {
+            if (!val.is_null()) {
+                val.get_to(v.root_.emplace());
+            }
+        } else if (key_matches(k, "annotations")) {
+            if (!val.is_null()) {
+                val.get_to(v.annotations.emplace());
+            }
+        }
+    }
+
+    if (!have_oci_version) {
+        throw std::runtime_error("oci_config.ociVersion is required");
+    }
+}
+
+void validate(const oci_config &v)
+{
+    if (v.process_) {
+        validate(*v.process_);
+    }
+
+    if (v.linux_) {
+        validate(*v.linux_);
+    }
+
+    if (v.root_) {
+        validate(*v.root_);
+    }
+
+    if (v.hooks_) {
+        validate(*v.hooks_);
+    }
+
+    for (const auto &m : v.mounts) {
+        validate(m);
+    }
+
+    if (!v.annotations) {
+        return;
+    }
+
+    std::for_each(v.annotations->cbegin(), v.annotations->cend(), [](const auto &pair) {
+        if (UNLIKELY(pair.first.empty())) {
+            throw std::runtime_error("annotations keys must not be empty");
+        }
+    });
+}
+
+auto oci_config::parse(std::string_view content) -> oci_config
+{
+    auto config = nlohmann::json::parse(content).get<oci_config>();
+    validate(config);
+    return config;
+}
+
+auto oci_config::parse(const std::filesystem::path &path) -> oci_config
+{
+    utils::uninit_vector<std::byte> buf;
+    auto len = read_json_to(path, buf);
+
+    const std::string_view content_view{ reinterpret_cast<const char *>(buf.data()), // NOLINT
+                                         len };
+
+    return parse(content_view);
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/oci_config.h
+++ b/src/linyaps_box/config/oci_config.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/config/hooks.h"
+#include "linyaps_box/config/linux.h"
+#include "linyaps_box/config/mount.h"
+#include "linyaps_box/config/process.h"
+#include "linyaps_box/config/root.h"
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace linyaps_box::config {
+
+using namespace std::string_view_literals;
+
+struct oci_config
+{
+    static constexpr auto version = "1.3.0"sv;
+
+    static auto parse(std::string_view content) -> oci_config;
+    static auto parse(const std::filesystem::path &path) -> oci_config;
+
+    std::optional<process> process_;
+    std::optional<std::string> hostname;
+    std::optional<std::string> domainname;
+    std::vector<mount> mounts;
+    std::optional<linux> linux_;
+    std::optional<hooks> hooks_;
+    std::optional<root> root_;
+    std::optional<std::unordered_map<std::string, std::string>> annotations;
+};
+
+void from_json(const nlohmann::json &j, oci_config &v);
+
+void validate(const oci_config &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/personality.cpp
+++ b/src/linyaps_box/config/personality.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/personality.h"
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <stdexcept>
+
+namespace linyaps_box::config {
+
+constexpr auto personality_domain_table = get_enum_table_from<personality::domain>();
+
+void from_json(const nlohmann::json &j, personality &v)
+{
+    auto domain_name = j.at("domain").get<std::string_view>();
+    auto domain_opt = personality_domain_table.from_name(domain_name);
+    if (UNLIKELY(!domain_opt)) {
+        throw std::runtime_error(fmt::format("unknown personality domain: {}", domain_name));
+    }
+    v.domain_ = *domain_opt;
+
+    if (auto flags_it = j.find("flags"); flags_it != j.end() && !flags_it->is_null()) {
+        flags_it->get_to(v.flags.emplace());
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/personality.h
+++ b/src/linyaps_box/config/personality.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/utils/enum_traits.h"
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace linyaps_box::config {
+
+struct personality
+{
+    enum class domain : uint8_t { linux, linux32 };
+
+    domain domain_;
+    std::optional<std::vector<std::string>> flags;
+};
+
+LINYAPS_REGISTER_ENUM_TABLE(personality::domain,
+                            2,
+                            { personality::domain::linux, "LINUX" },
+                            { personality::domain::linux32, "LINUX32" })
+
+void from_json(const nlohmann::json &j, personality &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/pids.cpp
+++ b/src/linyaps_box/config/pids.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/pids.h"
+
+#include <nlohmann/json.hpp>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, pids &v)
+{
+    if (auto it = j.find("limit"); it != j.end() && !it->is_null()) {
+        it->get_to(v.limit.emplace());
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/pids.h
+++ b/src/linyaps_box/config/pids.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <optional>
+
+namespace linyaps_box::config {
+
+struct pids
+{
+    std::optional<int64_t> limit;
+};
+
+void from_json(const nlohmann::json &j, pids &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/process.cpp
+++ b/src/linyaps_box/config/process.cpp
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/process.h"
+
+#include "linyaps_box/config/utils.h"
+#include "linyaps_box/utils/enum_formatter.h" // IWYU pragma: keep
+#include "linyaps_box/utils/environ.h"
+#include "linyaps_box/utils/utils.h"
+
+#include <fmt/std.h>
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <bitset>
+#include <stdexcept>
+
+#include <sys/types.h>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, process &v)
+{
+    bool have_cwd{ false };
+    bool have_args{ false };
+    for (const auto &[key, val] : j.items()) {
+        const auto k = std::string_view{ key };
+        if (key_matches(k, "terminal")) {
+            if (!val.is_null()) {
+                val.get_to(v.terminal.emplace());
+            }
+        } else if (key_matches(k, "consoleSize")) {
+            if (!val.is_null()) {
+                val.get_to(v.console_size_.emplace());
+            }
+        } else if (key_matches(k, "cwd")) {
+            val.get_to(v.cwd);
+            have_cwd = true;
+        } else if (key_matches(k, "env")) {
+            if (!val.is_null()) {
+                val.get_to(v.env.emplace());
+            }
+        } else if (key_matches(k, "args")) {
+            val.get_to(v.args);
+            have_args = true;
+        } else if (key_matches(k, "rlimits")) {
+            if (!val.is_null()) {
+                val.get_to(v.rlimits.emplace());
+            }
+        } else if (key_matches(k, "apparmorProfile")) {
+            if (!val.is_null()) {
+                val.get_to(v.apparmor_profile.emplace());
+            }
+        } else if (key_matches(k, "capabilities")) {
+            if (!val.is_null()) {
+                val.get_to(v.capabilities_.emplace());
+            }
+        } else if (key_matches(k, "noNewPrivileges")) {
+            if (!val.is_null()) {
+                val.get_to(v.no_new_privileges.emplace());
+            }
+        } else if (key_matches(k, "oomScoreAdj")) {
+            if (!val.is_null()) {
+                val.get_to(v.oom_score_adj.emplace());
+            }
+        } else if (key_matches(k, "scheduler")) {
+            if (!val.is_null()) {
+                val.get_to(v.scheduler_.emplace());
+            }
+        } else if (key_matches(k, "selinuxLabel")) {
+            if (!val.is_null()) {
+                val.get_to(v.selinux_label.emplace());
+            }
+        } else if (key_matches(k, "ioPriority")) {
+            if (!val.is_null()) {
+                val.get_to(v.io_priority_.emplace());
+            }
+        } else if (key_matches(k, "execCPUAffinity")) {
+            if (!val.is_null()) {
+                val.get_to(v.exec_cpu_affinity_.emplace());
+            }
+        } else if (key_matches(k, "user")) {
+            if (!val.is_null()) {
+                val.get_to(v.user_);
+            } else {
+                v.user_ = { };
+            }
+        }
+    }
+
+    // consoleSize only meaningful with terminal enabled
+    if (!v.terminal.value_or(false)) {
+        v.console_size_.reset();
+    }
+
+    if (UNLIKELY(!have_cwd)) {
+        throw std::runtime_error("process.cwd is required");
+    }
+
+    if (UNLIKELY(!have_args)) {
+        throw std::runtime_error("process.args is required");
+    }
+}
+
+void validate(const process &v)
+{
+    // Capability names are deliberately not validated here. Unlike the
+    // closed value sets (seccomp actions, namespace types, ...), the OCI
+    // runtime spec (config.md, "capabilities") mandates that a value which
+    // cannot be mapped to a relevant kernel interface MUST be logged as a
+    // warning and the runtime SHOULD NOT fail the container because of it.
+    // security/privilege.cpp::parse_names implements exactly that behavior,
+    // so unknown names are surfaced at runtime as warnings, not here.
+    if (v.capabilities_) {
+#ifndef LINYAPS_BOX_ENABLE_CAP
+        throw std::runtime_error("capabilities support is not compiled in");
+#endif
+    }
+
+    validate(v.user_);
+
+    if (UNLIKELY(!v.cwd.is_absolute())) {
+        throw std::runtime_error(
+          fmt::format("process.cwd must be an absolute path, got: {}", v.cwd));
+    }
+
+    if (v.env) {
+        auto invalid = std::find_if(v.env->cbegin(), v.env->cend(), utils::is_invalid_env);
+        if (UNLIKELY(invalid != v.env->cend())) {
+            throw std::runtime_error(
+              fmt::format("process.env contains a invalid env: {}", *invalid));
+        }
+    }
+
+    if (UNLIKELY(v.args.empty())) {
+        throw std::runtime_error("process.args must not be empty");
+    }
+
+    if (v.rlimits) {
+        std::bitset<16> seen;
+        for (const auto &rl : *v.rlimits) {
+            auto type_val = static_cast<size_t>(rl.type_);
+            if (UNLIKELY(type_val >= seen.size())) {
+                throw std::runtime_error("invalid rlimit type value out of range");
+            }
+
+            if (UNLIKELY(seen.test(type_val))) {
+                throw std::runtime_error(fmt::format("duplicate rlimit type: {}", rl.type_));
+            }
+
+            seen.set(type_val);
+        }
+    }
+
+    if (v.scheduler_) {
+        validate(*v.scheduler_);
+    }
+
+    if (v.io_priority_) {
+        validate(*v.io_priority_);
+    }
+}
+
+auto process::parse(std::string_view content) -> process
+{
+    auto process_config = nlohmann::json::parse(content).get<process>();
+    validate(process_config);
+    return process_config;
+}
+
+auto process::parse(const std::filesystem::path &path) -> process
+{
+    utils::uninit_vector<std::byte> buf;
+    auto len = read_json_to(path, buf);
+
+    const std::string_view content_view{ reinterpret_cast<const char *>(buf.data()), // NOLINT
+                                         len };
+
+    return parse(content_view);
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/process.h
+++ b/src/linyaps_box/config/process.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/config/capabilities.h"
+#include "linyaps_box/config/console_size.h"
+#include "linyaps_box/config/exec_cpu_affinity.h"
+#include "linyaps_box/config/io_priority.h"
+#include "linyaps_box/config/rlimit.h"
+#include "linyaps_box/config/scheduler.h"
+#include "linyaps_box/config/user.h"
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace linyaps_box::config {
+
+struct process
+{
+    // exec process is a special case, it is not a full OCI config, but we still want to use the
+    // same parsing and validation logic as the process section of an OCI config.
+    static auto parse(std::string_view content) -> process;
+    static auto parse(const std::filesystem::path &path) -> process;
+
+    std::optional<capabilities> capabilities_;
+    std::optional<exec_cpu_affinity> exec_cpu_affinity_;
+    user user_;
+    std::optional<std::string> apparmor_profile;
+    std::optional<scheduler> scheduler_;
+    std::optional<std::string> selinux_label;
+    std::filesystem::path cwd;
+    std::optional<std::vector<std::string>> env;
+    std::optional<std::vector<rlimit>> rlimits;
+    std::vector<std::string> args;
+    std::optional<int> oom_score_adj;
+    std::optional<io_priority> io_priority_;
+    std::optional<console_size> console_size_;
+    std::optional<bool> terminal;
+    std::optional<bool> no_new_privileges;
+};
+
+void from_json(const nlohmann::json &j, process &v);
+
+void validate(const process &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/rdma.cpp
+++ b/src/linyaps_box/config/rdma.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/rdma.h"
+
+#include <nlohmann/json.hpp>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, rdma &v)
+{
+    if (auto it = j.find("hcaHandles"); it != j.end() && !it->is_null()) {
+        it->get_to(v.hca_handles.emplace());
+    }
+
+    if (auto it = j.find("hcaObjects"); it != j.end() && !it->is_null()) {
+        it->get_to(v.hca_objects.emplace());
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/rdma.h
+++ b/src/linyaps_box/config/rdma.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <optional>
+
+namespace linyaps_box::config {
+
+struct rdma
+{
+    std::optional<uint32_t> hca_handles;
+    std::optional<uint32_t> hca_objects;
+};
+
+void from_json(const nlohmann::json &j, rdma &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/resources.cpp
+++ b/src/linyaps_box/config/resources.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/resources.h"
+
+#include "linyaps_box/config/utils.h"
+#include "linyaps_box/utils/utils.h"
+
+#include <nlohmann/json.hpp>
+
+#include <string_view>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, resources &v)
+{
+    for (const auto &[key, val] : j.items()) {
+        const auto k = std::string_view{ key };
+        if (key_matches(k, "unified")) {
+            if (!val.is_null()) {
+                val.get_to(v.unified.emplace());
+            }
+        } else if (key_matches(k, "devices")) {
+            if (!val.is_null()) {
+                val.get_to(v.devices.emplace());
+            }
+        } else if (key_matches(k, "pids")) {
+            if (!val.is_null()) {
+                val.get_to(v.pids_.emplace());
+            }
+        } else if (key_matches(k, "memory")) {
+            if (!val.is_null()) {
+                val.get_to(v.memory_.emplace());
+            }
+        } else if (key_matches(k, "cpu")) {
+            if (!val.is_null()) {
+                val.get_to(v.cpu_.emplace());
+            }
+        } else if (key_matches(k, "hugepageLimits")) {
+            if (!val.is_null()) {
+                val.get_to(v.hugepage_limits.emplace());
+            }
+        } else if (key_matches(k, "blockIO")) {
+            if (!val.is_null()) {
+                val.get_to(v.block_io_.emplace());
+            }
+        } else if (key_matches(k, "network")) {
+            if (!val.is_null()) {
+                val.get_to(v.network_.emplace());
+            }
+        } else if (key_matches(k, "rdma")) {
+            if (!val.is_null()) {
+                val.get_to(v.rdma_.emplace());
+            }
+        }
+    }
+}
+
+void validate(const resources &v)
+{
+    if (v.memory_) {
+        validate(*v.memory_);
+    }
+
+    if (v.cpu_) {
+        validate(*v.cpu_);
+    }
+
+    if (v.block_io_) {
+        validate(*v.block_io_);
+    }
+
+    if (v.network_) {
+        validate(*v.network_);
+    }
+
+    if (!v.hugepage_limits) {
+        return;
+    }
+
+    std::for_each(v.hugepage_limits->cbegin(), v.hugepage_limits->cend(), [](const auto &limit) {
+        if (UNLIKELY(limit.page_size.empty())) {
+            throw std::runtime_error("resources.hugepageLimits pageSize must not be empty");
+        }
+    });
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/resources.h
+++ b/src/linyaps_box/config/resources.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/config/block_io.h"
+#include "linyaps_box/config/cpu.h"
+#include "linyaps_box/config/device_rule.h"
+#include "linyaps_box/config/hugepage.h"
+#include "linyaps_box/config/memory.h"
+#include "linyaps_box/config/network.h"
+#include "linyaps_box/config/pids.h"
+#include "linyaps_box/config/rdma.h"
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace linyaps_box::config {
+
+struct resources
+{
+    std::optional<std::vector<device_rule>> devices;
+    std::optional<memory> memory_;
+    std::optional<cpu> cpu_;
+    std::optional<block_io> block_io_;
+    std::optional<std::vector<hugepage_limit>> hugepage_limits;
+    std::optional<network> network_;
+    std::optional<pids> pids_;
+    std::optional<std::unordered_map<std::string, rdma>> rdma_;
+    std::optional<std::unordered_map<std::string, std::string>> unified;
+};
+
+void from_json(const nlohmann::json &j, resources &v);
+
+void validate(const resources &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/rlimit.cpp
+++ b/src/linyaps_box/config/rlimit.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/rlimit.h"
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <stdexcept>
+#include <string_view>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, rlimit &v)
+{
+    auto name = j.at("type").get<std::string_view>();
+    auto opt = get_enum_table_from<rlimit::type>().from_name(name);
+    if (UNLIKELY(!opt)) {
+        throw std::runtime_error(fmt::format("unknown rlimit type: {}", name));
+    }
+
+    v.type_ = *opt;
+    j.at("soft").get_to(v.soft);
+    j.at("hard").get_to(v.hard);
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/rlimit.h
+++ b/src/linyaps_box/config/rlimit.h
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/utils/enum_traits.h"
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <string_view>
+
+namespace linyaps_box::config {
+
+struct rlimit
+{
+    enum class type : std::uint8_t {
+        as,
+        core,
+        cpu,
+        data,
+        fsize,
+        locks,
+        memlock,
+        msgqueue,
+        nice,
+        nofile,
+        nproc,
+        rss,
+        rtprio,
+        rttime,
+        sigpending,
+        stack,
+    };
+
+    type type_;
+    uint64_t soft;
+    uint64_t hard;
+};
+
+LINYAPS_REGISTER_ENUM_TABLE(rlimit::type,
+                            16,
+                            { rlimit::type::as, "RLIMIT_AS" },
+                            { rlimit::type::core, "RLIMIT_CORE" },
+                            { rlimit::type::cpu, "RLIMIT_CPU" },
+                            { rlimit::type::data, "RLIMIT_DATA" },
+                            { rlimit::type::fsize, "RLIMIT_FSIZE" },
+                            { rlimit::type::locks, "RLIMIT_LOCKS" },
+                            { rlimit::type::memlock, "RLIMIT_MEMLOCK" },
+                            { rlimit::type::msgqueue, "RLIMIT_MSGQUEUE" },
+                            { rlimit::type::nice, "RLIMIT_NICE" },
+                            { rlimit::type::nofile, "RLIMIT_NOFILE" },
+                            { rlimit::type::nproc, "RLIMIT_NPROC" },
+                            { rlimit::type::rss, "RLIMIT_RSS" },
+                            { rlimit::type::rtprio, "RLIMIT_RTPRIO" },
+                            { rlimit::type::rttime, "RLIMIT_RTTIME" },
+                            { rlimit::type::sigpending, "RLIMIT_SIGPENDING" },
+                            { rlimit::type::stack, "RLIMIT_STACK" })
+
+void from_json(const nlohmann::json &j, rlimit &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/root.cpp
+++ b/src/linyaps_box/config/root.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/root.h"
+
+#include "linyaps_box/utils/utils.h"
+
+#include <nlohmann/json.hpp>
+
+#include <stdexcept>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, root &v)
+{
+    j.at("path").get_to(v.path);
+    v.readonly = j.value("readonly", false);
+}
+
+void validate(const root &v)
+{
+    if (UNLIKELY(v.path.empty())) {
+        throw std::runtime_error("root.path must not be empty");
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/root.h
+++ b/src/linyaps_box/config/root.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <filesystem>
+
+namespace linyaps_box::config {
+
+struct root
+{
+    std::filesystem::path path;
+    bool readonly{ false };
+};
+
+void from_json(const nlohmann::json &j, root &v);
+
+void validate(const root &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/scheduler.cpp
+++ b/src/linyaps_box/config/scheduler.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/scheduler.h"
+
+#include "linyaps_box/config/utils.h"
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, scheduler &v)
+{
+    bool have_policy{ false };
+    for (const auto &[key, val] : j.items()) {
+        const auto k = std::string_view{ key };
+        if (key_matches(k, "policy")) {
+            auto policy_name = val.get<std::string_view>();
+            auto policy_opt = get_enum_table_from<scheduler::policy>().from_name(policy_name);
+            if (UNLIKELY(!policy_opt)) {
+                throw std::runtime_error(fmt::format("unknown scheduler policy: {}", policy_name));
+            }
+
+            v.policy_ = *policy_opt;
+            have_policy = true;
+        } else if (key_matches(k, "nice")) {
+            if (!val.is_null()) {
+                val.get_to(v.nice.emplace());
+            }
+        } else if (key_matches(k, "priority")) {
+            if (!val.is_null()) {
+                val.get_to(v.priority.emplace());
+            }
+        } else if (key_matches(k, "flags")) {
+            if (!val.is_null()) {
+                auto flags{ scheduler::flag::none };
+                for (const auto &f : val) {
+                    const auto &flag_str = f.get_ref<const std::string &>();
+                    auto flag_opt = get_enum_table_from<scheduler::flag>().from_name(flag_str);
+                    if (UNLIKELY(!flag_opt)) {
+                        throw std::runtime_error(
+                          fmt::format("unknown scheduler flag: {}", flag_str));
+                    }
+
+                    flags |= *flag_opt;
+                }
+
+                v.flags = flags;
+            }
+        } else if (key_matches(k, "runtime")) {
+            if (!val.is_null()) {
+                val.get_to(v.runtime.emplace());
+            }
+        } else if (key_matches(k, "deadline")) {
+            if (!val.is_null()) {
+                val.get_to(v.deadline.emplace());
+            }
+        } else if (key_matches(k, "period")) {
+            if (!val.is_null()) {
+                val.get_to(v.period.emplace());
+            }
+        }
+    }
+
+    if (!have_policy) {
+        throw std::runtime_error("scheduler.policy is required");
+    }
+}
+
+void validate(const scheduler &v)
+{
+    using policy_t = scheduler::policy;
+
+    if (v.nice) {
+        if (UNLIKELY(*v.nice < -20 || *v.nice > 19)) {
+            throw std::runtime_error(
+              fmt::format("scheduler.nice must be in range [-20, 19]: got {}", *v.nice));
+        }
+    }
+
+    if (v.priority && *v.priority != 0) {
+        if (UNLIKELY(v.policy_ != policy_t::fifo && v.policy_ != policy_t::rr)) {
+            throw std::runtime_error(
+              "scheduler.priority can only be specified for SCHED_FIFO or SCHED_RR");
+        }
+    }
+
+    if (v.runtime || v.deadline || v.period) {
+        if (UNLIKELY(v.policy_ != policy_t::deadline)) {
+            throw std::runtime_error(
+              "scheduler runtime/deadline/period can only be specified for SCHED_DEADLINE");
+        }
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/scheduler.h
+++ b/src/linyaps_box/config/scheduler.h
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/utils/enum_traits.h"
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <optional>
+
+namespace linyaps_box::config {
+
+struct scheduler
+{
+    enum class policy : uint8_t { other, fifo, rr, batch, iso, idle, deadline };
+
+    enum class flag : std::uint8_t {
+        none = 0U,
+        reset_on_fork = (1U << 0),
+        reclaim = (1U << 1),
+        dl_overrun = (1U << 2),
+        keep_policy = (1U << 3),
+        keep_params = (1U << 4),
+        util_clamp_min = (1U << 5),
+        util_clamp_max = (1U << 6),
+    };
+
+    std::optional<uint64_t> runtime;
+    std::optional<uint64_t> deadline;
+    std::optional<uint64_t> period;
+    std::optional<int32_t> nice;
+    std::optional<int32_t> priority;
+    std::optional<flag> flags;
+    policy policy_;
+};
+
+LINYAPS_ENABLE_BITMASK_ENUM(scheduler::flag);
+
+LINYAPS_REGISTER_ENUM_TABLE(scheduler::policy,
+                            7,
+                            { scheduler::policy::other, "SCHED_OTHER" },
+                            { scheduler::policy::fifo, "SCHED_FIFO" },
+                            { scheduler::policy::rr, "SCHED_RR" },
+                            { scheduler::policy::batch, "SCHED_BATCH" },
+                            { scheduler::policy::iso, "SCHED_ISO" },
+                            { scheduler::policy::idle, "SCHED_IDLE" },
+                            { scheduler::policy::deadline, "SCHED_DEADLINE" })
+
+LINYAPS_REGISTER_ENUM_TABLE(scheduler::flag,
+                            7,
+                            { scheduler::flag::reset_on_fork, "SCHED_FLAG_RESET_ON_FORK" },
+                            { scheduler::flag::reclaim, "SCHED_FLAG_RECLAIM" },
+                            { scheduler::flag::dl_overrun, "SCHED_FLAG_DL_OVERRUN" },
+                            { scheduler::flag::keep_policy, "SCHED_FLAG_KEEP_POLICY" },
+                            { scheduler::flag::keep_params, "SCHED_FLAG_KEEP_PARAMS" },
+                            { scheduler::flag::util_clamp_min, "SCHED_FLAG_UTIL_CLAMP_MIN" },
+                            { scheduler::flag::util_clamp_max, "SCHED_FLAG_UTIL_CLAMP_MAX" })
+
+void from_json(const nlohmann::json &j, scheduler &v);
+
+void validate(const scheduler &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/seccomp.cpp
+++ b/src/linyaps_box/config/seccomp.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/seccomp.h"
+
+#include "linyaps_box/config/utils.h"
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace linyaps_box::config {
+constexpr auto seccomp_action_table = get_enum_table_from<seccomp::action>();
+
+void from_json(const nlohmann::json &j, seccomp::syscall::arg &v)
+{
+    j.at("index").get_to(v.index);
+    j.at("value").get_to(v.value);
+
+    if (auto value_two_it = j.find("valueTwo");
+        value_two_it != j.end() && !value_two_it->is_null()) {
+        value_two_it->get_to(v.value_two.emplace());
+    }
+
+    auto op_name = j.at("op").get<std::string_view>();
+    auto op_opt = get_enum_table_from<seccomp::syscall::arg::op>().from_name(op_name);
+    if (UNLIKELY(!op_opt)) {
+        throw std::runtime_error(fmt::format("unknown seccomp arg op: {}", op_name));
+    }
+
+    v.op_ = *op_opt;
+}
+
+void from_json(const nlohmann::json &j, seccomp::syscall &v)
+{
+    j.at("names").get_to(v.names);
+
+    auto action_name = j.at("action").get<std::string_view>();
+    auto action_opt = seccomp_action_table.from_name(action_name);
+    if (UNLIKELY(!action_opt)) {
+        throw std::runtime_error(fmt::format("unknown seccomp action: {}", action_name));
+    }
+    v.action_ = *action_opt;
+
+    if (auto it = j.find("errnoRet"); it != j.end() && !it->is_null()) {
+        it->get_to(v.errno_ret.emplace());
+    }
+
+    if (auto it = j.find("args"); it != j.end() && !it->is_null()) {
+        it->get_to(v.args.emplace());
+    }
+}
+
+void from_json(const nlohmann::json &j, seccomp &v)
+{
+    bool have_default_action{ false };
+    for (const auto &[key, val] : j.items()) {
+        const auto k = std::string_view{ key };
+        if (key_matches(k, "defaultAction")) {
+            auto action_name = val.get<std::string_view>();
+            auto action_opt = seccomp_action_table.from_name(action_name);
+            if (UNLIKELY(!action_opt)) {
+                throw std::runtime_error(fmt::format("unknown seccomp action: {}", action_name));
+            }
+
+            v.default_action = *action_opt;
+            have_default_action = true;
+        } else if (key_matches(k, "defaultErrnoRet")) {
+            if (!val.is_null()) {
+                val.get_to(v.default_errno_ret.emplace());
+            }
+        } else if (key_matches(k, "architectures")) {
+            if (!val.is_null()) {
+                std::vector<seccomp::arch> archs;
+                archs.reserve(val.size());
+
+                for (const auto &elem : val) {
+                    auto arch_str = elem.get<std::string_view>();
+                    auto arch_opt = get_enum_table_from<seccomp::arch>().from_name(arch_str);
+
+                    if (UNLIKELY(!arch_opt)) {
+                        throw std::runtime_error(
+                          fmt::format("unknown seccomp architecture: {}", arch_str));
+                    }
+
+                    archs.push_back(*arch_opt);
+                }
+
+                v.architectures = std::move(archs);
+            }
+        } else if (key_matches(k, "flags")) {
+            if (!val.is_null()) {
+                auto flags{ seccomp::flag::none };
+                for (const auto &elem : val) {
+                    auto flag_str = elem.get<std::string_view>();
+                    auto flag_opt = get_enum_table_from<seccomp::flag>().from_name(flag_str);
+                    if (UNLIKELY(!flag_opt)) {
+                        throw std::runtime_error(fmt::format("unknown seccomp flag: {}", flag_str));
+                    }
+
+                    flags |= *flag_opt;
+                }
+
+                v.flags = flags;
+            }
+        } else if (key_matches(k, "listenerPath")) {
+            if (!val.is_null()) {
+                val.get_to(v.listener_path.emplace());
+            }
+        } else if (key_matches(k, "listenerMetadata")) {
+            if (!val.is_null()) {
+                val.get_to(v.listener_metadata.emplace());
+            }
+        } else if (key_matches(k, "syscalls")) {
+            if (!val.is_null()) {
+                val.get_to(v.syscalls.emplace());
+            }
+        }
+    }
+
+    if (UNLIKELY(!have_default_action)) {
+        throw std::runtime_error("seccomp.defaultAction is required");
+    }
+}
+
+void validate(const seccomp::syscall &v)
+{
+    if (UNLIKELY(v.names.empty())) {
+        throw std::runtime_error("seccomp syscall names must not be empty");
+    }
+
+    if (UNLIKELY(v.errno_ret && v.action_ != seccomp::action::errno_
+                 && v.action_ != seccomp::action::trace)) {
+        throw std::runtime_error(
+          "seccomp syscall errnoRet is only valid with SCMP_ACT_ERRNO or SCMP_ACT_TRACE");
+    }
+}
+
+void validate(const seccomp &v)
+{
+    if (UNLIKELY(v.default_errno_ret && v.default_action != seccomp::action::errno_
+                 && v.default_action != seccomp::action::trace)) {
+        throw std::runtime_error(
+          "seccomp defaultErrnoRet is only valid with SCMP_ACT_ERRNO or SCMP_ACT_TRACE");
+    }
+
+    if (UNLIKELY(v.default_action == seccomp::action::notify && !v.listener_path)) {
+        throw std::runtime_error("seccomp SCMP_ACT_NOTIFY requires listenerPath");
+    }
+
+    if (UNLIKELY(v.listener_metadata && !v.listener_path)) {
+        throw std::runtime_error("seccomp listenerMetadata requires listenerPath to be set");
+    }
+
+    if (!v.syscalls) {
+        return;
+    }
+
+    std::for_each(v.syscalls->cbegin(), v.syscalls->cend(), [](const auto &syscall) {
+        validate(syscall);
+    });
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/seccomp.h
+++ b/src/linyaps_box/config/seccomp.h
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/utils/enum_traits.h"
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace linyaps_box::config {
+
+struct seccomp
+{
+    enum class action : std::uint8_t {
+        allow,
+        errno_,
+        kill,
+        kill_process,
+        kill_thread,
+        log,
+        notify,
+        trace,
+        trap
+    };
+
+    enum class arch : uint8_t {
+        x86,
+        x86_64,
+        x32,
+        arm,
+        aarch64,
+        mips,
+        mips64,
+        mips64n32,
+        mipsel,
+        mipsel64,
+        mipsel64n32,
+        ppc,
+        ppc64,
+        ppc64le,
+        s390,
+        s390x,
+        parisc,
+        parisc64,
+        riscv64,
+        loongarch64,
+        m68k,
+        sh,
+        sheb,
+    };
+
+    enum class flag : std::uint8_t {
+        none = 0U,
+        tsync = (1U << 0),
+        log = (1U << 1),
+        spec_allow = (1U << 2),
+        wait_killable_recv = (1U << 3),
+    };
+
+    struct syscall
+    {
+        std::vector<std::string> names;
+        action action_;
+        std::optional<std::uint32_t> errno_ret;
+
+        struct arg
+        {
+            enum class op : uint8_t { eq, ne, lt, le, gt, ge, masked_eq };
+
+            std::uint32_t index{ 0 };
+            uint64_t value{ 0 };
+            std::optional<uint64_t> value_two;
+            op op_;
+        };
+
+        std::optional<std::vector<arg>> args;
+    };
+
+    std::optional<std::vector<arch>> architectures;
+    std::optional<std::string> listener_metadata;
+    std::optional<std::filesystem::path> listener_path;
+    std::optional<std::vector<syscall>> syscalls;
+    std::optional<std::uint32_t> default_errno_ret;
+    std::optional<flag> flags;
+    action default_action;
+};
+
+LINYAPS_REGISTER_ENUM_TABLE(seccomp::action,
+                            9,
+                            { seccomp::action::allow, "SCMP_ACT_ALLOW" },
+                            { seccomp::action::errno_, "SCMP_ACT_ERRNO" },
+                            { seccomp::action::kill, "SCMP_ACT_KILL" },
+                            { seccomp::action::kill_process, "SCMP_ACT_KILL_PROCESS" },
+                            { seccomp::action::kill_thread, "SCMP_ACT_KILL_THREAD" },
+                            { seccomp::action::log, "SCMP_ACT_LOG" },
+                            { seccomp::action::notify, "SCMP_ACT_NOTIFY" },
+                            { seccomp::action::trace, "SCMP_ACT_TRACE" },
+                            { seccomp::action::trap, "SCMP_ACT_TRAP" })
+
+LINYAPS_REGISTER_ENUM_TABLE(seccomp::arch,
+                            23,
+                            { seccomp::arch::x86, "SCMP_ARCH_X86" },
+                            { seccomp::arch::x86_64, "SCMP_ARCH_X86_64" },
+                            { seccomp::arch::x32, "SCMP_ARCH_X32" },
+                            { seccomp::arch::arm, "SCMP_ARCH_ARM" },
+                            { seccomp::arch::aarch64, "SCMP_ARCH_AARCH64" },
+                            { seccomp::arch::mips, "SCMP_ARCH_MIPS" },
+                            { seccomp::arch::mips64, "SCMP_ARCH_MIPS64" },
+                            { seccomp::arch::mips64n32, "SCMP_ARCH_MIPS64N32" },
+                            { seccomp::arch::mipsel, "SCMP_ARCH_MIPSEL" },
+                            { seccomp::arch::mipsel64, "SCMP_ARCH_MIPSEL64" },
+                            { seccomp::arch::mipsel64n32, "SCMP_ARCH_MIPSEL64N32" },
+                            { seccomp::arch::ppc, "SCMP_ARCH_PPC" },
+                            { seccomp::arch::ppc64, "SCMP_ARCH_PPC64" },
+                            { seccomp::arch::ppc64le, "SCMP_ARCH_PPC64LE" },
+                            { seccomp::arch::s390, "SCMP_ARCH_S390" },
+                            { seccomp::arch::s390x, "SCMP_ARCH_S390X" },
+                            { seccomp::arch::parisc, "SCMP_ARCH_PARISC" },
+                            { seccomp::arch::parisc64, "SCMP_ARCH_PARISC64" },
+                            { seccomp::arch::riscv64, "SCMP_ARCH_RISCV64" },
+                            { seccomp::arch::loongarch64, "SCMP_ARCH_LOONGARCH64" },
+                            { seccomp::arch::m68k, "SCMP_ARCH_M68K" },
+                            { seccomp::arch::sh, "SCMP_ARCH_SH" },
+                            { seccomp::arch::sheb, "SCMP_ARCH_SHEB" })
+
+LINYAPS_ENABLE_BITMASK_ENUM(seccomp::flag);
+
+LINYAPS_REGISTER_ENUM_TABLE(seccomp::flag,
+                            4,
+                            { seccomp::flag::tsync, "SECCOMP_FILTER_FLAG_TSYNC" },
+                            { seccomp::flag::log, "SECCOMP_FILTER_FLAG_LOG" },
+                            { seccomp::flag::spec_allow, "SECCOMP_FILTER_FLAG_SPEC_ALLOW" },
+                            { seccomp::flag::wait_killable_recv,
+                              "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV" })
+
+LINYAPS_REGISTER_ENUM_TABLE(seccomp::syscall::arg::op,
+                            7,
+                            { seccomp::syscall::arg::op::eq, "SCMP_CMP_EQ" },
+                            { seccomp::syscall::arg::op::ne, "SCMP_CMP_NE" },
+                            { seccomp::syscall::arg::op::lt, "SCMP_CMP_LT" },
+                            { seccomp::syscall::arg::op::le, "SCMP_CMP_LE" },
+                            { seccomp::syscall::arg::op::gt, "SCMP_CMP_GT" },
+                            { seccomp::syscall::arg::op::ge, "SCMP_CMP_GE" },
+                            { seccomp::syscall::arg::op::masked_eq, "SCMP_CMP_MASKED_EQ" })
+
+void from_json(const nlohmann::json &j, seccomp::syscall::arg &v);
+
+void from_json(const nlohmann::json &j, seccomp::syscall &v);
+
+void from_json(const nlohmann::json &j, seccomp &v);
+
+void validate(const seccomp::syscall &v);
+
+void validate(const seccomp &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/time_offset.cpp
+++ b/src/linyaps_box/config/time_offset.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/time_offset.h"
+
+#include <nlohmann/json.hpp>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, time_offset &v)
+{
+    j.at("secs").get_to(v.secs);
+    j.at("nanosecs").get_to(v.nanosecs);
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/time_offset.h
+++ b/src/linyaps_box/config/time_offset.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <cstdint>
+
+namespace linyaps_box::config {
+
+struct time_offset
+{
+    int64_t secs;
+    uint32_t nanosecs;
+};
+
+void from_json(const nlohmann::json &j, time_offset &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/user.cpp
+++ b/src/linyaps_box/config/user.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/user.h"
+
+#include "linyaps_box/utils/utils.h"
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+namespace linyaps_box::config {
+
+void from_json(const nlohmann::json &j, user &v)
+{
+    j.at("uid").get_to(v.uid);
+    j.at("gid").get_to(v.gid);
+
+    if (auto it = j.find("umask"); it != j.end() && !it->is_null()) {
+        it->get_to(v.umask.emplace());
+    }
+
+    if (auto it = j.find("additionalGids"); it != j.end() && !it->is_null()) {
+        it->get_to(v.additional_gids.emplace());
+    }
+}
+
+void validate(const user &v)
+{
+    if (!v.umask) {
+        return;
+    }
+
+    auto val = v.umask.value();
+    if (UNLIKELY((val & ~std::filesystem::perms::all) != std::filesystem::perms::none)) {
+        throw std::runtime_error(
+          fmt::format("user.umask is invalid: 0{:o}", static_cast<mode_t>(val)));
+    }
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/user.h
+++ b/src/linyaps_box/config/user.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <filesystem>
+#include <optional>
+#include <vector>
+
+#include <sys/types.h>
+
+namespace linyaps_box::config {
+
+struct user
+{
+    uid_t uid{ 0 };
+    gid_t gid{ 0 };
+    std::optional<std::filesystem::perms> umask;
+    std::optional<std::vector<gid_t>> additional_gids;
+};
+
+void from_json(const nlohmann::json &j, user &v);
+
+void validate(const user &v);
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/utils.cpp
+++ b/src/linyaps_box/config/utils.cpp
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/config/utils.h"
+
+#include "linyaps_box/io/stream.h"
+#include "linyaps_box/os/fs.h"
+
+#include <charconv>
+
+namespace linyaps_box::config {
+
+auto read_json_to(const std::filesystem::path &path, utils::uninit_vector<std::byte> &buffer)
+  -> std::size_t
+{
+    auto fd = os::open(path, { os::sys::open_flag::cloexec, os::sys::access_mode::read_only });
+    if (UNLIKELY(!fd)) {
+        throw std::filesystem::filesystem_error("failed to open config file", path, fd.error());
+    }
+
+    auto stat = os::fstat(*fd);
+    if (UNLIKELY(!stat)) {
+        throw std::system_error(stat.error(), "failed to stat config file");
+    }
+
+    auto type = os::to_fs_file_type(stat->st_mode);
+    if (UNLIKELY(type != std::filesystem::file_type::regular)) {
+        throw std::runtime_error("config file is not a regular file");
+    }
+
+    auto ret = io::read_to_end(fd.value(), buffer);
+    if (UNLIKELY(!ret)) {
+        throw std::system_error(ret.error(), "failed to read config file");
+    }
+
+    return *ret;
+}
+
+auto parse_range_list(std::string_view s) -> std::vector<unsigned int>
+{
+    std::vector<unsigned int> result;
+    if (s.empty()) {
+        return result;
+    }
+
+    result.reserve(16);
+
+    const auto *ptr = s.data();
+    const auto *end = ptr + s.size();
+
+    auto skip_whitespace = [](const char *p, const char *e) {
+        while (p < e && static_cast<unsigned char>(*p) <= ' ') {
+            ++p;
+        }
+
+        return p;
+    };
+
+    while (ptr < end) {
+        ptr = skip_whitespace(ptr, end);
+        if (ptr == end) {
+            break;
+        }
+
+        auto start{ 0U };
+        auto [p_start, ec_start] = std::from_chars(ptr, end, start);
+        if (UNLIKELY(ec_start != std::errc{ })) {
+            if (ec_start == std::errc::result_out_of_range) {
+                throw std::runtime_error(
+                  "value overflow in range list at: "
+                  + std::string(ptr, std::min(end - ptr, static_cast<std::ptrdiff_t>(16))));
+            }
+
+            throw std::runtime_error(
+              "invalid value in range list at: "
+              + std::string(ptr, std::min(end - ptr, static_cast<std::ptrdiff_t>(16))));
+        }
+
+        ptr = p_start;
+        ptr = skip_whitespace(ptr, end);
+
+        if (ptr < end && *ptr == '-') {
+            ++ptr;
+            ptr = skip_whitespace(ptr, end);
+
+            auto finish{ 0U };
+            auto [p_finish, ec_finish] = std::from_chars(ptr, end, finish);
+            if (UNLIKELY(ec_finish != std::errc{ })) {
+                if (ec_finish == std::errc::result_out_of_range) {
+                    throw std::runtime_error(
+                      "value overflow in range list at: "
+                      + std::string(ptr, std::min(end - ptr, static_cast<std::ptrdiff_t>(16))));
+                }
+                throw std::runtime_error(
+                  "invalid range end in range list at: "
+                  + std::string(ptr, std::min(end - ptr, static_cast<std::ptrdiff_t>(16))));
+            }
+
+            ptr = p_finish;
+            if (UNLIKELY(finish < start)) {
+                throw std::runtime_error(
+                  "invalid range in range list (finish < start) at: "
+                  + std::string(ptr, std::min(end - ptr, static_cast<std::ptrdiff_t>(16))));
+            }
+
+            if (UNLIKELY(start == 0 && finish == std::numeric_limits<unsigned int>::max())) {
+                throw std::runtime_error(
+                  "range too large in range list at: "
+                  + std::string(ptr, std::min(end - ptr, static_cast<std::ptrdiff_t>(16))));
+            }
+
+            auto n = finish - start + 1;
+            auto pos = result.size();
+            result.resize(pos + n);
+            for (unsigned int j = 0; j < n; ++j) {
+                result[pos + j] = start + j;
+            }
+        } else {
+            result.push_back(start);
+        }
+
+        ptr = skip_whitespace(ptr, end);
+        if (ptr < end) {
+            if (UNLIKELY(*ptr != ',')) {
+                throw std::runtime_error(
+                  "expected ',' or end-of-string in range list at: "
+                  + std::string(ptr, std::min(end - ptr, static_cast<std::ptrdiff_t>(16))));
+            }
+
+            ++ptr;
+        }
+    }
+
+    return result;
+}
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/config/utils.h
+++ b/src/linyaps_box/config/utils.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linyaps_box/utils/utils.h"
+
+#include <filesystem>
+#include <string_view>
+
+namespace linyaps_box::config {
+
+[[nodiscard]] constexpr auto key_matches(std::string_view key, const char *name) noexcept -> bool
+{
+    const auto len = std::char_traits<char>::length(name);
+    return key.size() == len && key.compare(0, len, name) == 0;
+}
+
+[[nodiscard]] auto read_json_to(const std::filesystem::path &path,
+                                utils::uninit_vector<std::byte> &buffer) -> std::size_t;
+
+[[nodiscard]] auto parse_range_list(std::string_view s) -> std::vector<unsigned int>;
+
+} // namespace linyaps_box::config

--- a/src/linyaps_box/utils/enum_formatter.h
+++ b/src/linyaps_box/utils/enum_formatter.h
@@ -23,6 +23,28 @@ struct enum_entry_view
     uint64_t value;
 };
 
+// Constexpr packing of an enum table for flag formatting.  N is deduced from
+// the table's type (not from a local variable) so the std::array size is a
+// type-level constant — referencing a local constexpr's size() as a template
+// argument breaks constant evaluation in templates under Clang.
+template <typename E, std::size_t N>
+constexpr auto make_enum_data(const enum_table<E, N> &table)
+{
+    struct packed_view
+    {
+        std::string_view type_name;
+        std::array<enum_entry_view, N> views;
+    };
+
+    packed_view result{ table.type_name(), { } };
+    for (std::size_t i = 0; i < N; ++i) {
+        result.views[i] = { table.entries()[i].name,
+                            static_cast<uint64_t>(table.entries()[i].value) };
+    }
+
+    return result;
+}
+
 template <typename T>
 struct enum_or_bitflags_traits
 {
@@ -148,24 +170,8 @@ struct fmt::formatter<T, std::enable_if_t<linyaps_box::utils::has_enum_table_v<T
         }
 
         if constexpr (linyaps_box::utils::is_bitmask_enum_v<E>) {
-            static constexpr auto enum_data = [] {
-                constexpr auto table = get_enum_table(static_cast<E *>(nullptr));
-
-                struct packed_view
-                {
-                    std::string_view type_name;
-                    std::array<linyaps_box::utils::detail::enum_entry_view, table.entries().size()>
-                      views;
-                };
-
-                packed_view result{ table.type_name(), { } };
-                for (std::size_t i = 0; i < table.entries().size(); ++i) {
-                    result.views[i] = { table.entries()[i].name,
-                                        static_cast<uint64_t>(table.entries()[i].value) };
-                }
-
-                return result;
-            }();
+            static constexpr auto enum_data =
+              linyaps_box::utils::detail::make_enum_data(get_enum_table(static_cast<E *>(nullptr)));
 
             return linyaps_box::utils::detail::format_flags_impl(ctx.out(),
                                                                  static_cast<uint64_t>(raw_val),

--- a/src/linyaps_box/utils/enum_traits.h
+++ b/src/linyaps_box/utils/enum_traits.h
@@ -477,3 +477,9 @@ constexpr E &operator^=(E &lhs, E rhs) noexcept
                       "enum_table entry count mismatch for " #E ": expected " #COUNT " entries"); \
         return table;                                                                             \
     }
+
+template <typename T>
+constexpr auto get_enum_table_from() noexcept
+{
+    return get_enum_table(static_cast<T *>(nullptr));
+}

--- a/src/linyaps_box/utils/environ.cpp
+++ b/src/linyaps_box/utils/environ.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linyaps_box/utils/environ.h"
+
+namespace linyaps_box::utils {
+
+auto is_invalid_env(std::string_view env) noexcept -> bool
+{
+    auto pos = env.find('=');
+    if (pos == std::string_view::npos) {
+        return true;
+    }
+
+    if (pos == 0) {
+        return true;
+    }
+
+    if (env.find('\0') != std::string_view::npos) {
+        return true;
+    }
+
+    return false;
+}
+
+} // namespace linyaps_box::utils

--- a/src/linyaps_box/utils/environ.h
+++ b/src/linyaps_box/utils/environ.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <string_view>
+
+namespace linyaps_box::utils {
+// see: https://pubs.opengroup.org/onlinepubs/9799919799/
+auto is_invalid_env(std::string_view env) noexcept -> bool;
+} // namespace linyaps_box::utils


### PR DESCRIPTION
New linyaps_box::config types replace flat config.h/cpp.

The migration will coexist with the old module and will be committed as a separate commit.